### PR TITLE
Check for blank headnote when rendering formatted_headnote. And set a…

### DIFF
--- a/app/models/content/node.rb
+++ b/app/models/content/node.rb
@@ -49,7 +49,7 @@ class Content::Node < ApplicationRecord
       content_params.each do |field|
         value = content_params[field]
         previous_revisions = unpublished_revisions.where(field: field)
-        
+
         if previous_revisions.present?
           previous_revisions.destroy_all
         end
@@ -59,7 +59,10 @@ class Content::Node < ApplicationRecord
   end
 
   def formatted_headnote
-    Nokogiri::HTML self.headnote {|config| config.strict.noblanks}
+    unless self.headnote.blank?
+      headnote_html = Nokogiri::HTML self.headnote {|config| config.strict.noblanks}
+      headnote_html.to_html.html_safe
+    end
   end
 
   private

--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -1,13 +1,12 @@
 %header.CasebookTitle= @casebook.title
 %header.CasebookSubtitle= @casebook.subtitle
+%p.CasebookHeadnote= @casebook.formatted_headnote
 
 %table-of-contents
   - @casebook.contents.each_with_index do |content, idx|
     %toc-entry{data: {depth: content.ordinals.length, idx: idx + 1}}
       = content.ordinal_string
       = content.title
-%p
-  = @casebook.formatted_headnote.to_html.html_safe
 
 - @casebook.contents.each_with_index do |content, idx|
   - if content.is_a? Content::Section
@@ -16,14 +15,14 @@
     - if content.subtitle.present?
       %header.SectionSubtitle=content.subtitle
     - if content.headnote.present?
-      %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
+      %p.SectionHeadnote= content.formatted_headnote
   - elsif content.is_a? Content::Resource
     %header.ResourceNumber{data: {'toc-idx': idx + 1}}=content.ordinal_string
     %header.ResourceTitle=content.title
     - if content.subtitle.present?
       %header.ResourceSubtitle= content.subtitle
     - if content.headnote.present?
-      %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
+      %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
         - content.annotated_paragraphs(editable: false).each_with_index do |p_node, p_idx|

--- a/app/views/content/details.html.erb
+++ b/app/views/content/details.html.erb
@@ -27,5 +27,5 @@
   <h5>
     <%= t 'content.show.headnote' %>
   </h5>
-  <p><%= @content.formatted_headnote.to_html.html_safe %></p>
+  <p><%= @content.formatted_headnote %></p>
 </section>

--- a/app/views/content/resources/export.haml
+++ b/app/views/content/resources/export.haml
@@ -7,14 +7,14 @@
   - if content.subtitle.present?
     %header.SectionSubtitle= content.subtitle
   - if content.headnote.present?
-    %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
+    %p.SectionHeadnote= content.formatted_headnote
 - elsif content.is_a? Content::Resource
   %header.ResourceNumber= content.ordinal_string
   %header.ResourceTitle= content.title
   - if content.subtitle.present?
     %header.ResourceSubtitle= content.subtitle
   - if content.headnote.present?
-    %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
+    %p.ResourceHeadnote= content.formatted_headnote
   - if content.resource.class.in? [Case, TextBlock]
     -# %main
     - content.annotated_paragraphs(editable: false).each_with_index do |p_node, p_idx|

--- a/app/views/content/resources/show.html.erb
+++ b/app/views/content/resources/show.html.erb
@@ -43,7 +43,7 @@
       </h3>
     <% end %>
     <p>
-      <%= @content.formatted_headnote.to_html.html_safe %>
+      <%= @content.formatted_headnote %>
     </p>
   </section>
 <% else %>

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -1,8 +1,7 @@
 %header.SectionNumber= @section.ordinal_string
 %header.CasebookTitle= @section.title
 %header.CasebookSubtitle= @section.subtitle
-%p
-  %header.CasebookHeadnote= @section.formatted_headnote.to_html.html_safe
+%p.CasebookHeadnote= @section.formatted_headnote
 - @section.contents.each do |content|
   - if content.is_a? Content::Section
     %header.SectionNumber= content.ordinal_string
@@ -10,14 +9,14 @@
     - if content.subtitle.present?
       %header.SectionSubtitle= content.subtitle
     - if content.headnote.present?
-      %header.SectionHeadnote= content.formatted_headnote.to_html.html_safe
+      %p.SectionHeadnote= content.formatted_headnote
   - elsif content.is_a? Content::Resource
     %header.ResourceNumber= content.ordinal_string
     %header.ResourceTitle= content.title
     - if content.subtitle.present?
       %header.ResourceSubtitle= content.subtitle
     - if content.headnote.present?
-      %header.ResourceHeadnote= content.formatted_headnote.to_html.html_safe
+      %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
         - content.annotated_paragraphs(editable: false).each_with_index do |p_node, p_idx|

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -63,7 +63,7 @@
       </h3>
     <% end %>
     <p>
-      <%= @content.formatted_headnote.to_html.html_safe %>
+      <%= @content.formatted_headnote %>
     </p>
   </section>
 <% else %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,2 +1,3 @@
 Mime::Type.register "image/svg+xml", :svg
 Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
+commented out b/c of https://github.com/karnov/htmltoword#with-rails

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,2 @@
 Mime::Type.register "image/svg+xml", :svg
 Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
-commented out b/c of https://github.com/karnov/htmltoword#with-rails


### PR DESCRIPTION
…ll header.CasebookHeadnote to p.CasebookHeadnote

Blank headnotes was causing export errors to word. 