### PR TITLE
Add validation check to destroying a casebook 

### DIFF
--- a/app/models/content/casebook.rb
+++ b/app/models/content/casebook.rb
@@ -114,4 +114,12 @@ class Content::Casebook < Content::Node
   def to_param
     "#{id}-#{slug}"
   end
+
+  def destroy
+    if self.descendants.present?
+     raise "Cannot delete a casebook with active descendants"
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
Check for ancestry dependents.

The reason is because resources are cloned when cloning a casebook but annotations are not, so if a child references an ancestor's annotations it would cause a 500 if that annotation had been deleted.