### PR TITLE
Correct tabs for resources 

### DIFF
--- a/app/views/content/_tabs.html.haml
+++ b/app/views/content/_tabs.html.haml
@@ -9,10 +9,11 @@
 - if active_tab.in? %w{edit layout annotate} # draft mode
   %a{:class => "tab #{active_tab == 'layout' ? 'active' : ''}", :href => layout_casebook_path(@casebook)}= t 'content.tabs.casebook'
   - if @resource.present?
-    %a{:class => "tab #{active_tab == 'annotate' ? 'active' : ''}", :href => annotate_resource_path(@casebook, @resource)}= t 'content.tabs.annotate'
-    - if @resource.resource_type != 'Case'
+    - if @resource.resource_type.in? %w{Case TextBlock}
+      %a{:class => "tab #{active_tab == 'annotate' ? 'active' : ''}", :href => annotate_resource_path(@casebook, @resource)}= t 'content.tabs.annotate'
+    - if @resource.resource_type.in? %w{Default TextBlock}
       %a{:class => "tab #{active_tab == 'edit' ? 'active' : ''}", :href => edit_resource_path(@casebook, @resource)}= t 'content.tabs.resource-details'
-  - elsif @section.present?
+  - if @section.present?
     %a{:class => "tab #{active_tab == 'layout' ? 'active' : ''}" }= t 'content.tabs.edit'
 
 - else # published mode

--- a/app/views/content/edit_details.html.erb
+++ b/app/views/content/edit_details.html.erb
@@ -1,20 +1,20 @@
 <%= simple_form_for @content, url: @section.present? ? section_path(@casebook, @section) : @resource.present? ? resource_path(@casebook, @resource) : casebook_path(@casebook), class: 'casebook-details' do |f| %>
-	<% if @section.present? %>
-	  <header class="casebook-header">
-	    <a class="casebook-title" href="<%= edit_casebook_path(@casebook) %>">
-	      <%= @casebook.title %>
-	    </a>
-	    <div class="collaborators">
-	      <%= render partial: 'content/collaborators', locals: {content: @casebook} %>
-	    </div>
-	  </header>
-	<% end %>
+  <% if @section.present? %>
+    <header class="casebook-header">
+      <a class="casebook-title" href="<%= edit_casebook_path(@casebook) %>">
+        <%= @casebook.title %>
+      </a>
+      <div class="collaborators">
+        <%= render partial: 'content/collaborators', locals: {content: @casebook} %>
+      </div>
+    </header>
+  <% end %>
 
-	<header class="content">
-	  <% if @section.present? %>
-	    <div class="breadcrumbs">
-	      <%= t 'content.show.section' %>
-	      <% @section.ordinals.each_with_index do |ordinal, idx| %>
+  <header class="content">
+    <% if @section.present? %>
+      <div class="breadcrumbs">
+        <%= t 'content.show.section' %>
+        <% @section.ordinals.each_with_index do |ordinal, idx| %>
           <% unless idx == @section.ordinals.length-1 %>
             <a class="breadcrumb" href="<%= edit_section_path(@casebook, @section.ordinals[0..idx].join('.')) %>" %><%= ordinal %></a>
             <span class="separator">.</span>
@@ -22,34 +22,34 @@
             <span class="breadcrumb active"><%= ordinal %>
          <% end %>
         <% end %>
-	    </div>
-	  <% end %>
-		<%= f.input :title, placeholder: t('simple_form.labels.casebook.name') %>
-		<%= f.input :subtitle, placeholder: t('simple_form.labels.casebook.subtitle') %>
-		<% if @section.nil? %>
-		  <div class="collaborators">
-		    <% @casebook.users.each do |user| %>
-		    	<div class="user <%= user.verified? ? 'verified' : '' %>"><%= user.display_name %></div>
-		    <% end %>
-		  </div>
-		<% end %>
-	</header>
+      </div>
+    <% end %>
+    <%= f.input :title, placeholder: t('simple_form.labels.casebook.name') %>
+    <%= f.input :subtitle, placeholder: t('simple_form.labels.casebook.subtitle') %>
+    <% if @section.nil? %>
+      <div class="collaborators">
+        <% @casebook.users.each do |user| %>
+          <div class="user <%= user.verified? ? 'verified' : '' %>"><%= user.display_name %></div>
+        <% end %>
+      </div>
+    <% end %>
+  </header>
 
   <section class="headnote">
-	  <h5>
-	    <%= t 'content.show.headnote' %>
-	  </h5>
-	  <%= f.input :headnote, placeholder: t('simple_form.labels.casebook.description') %>
-	</section>
+    <h5>
+      <%= t 'content.show.headnote' %>
+    </h5>
+    <%= f.input :headnote, placeholder: t('simple_form.labels.casebook.description') %>
+  </section>
 
-	<section class="resource">
-		<%= f.simple_fields_for :resource do |r| %>
-			<% if @content.resource.is_a? Default %>
-				<%= r.input :url %> 
-			<% elsif @content.resource.is_a? TextBlock %>
-				<%= r.cktext_area :content, class: 'ckeditor form-control' %>
-			<% end %>
-		<% end %>
-	</section>
+  <section class="resource">
+    <%= f.simple_fields_for :resource do |r| %>
+      <% if @content.resource.is_a? Default %>
+        <%= r.input :url %> 
+      <% elsif @content.resource.is_a? TextBlock %>
+        <%= r.cktext_area :content, class: 'ckeditor form-control' %>
+      <% end %>
+    <% end %>
+  </section>
 
 <% end %>

