### PR TITLE
js requests can handle both cases 

### DIFF
--- a/app/assets/javascripts/lib/requests.js
+++ b/app/assets/javascripts/lib/requests.js
@@ -15,7 +15,12 @@ export function request (url, method, data = {}, options = {scroll: true}) {
     .then(response => {
       let html = response.data;
       let location = response.request.responseURL;
-      document.location.reload(true);
+
+      if (window.location.href != location){
+        window.location.replace(location);
+      } else {
+        window.location.reload(true); // save scroll position for annotations
+      }
 
       if (options["modal"]){
         options["modal"].destroy();


### PR DESCRIPTION
reload page if next location is on same page, otherwise replace the window location (for publishing a casebook for example).