### PR TITLE
Add transaction block around merging draft

### DIFF
--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -80,10 +80,6 @@ class Content::Annotation < ApplicationRecord
     end
   end
 
-  def exists_in_published_casebook?
-   resource.casebook.draft_mode_of_published_casebook && copy_of.present?
-  end
-
   def copy_of
     resource.copy_of.annotations.where(start_p: self.start_p, end_p: self.end_p, 
           start_offset: self.start_offset, end_offset: self.end_offset).first

--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -83,10 +83,6 @@ class Content::Resource < Content::Child
     nodes
   end
 
-  def exists_in_published_casebook?
-    casebook.draft_mode_of_published_casebook && copy_of.present?
-  end
-
   # def annotations
   #   if is_alias?
   #     copy_of.annotations # delete all of this because i should run a script to migrate 

--- a/app/services/merge_draft_into_published_casebook.rb
+++ b/app/services/merge_draft_into_published_casebook.rb
@@ -89,6 +89,7 @@ class MergeDraftIntoPublishedCasebook
   def deleted_annotations
     revisions.where(field: "deleted_annotation").each do |revision|
       Content::Annotation.find(revision.value.to_i).destroy
+      revision.destroy
     end
   end
 

--- a/app/services/merge_draft_into_published_casebook.rb
+++ b/app/services/merge_draft_into_published_casebook.rb
@@ -145,4 +145,5 @@ class MergeDraftIntoPublishedCasebook
 
   def annotating_new_resource?(annotation)
     ! annotation.resource.copy_of.present?
+  end
 end


### PR DESCRIPTION
* replace begin block with transaction block
* raise exceptions for CRUD commands
* Instead of looking for new and updated annotations by data, do the logic directly 
* Destroy deleted annotations unpublished revisions when done 

* Remove unneeded exists_in_published_casebook methods 