### PR TITLE
Present case citations to Solr as string, not array

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -120,7 +120,7 @@ class Case < ApplicationRecord
   alias :to_s :display_name
 
   def indexable_case_citations
-    self.case_citations.map(&:display_name)
+    self.case_citations.map(&:display_name).join(" ")
   end
   def indexable_case_docket_numbers
     self.case_docket_numbers.map(&:docket_number)


### PR DESCRIPTION
This fixes a bug where `rake sunspot:reindex` produced a Solr error: 

```
RSolr::Error::Http: RSolr::Error::Http - 400 Bad Request
Error: {"responseHeader":{"status":400,"QTime":17},"error":{"metadata":["error-class","org.apache.solr.common.SolrException","root-error-class","org.apache.solr.common.SolrException"],"msg":"Error parsing JSON field value. Unexpected OBJECT_START at [2036], field=indexable_case_citations_text","code":400}}
```

That is, for cases with multiple citations, the citations were being presented to Solr as a list, which apparently it doesn't want to see for indexable items.