### PR TITLE
fixed: active class in tabs in draft casebook view

### DIFF
--- a/app/views/content/_tabs.html.haml
+++ b/app/views/content/_tabs.html.haml
@@ -7,14 +7,17 @@
   - active_tab = action_name
 
 - if active_tab.in? %w{edit layout annotate} # draft mode
-  %a{:class => "tab #{active_tab == 'layout' ? 'active' : ''}", :href => layout_casebook_path(@casebook)}= t 'content.tabs.casebook'
   - if @resource.present?
+    %a{:class => "tab #{active_tab == 'layout' ? '' : ''}", :href => layout_casebook_path(@casebook)}= t 'content.tabs.casebook'
     - if @resource.resource_type.in? %w{Case TextBlock}
       %a{:class => "tab #{active_tab == 'annotate' ? 'active' : ''}", :href => annotate_resource_path(@casebook, @resource)}= t 'content.tabs.annotate'
     - if @resource.resource_type.in? %w{Default TextBlock}
       %a{:class => "tab #{active_tab == 'edit' ? 'active' : ''}", :href => edit_resource_path(@casebook, @resource)}= t 'content.tabs.resource-details'
-  - if @section.present?
+  - elsif @section.present?
+    %a{:class => "tab #{active_tab == 'layout' ? '' : ''}", :href => layout_casebook_path(@casebook)}= t 'content.tabs.casebook'
     %a{:class => "tab #{active_tab == 'layout' ? 'active' : ''}" }= t 'content.tabs.edit'
+  - else
+    %a{:class => "tab #{active_tab == 'layout' ? 'active' : ''}", :href => layout_casebook_path(@casebook)}= t 'content.tabs.casebook'
 
 - else # published mode
   %a{:class => "tab #{active_tab == 'casebook' ? 'active' : ''}", :href => casebook_path(@casebook)}= t 'content.tabs.casebook'


### PR DESCRIPTION
In draft casebook view, when viewing resource or section, both layout tab and resource/section tab had `active` class. This change removes 'active' class from layout tab when resource/section being viewed.