--- a/app/views/content/table_of_contents/_edit.haml
+++ b/app/views/content/table_of_contents/_edit.haml
@@ -2,21 +2,25 @@
 - content = edit
 - if content.is_a? Content::Resource
   .listing-wrapper{data: {ordinals: content.ordinal_string}}
-    %a.listing.resource{href: annotate_resource_path(content.casebook, content), draggable: true, data: {ordinals: content.ordinal_string, editable: editable}}
-      .section-number= content.ordinal_string
-      .section-title= content.title
-      - if content.resource.is_a? Case
-        .section-title= content.resource.short_name
-        .resource-case= content.resource.case_citations.first
-        .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
-        .resource-type= t 'content.resource.type.case'
-      - elsif content.resource.is_a? TextBlock
-        .resource-type= t 'content.resource.type.text'
-      - elsif content.resource.is_a? Default
+    - if content.resource.is_a? Default
+      %a.listing.resource{href: edit_resource_path(content.casebook, content), draggable: true, data: {ordinals: content.ordinal_string, editable: editable}}
+        .section-number= content.ordinal_string
+        .section-title= content.title
         .resource-type= t "content.resource.type.#{content.resource.content_type.parameterize}"
-      - else
-        .resource-type
-          .not-applicable= t "content.resource.type.not-applicable"
+    - else
+      %a.listing.resource{href: annotate_resource_path(content.casebook, content), draggable: true, data: {ordinals: content.ordinal_string, editable: editable}}
+        .section-number= content.ordinal_string
+        .section-title= content.title
+        - if content.resource.is_a? Case
+          .section-title= content.resource.short_name
+          .resource-case= content.resource.case_citations.first
+          .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
+          .resource-type= t 'content.resource.type.case'
+        - elsif content.resource.is_a? TextBlock
+          .resource-type= t 'content.resource.type.text'
+        - else
+          .resource-type
+            .not-applicable= t "content.resource.type.not-applicable"
     - if editable
       .actions
         = button_to t('content.edit.delete-section'), section_path(content.casebook, content), method: :delete, class: 'action-delete', 'data-n-children': content.try(:contents).try(:count)

--- a/app/views/content/table_of_contents/_edit.haml
+++ b/app/views/content/table_of_contents/_edit.haml
@@ -4,23 +4,19 @@
   .listing-wrapper{data: {ordinals: content.ordinal_string}}
     %a.listing.resource{href: annotate_resource_path(content.casebook, content), draggable: true, data: {ordinals: content.ordinal_string, editable: editable}}
       .section-number= content.ordinal_string
-      - if content.is_a? Content::Resource
-        - if content.resource.is_a? Case
-          .section-title= content.resource.short_name
-          .resource-case= content.resource.case_citations.first
-          .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
-        - else
-          .section-title= content.title
-      - if content.is_a? Content::Resource
-        - if content.resource.is_a? Case
-          .resource-type= t 'content.resource.type.case'
-        - elsif content.resource.is_a? TextBlock
-          .resource-type= t 'content.resource.type.text'
-        - elsif content.resource.is_a? Default
-          .resource-type= t "content.resource.type.#{content.resource.content_type.parameterize}"
-        - else
-          .resource-type
-            .not-applicable= t "content.resource.type.not-applicable"
+      .section-title= content.title
+      - if content.resource.is_a? Case
+        .section-title= content.resource.short_name
+        .resource-case= content.resource.case_citations.first
+        .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
+        .resource-type= t 'content.resource.type.case'
+      - elsif content.resource.is_a? TextBlock
+        .resource-type= t 'content.resource.type.text'
+      - elsif content.resource.is_a? Default
+        .resource-type= t "content.resource.type.#{content.resource.content_type.parameterize}"
+      - else
+        .resource-type
+          .not-applicable= t "content.resource.type.not-applicable"
     - if editable
       .actions
         = button_to t('content.edit.delete-section'), section_path(content.casebook, content), method: :delete, class: 'action-delete', 'data-n-children': content.try(:contents).try(:count)

--- a/app/views/content/table_of_contents/_edit.haml
+++ b/app/views/content/table_of_contents/_edit.haml
@@ -10,15 +10,16 @@
     - else
       %a.listing.resource{href: annotate_resource_path(content.casebook, content), draggable: true, data: {ordinals: content.ordinal_string, editable: editable}}
         .section-number= content.ordinal_string
-        .section-title= content.title
         - if content.resource.is_a? Case
           .section-title= content.resource.short_name
           .resource-case= content.resource.case_citations.first
           .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
           .resource-type= t 'content.resource.type.case'
         - elsif content.resource.is_a? TextBlock
+          .section-title= content.title
           .resource-type= t 'content.resource.type.text'
         - else
+          .section-title= content.title
           .resource-type
             .not-applicable= t "content.resource.type.not-applicable"
     - if editable


### PR DESCRIPTION
* From table of contents Default ( this is actually a Link but legacy name ) should go to the Edit Details ( or Resource Details ) tab
** Default resources should not have an Annotate tab
** From table of contents  Case & TextBlock go to the Annotate tab

Closes https://github.com/harvard-lil/h2o/issues/162 