### PR TITLE
Exporting docs & pdf has headnotes

### DIFF
--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -6,6 +6,9 @@
     %toc-entry{data: {depth: content.ordinals.length, idx: idx + 1}}
       = content.ordinal_string
       = content.title
+%br
+= @casebook.formatted_headnote.to_html.html_safe
+
 - @casebook.contents.each_with_index do |content, idx|
   - if content.is_a? Content::Section
     %header.SectionNumber{data: {'toc-idx': idx + 1}}=content.ordinal_string

--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -6,8 +6,8 @@
     %toc-entry{data: {depth: content.ordinals.length, idx: idx + 1}}
       = content.ordinal_string
       = content.title
-%br
-= @casebook.formatted_headnote.to_html.html_safe
+%p
+  = @casebook.formatted_headnote.to_html.html_safe
 
 - @casebook.contents.each_with_index do |content, idx|
   - if content.is_a? Content::Section

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -1,6 +1,7 @@
 %header.SectionNumber= @section.ordinal_string
 %header.CasebookTitle= @section.title
 %header.CasebookSubtitle= @section.subtitle
+%header.CasebookHeadnote= @section.formatted_headnote.to_html.html_safe
 - @section.contents.each do |content|
   - if content.is_a? Content::Section
     %header.SectionNumber= content.ordinal_string

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -1,7 +1,8 @@
 %header.SectionNumber= @section.ordinal_string
 %header.CasebookTitle= @section.title
 %header.CasebookSubtitle= @section.subtitle
-%header.CasebookHeadnote= @section.formatted_headnote.to_html.html_safe
+%p
+  %header.CasebookHeadnote= @section.formatted_headnote.to_html.html_safe
 - @section.contents.each do |content|
   - if content.is_a? Content::Section
     %header.SectionNumber= content.ordinal_string


### PR DESCRIPTION
* exporting a casebook includes casebook headnote
* exporting a section includes section headnote
* resources already were exporting their headnotes 

BLOCKED - will need to update the osx & travis test files to make tests pass since exported files will now be bigger than what was previously stored