### PR TITLE
Remove rails_admin object_label_method 

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -244,9 +244,6 @@ RailsAdmin.config do |config|
   end
 
   config.model 'User' do
-    object_label_method do
-      :custom_label_method
-    end
     list do
       field :id
       field :login


### PR DESCRIPTION
* looks like code was previously deleted and this was leftover.