### PR TITLE
Attribution style

### DIFF
--- a/app/assets/stylesheets/casebook.scss
+++ b/app/assets/stylesheets/casebook.scss
@@ -149,10 +149,10 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
 }
 
 .casebook-inner {
-  header.content{
+  header.content {
     padding: 20px 30px;
 
-    .form-control{
+    .form-control {
       font-size: 15px;
     }
   }
@@ -260,35 +260,41 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
     @include sans-serif($medium, 36px, 36px);
     padding: 32px 20px 25px;
   }
-  .collaborators {
-    .add-collaborator {
-      @include square(20px);
-      display: inline-block;
-      vertical-align: middle;
 
-      color: transparent;
-      background-image: asset-url('add-icon.png');
-      background-size: auto;
-    }
-    .user {
-      @include sans-serif($medium, 13px, 13px);
-      font-weight: bold;
+  .authorship {
+    .collaborators {
       display: inline-block;
-      &.verified::before {
-        @include square(13px);
+      .add-collaborator {
+        @include square(20px);
         display: inline-block;
         vertical-align: middle;
-        content: '';
-        background: asset-url('ui/verified.png') no-repeat;
+
+        color: transparent;
+        background-image: asset-url('add-icon.png');
+        background-size: auto;
       }
+      .user {
+        @include sans-serif($medium, 13px, 13px);
+        font-weight: bold;
+        display: inline-block;
+        &.verified::before {
+          @include square(13px);
+          display: inline-block;
+          vertical-align: middle;
+          content: '';
+          background: asset-url('ui/verified.png') no-repeat;
+        }
+      }
+    }
+    .root-attribution {
+    text-align: right;
+    font-size: 13px;
+    display: inline-block;
+    float: right;
     }
   }
 
-  .root-attribution {
-    text-align: right;
-    margin-top: -20px;
-    font-size: 13px;
-  }
+  
 
   .resource {
     padding: 40px;

--- a/app/assets/stylesheets/casebook.scss
+++ b/app/assets/stylesheets/casebook.scss
@@ -287,14 +287,12 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
       }
     }
     .root-attribution {
-    text-align: right;
-    font-size: 13px;
-    display: inline-block;
-    float: right;
+      text-align: right;
+      font-size: 13px;
+      display: inline-block;
+      float: right;
     }
   }
-
-  
 
   .resource {
     padding: 40px;

--- a/app/views/content/_edit_details.html.erb
+++ b/app/views/content/_edit_details.html.erb
@@ -27,15 +27,17 @@
 	</section>
 
   <% if @section.nil? %>
-    <div class="collaborators">
-      <% @casebook.users.each do |user| %>
-        <div class="user <%= user.verified? ? 'verified' : '' %>"><%= user.display_name %></div>
-      <% end %>
-    </div>
-    <div class="root-attribution">
-      <% if @casebook.ancestry %>
-        Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
-      <% end %>
+    <div class="authorship">
+      <div class="collaborators">
+        <% @casebook.users.each do |user| %>
+          <div class="user <%= user.verified? ? 'verified' : '' %>"><%= user.display_name %></div>
+        <% end %>
+      </div>
+      <div class="root-attribution">
+        <% if @casebook.ancestry %>
+          Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -37,27 +37,23 @@
       <%= @content.title %>
     <% end %>
   </h1>
-    <% if @section.nil? %>
-      <h2 class="subtitle">
-        <%= @content.subtitle %>
-      </h2>
-    <% end %>
-    <% if @section.nil? %>
-      <div class="authorship">
-        <div class="collaborators">
-          <%= render partial: 'content/collaborators', locals: {content: @content} %>
-        </div>
-        <div class="root-attribution">
-          <% if @casebook.ancestry %>
-            Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
-          <% end %>
-        </div>
+  <% if @section.nil? %>
+    <h2 class="subtitle">
+      <%= @content.subtitle %>
+    </h2>
+  <% end %>
+  <% if @section.nil? %>
+    <div class="authorship">
+      <div class="collaborators">
+        <%= render partial: 'content/collaborators', locals: {content: @content} %>
       </div>
-    <% end %>
-
-    
-
- 
+      <div class="root-attribution">
+        <% if @casebook.ancestry %>
+          Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </header>
 <% if @content.headnote.present? || @content.subtitle.present? %>
   <section class="headnote">

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -36,23 +36,28 @@
     <% else %>
       <%= @content.title %>
     <% end %>
-
+  </h1>
     <% if @section.nil? %>
       <h2 class="subtitle">
         <%= @content.subtitle %>
       </h2>
     <% end %>
     <% if @section.nil? %>
-      <div class="collaborators">
-        <%= render partial: 'content/collaborators', locals: {content: @content} %>
+      <div class="authorship">
+        <div class="collaborators">
+          <%= render partial: 'content/collaborators', locals: {content: @content} %>
+        </div>
+        <div class="root-attribution">
+          <% if @casebook.ancestry %>
+            Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
+          <% end %>
+        </div>
       </div>
     <% end %>
-    <div class="root-attribution">
-      <% if @casebook.ancestry %>
-        Original author: <%= link_to @casebook.root.root_owner, user_path(@casebook.root.root_owner) %>
-      <% end %>
-    </div>
-  </h1>
+
+    
+
+ 
 </header>
 <% if @content.headnote.present? || @content.subtitle.present? %>
   <section class="headnote">


### PR DESCRIPTION
Casebook header padding was funky with new root-attribution class. Resolved by putting both .collaborators and .root-attribution inside div with .authorship class, and setting them both to display: inline-block. 

Reflected this change in both the Show and Edit views.