### PR TITLE
Fix weird formatting in exported docs 

### DIFF
--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -12,14 +12,14 @@
     %header.SectionTitle=content.title
     - if content.subtitle.present?
       %header.SectionSubtitle=content.subtitle
-    - if content.formatted_headnote.present?
+    - if content.headnote.present?
       %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
   - elsif content.is_a? Content::Resource
     %header.ResourceNumber{data: {'toc-idx': idx + 1}}=content.ordinal_string
     %header.ResourceTitle=content.title
     - if content.subtitle.present?
       %header.ResourceSubtitle= content.subtitle
-    - if content.formatted_headnote.present?
+    - if content.headnote.present?
       %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body

--- a/app/views/content/resources/export.haml
+++ b/app/views/content/resources/export.haml
@@ -6,14 +6,14 @@
   %header.SectionTitle= content.title
   - if content.subtitle.present?
     %header.SectionSubtitle= content.subtitle
-  - if content.formatted_headnote.present?
+  - if content.headnote.present?
     %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
 - elsif content.is_a? Content::Resource
   %header.ResourceNumber= content.ordinal_string
   %header.ResourceTitle= content.title
   - if content.subtitle.present?
     %header.ResourceSubtitle= content.subtitle
-  - if content.formatted_headnote.present?
+  - if content.headnote.present?
     %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
   - if content.resource.class.in? [Case, TextBlock]
     -# %main

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -7,14 +7,14 @@
     %header.SectionTitle= content.title
     - if content.subtitle.present?
       %header.SectionSubtitle= content.subtitle
-    - if content.formatted_headnote.present?
+    - if content.headnote.present?
       %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
   - elsif content.is_a? Content::Resource
     %header.ResourceNumber= content.ordinal_string
     %header.ResourceTitle= content.title
     - if content.subtitle.present?
       %header.ResourceSubtitle= content.subtitle
-    - if content.formatted_headnote.present?
+    - if content.headnote.present?
       %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body


### PR DESCRIPTION
* in the export views it was checking for `content.formatted_headnote?` - now it just checks for `content.headnote?`