### PR TITLE
Bug - background remained frozen after add-resource modal was closed 

### DIFF
--- a/app/assets/javascripts/lib/ui/content/add_content.js.erb
+++ b/app/assets/javascripts/lib/ui/content/add_content.js.erb
@@ -111,6 +111,7 @@ class AddResourceModal extends Component {
 
   destroy () {
     super.destroy();
+    document.body.classList.remove('modal-open');
     modal = null;
   }
 


### PR DESCRIPTION
* Remove modal-open class when modal destroyed 