### PR TITLE
Revise button in published view

### DIFF
--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -17,6 +17,12 @@ class Content::CasebooksController < Content::NodeController
     render 'content/show'
   end
 
+  def edit
+    @casebook.update_attributes public: false
+    @content = @casebook
+    render 'content/edit_details'
+  end
+
   def clone
     @clone = current_user.casebooks.owned.where(copy_of: @casebook).first ||
       @casebook.clone(owner: current_user)
@@ -36,7 +42,6 @@ class Content::CasebooksController < Content::NodeController
 
   def export
     html = render_to_string layout: 'export'
-    # binding.pry
     html.gsub! /\\/, '\\\\\\'
     respond_to do |format|
       format.pdf {

--- a/app/views/content/_actions.html.haml
+++ b/app/views/content/_actions.html.haml
@@ -1,9 +1,9 @@
 - if action_name.in? %w{edit layout annotate}
-  = button_to t('content.actions.publish'), casebook_path(@casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line'
   - if action_name == 'layout'
     = button_to t('content.actions.add-section'), sections_path(@casebook, params: {parent: @section.try(:id)}), method: :post, class: 'action add-section'
     = link_to t('content.actions.add-resource'), new_section_path(@casebook), class: 'action add-resource'
     - if @content.is_a? Content::Casebook
+      = button_to t('content.actions.publish'), casebook_path(@casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line'
       = link_to t('content.actions.preview'), casebook_path(@casebook), class: 'action one-line preview', target: '_blank'
     - elsif @content.is_a? Content::Section
       = link_to t('content.actions.preview'), section_path(@casebook, @section), class: 'action one-line preview', target: '_blank'
@@ -12,7 +12,7 @@
 - else
   - if @casebook.owners.include?(current_user)
     - if @casebook.public
-      = button_to t('content.actions.edit-draft'), clone_casebook_path(@casebook, params: {draft: true}), method: :post, class: 'action clone-casebook'
+      = link_to t('content.actions.revise'), edit_casebook_path(@casebook), class: 'action edit one-line'
     - else
       - if action_name == 'details'
         - if @content.is_a? Content::Casebook
@@ -28,6 +28,5 @@
           = link_to t('content.actions.edit'), layout_section_path(@casebook, @section), class: 'action edit one-line'
         - elsif @content.is_a? Content::Resource
           = link_to t('content.actions.edit'), annotate_resource_path(@casebook, @resource), class: 'action edit one-line'
-  - else
-    = button_to t('content.actions.clone-casebook'), clone_casebook_path(@casebook), method: :post, class: 'action clone-casebook'
+  = button_to t('content.actions.clone-casebook'), clone_casebook_path(@casebook), method: :post, class: 'action clone-casebook'
   = link_to t('content.actions.export'), export_casebook_path(@casebook), class: 'action one-line export'

--- a/lib/locales/en/content.yml
+++ b/lib/locales/en/content.yml
@@ -66,7 +66,7 @@ en:
       format: "Format:"
     actions:
       publish: Publish
-      edit: Edit
+      revise: Revise 
       clone-casebook: Clone
       edit-draft: Edit Draft
       add-section: Add Section

--- a/test/system/casebooks_test.rb
+++ b/test/system/casebooks_test.rb
@@ -69,7 +69,8 @@ class CasebookSystemTest < ApplicationSystemTestCase
       resource = content_nodes(:'public_casebook_section_1.1')
 
       visit layout_casebook_path casebook
-      click_button 'Edit Draft'
+      click_link 'Revise'
+      click_link 'Layout'
 
       assert_content 'This casebook is a draft'
       assert_content "1.1 #{resource.resource.short_name}"


### PR DESCRIPTION
- Owner sees a revise button 
---> revise button takes you to edit details page (because of rails routing -- can fix later )

- Remove publish button from details view ( when in draft mode ) 