### PR TITLE
Remove urldomainformatter code that removed file path.

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,6 +1,6 @@
 class PasswordResetsController < ApplicationController
   before_action :load_user_using_perishable_token, :only => [:edit, :update]
-  layout 'main', only: [:new, :create]
+  layout 'main', only: [:new, :create, :edit, :update]
 
   def new
     @user = {email_address: params.fetch(:email_address, '')}

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -32,7 +32,7 @@ class UserSessionsController < ApplicationController
     if current_user_session.present?
       current_user_session.destroy
     end
-    redirect_back_or_default "/"
+    redirect_to :root
   end
 
   private

--- a/app/services/url_domain_formatter.rb
+++ b/app/services/url_domain_formatter.rb
@@ -3,8 +3,6 @@ class UrlDomainFormatter
     if !URI.parse(domain).host
       domain.prepend("http://")
     end
-    # remove file path
-    domain = URI.join(domain, "/").to_s
     
     domain
   end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,9 +1,22 @@
+<header class="users">
+  <div class="content">
+    <h1>
+      <%= t 'users.change-password.header' %>
+    </h1>
+  </div>
+</header>
 
-<h3><%= t 'users.change-password.header' %></h3>
-<div class="form">
-  <%= simple_form_for @user, url: password_reset_path, html: {data: {remote: true}} do |f| %>
-    <%= f.input :password, required: true %>
-    <%= f.input :password_confirmation, required: true %>
-    <%= f.button :submit, t('simple_form.labels.user.change-password') %>
-  <% end %>
-</div>
+
+<section class="reset-password">
+  <div class="content">
+    <div class="layout">
+      <div class="form">
+        <%= simple_form_for @user, url: password_reset_path, html: {data: {remote: true}} do |f| %>
+          <%= f.input :password, required: true %>
+          <%= f.input :password_confirmation, required: true %>
+          <%= f.button :submit, t('simple_form.labels.user.change-password') %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
* reset password was using css from old h2o / now uses same css as form in edit profile
* when adding a new link resource the file path isn't stripped out   
* logging out redirects to the root path --- was going back to the reset password page because of ajax