### PR TITLE
Remove case citation calls

### DIFF
--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -29,7 +29,7 @@
       <div class="<%= @content.resource_type.downcase %>">
         <div class="title-metadata">
           <span class="resource-type"><%= @content.resource_type %></span>
-          <span class="citation"><%= @content.resource.case_citations.first %></span>
+          <span class="citation"><%= @content.resource.primary_case_citation %></span>
         </div>
         <%= @content.title %>
       </div>

--- a/app/views/content/table_of_contents/_edit.haml
+++ b/app/views/content/table_of_contents/_edit.haml
@@ -12,7 +12,7 @@
         .section-number= content.ordinal_string
         - if content.resource.is_a? Case
           .section-title= content.resource.short_name
-          .resource-case= content.resource.case_citations.first
+          .resource-case= content.resource.primary_case_citation
           .resource-date= content.resource.try(:date_year) || t('content.resource.date.not-applicable')
           .resource-type= t 'content.resource.type.case'
         - elsif content.resource.is_a? TextBlock

--- a/app/views/content/table_of_contents/_show.erb
+++ b/app/views/content/table_of_contents/_show.erb
@@ -19,7 +19,7 @@
         <div class="section-number"> <%= content.ordinal_string %> </div>
         <% if content.resource.is_a? Case %>
           <div class="section-title"> <%= content.resource.short_name %> </div>
-          <div class="resource-case"> <%= content.resource.case_citations.first %></div>
+          <div class="resource-case"> <%= content.resource.primary_case_citation %></div>
           <div class="resource-date"> <%= content.resource.try(:date_year) || t('content.resource.date.not-applicable') %> </div>
           <div class="resource-type"> <%= t 'content.resource.type.case' %></div>
         <% elsif content.resource.is_a? TextBlock %>

--- a/db/migrate/20180315204122_add_case_citation_field_to_case.rb
+++ b/db/migrate/20180315204122_add_case_citation_field_to_case.rb
@@ -1,0 +1,9 @@
+class AddCaseCitationFieldToCase < ActiveRecord::Migration[5.1]
+  def up
+    add_column :cases, :primary_case_citation, :string, index: true
+  end
+
+  def down
+    remove_column :cases, :primary_case_citation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180209184936) do
+ActiveRecord::Schema.define(version: 20180315204122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 20180209184936) do
     t.boolean "sent_in_cases_list", default: false
     t.integer "user_id", default: 0
     t.boolean "created_via_import", default: false, null: false
+    t.string "primary_case_citation"
     t.index ["author"], name: "index_cases_on_author"
     t.index ["case_jurisdiction_id"], name: "index_cases_on_case_jurisdiction_id"
     t.index ["created_at"], name: "index_cases_on_created_at"

--- a/lib/backfill_case_citations.rb
+++ b/lib/backfill_case_citations.rb
@@ -1,0 +1,9 @@
+module BackfillCaseCitations
+  class << self
+    def fill
+      Case.all.each do |kase|
+        kase.update(primary_case_citation: kase.case_citations.first)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously a db call was made for every case when a casebook is loading, significantly slowing down the time. 

By filling the primary citation, which is the only one that was being used, into the case record - this cuts down on a lot of lag. 

This will be something to keep in mind when importing new cases in the future. 