### PR TITLE
Better search results for case title search

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,7 +5,7 @@ class SearchesController < ApplicationController
   before_action :read_page
 
   def show
-    @authors = User.all 
+    @authors = User.all
     @schools = schools
     @query = params[:q]
     @type = params[:type] || 'casebooks'
@@ -14,6 +14,10 @@ class SearchesController < ApplicationController
       result_groups @query
     else
       result_groups '*'
+    end
+
+    if @results[@type.to_sym].nil? && !params[:partial]
+      @type = @results.select { |key, value| value.present? }.keys.first.to_s || 'casebooks'
     end
 
     @pagination = paginate_group @results[@type.to_sym]
@@ -66,7 +70,7 @@ class SearchesController < ApplicationController
       any_of do
         with :public, true
         if current_user.present?
-          with :owner_ids, current_user.id 
+          with :owner_ids, current_user.id
         end
       end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -82,11 +82,12 @@ class Case < ApplicationRecord
   validates_length_of     :content,         :in => 1..(5.megabytes), :allow_blank => true, :allow_nil => true
 
   searchable do
-    text :display_name, :boost => 3.0
+    text :full_name, :boost => 3.0
+    text :short_name
     text :indexable_case_citations, :boost => 3.0
-    text :clean_content
     text :indexable_case_docket_numbers
-    text :case_jurisdiction
+    text :indexable_case_jurisdiction
+    # text :clean_content
 
     string :display_name, :stored => true
     string :id, :stored => true

--- a/app/models/content/casebook.rb
+++ b/app/models/content/casebook.rb
@@ -41,11 +41,17 @@ class Content::Casebook < Content::Node
     text :title, boost: 3.0
     text :subtitle
     text :headnote
-    text :content do
-      if self.is_a? Content::Resource
-        resource.content
-      end
+    text :owner do
+      owners.map do |owner|
+        "#{owners.first.attribution} #{owners.first.affiliation}"
+      end.join '\n'
     end
+
+    # text :content do
+    #   if self.is_a? Content::Resource
+    #     resource.content
+    #   end
+    # end
 
     string(:klass, stored: true) { self.class.name }
     string(:display_name, stored: true) { title }

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,5 +1,6 @@
 <header class="advanced-search">
   <%= simple_form_for :search, url: :search, method: :get do |f| %>
+    <%= f.input :type, as: :hidden, input_html: { name: 'type', value: @type }  %>
     <div class="narrow-inner">
       <%= text_field_tag :q, @query, class: 'form-control',  placeholder: t('search.labels.query.placeholder') %>
     </div>


### PR DESCRIPTION
- Removes full case text from the search index, so e.g. "roe v. wade" returns only a single case result.
- Fixes a bug where the selected search tab would reset when the search query was changed.
- Adds a feature where if there are no search results for the current search tab, results for another tab are shown automatically.