### PR TITLE
Browse page shows only verified professors 

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -73,7 +73,7 @@ class SearchesController < ApplicationController
       with :attribution, params[:author] if params[:author].present?
       with :affiliation, params[:school] if params[:school].present?
 
-      if params[:type] == ('casebooks' || 'users')
+      if content_has_verified_professor?
         with(:verified_professor).equal_to(true)
       end
 
@@ -89,6 +89,22 @@ class SearchesController < ApplicationController
         params['group.offset'] = (page - 1) * PER_PAGE
       end
     end
+  end
+
+  def content_has_verified_professor?
+    browse_page || casebooks_tab || users_tab
+  end
+
+  def browse_page
+    ! params[:type].present?
+  end
+
+  def casebooks_tab
+    params[:type].include?('casebooks')
+  end
+
+  def users_tab
+    params[:type].include?('users')
   end
 
   def paginate_group(group)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -40,3 +40,5 @@ verified_professor:
   attribution: verified_professor
   affiliation: verified_professor's Affiliation
   persistence_token: abcd
+  verified_professor: true
+  professor_verification_requested: true

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -39,7 +39,7 @@ class UserSystemTest < ApplicationSystemTestCase
     end
     scenario 'browsing users', solr: true do
       visit users_path
-      assert_content "student_user"
+      assert_content "verified_professor"
     end
     scenario 'browsing a non-user' do
       visit user_path(:nonID)


### PR DESCRIPTION
Solr doesn't look for the `:verified_professor` field on the `cases` tab, but it does everywhere else (`/browse`, `casebooks`, `users`)