### PR TITLE
Skip links via layouts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require select2
 //= require 'polyfills'
 //= require 'lib/requests'
+//= require 'lib/ui/skip-link-focus-fix'
 //= require 'lib/ui/content'
 //= require 'lib/ui/filter-selectize'
 //= require 'lib/ckeditor'

--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -29,3 +29,38 @@ a {
     color: inherit;
   }
 }
+
+/* adapted from https://github.com/Automattic/_s/blob/master/sass/modules/_accessibility.scss */
+.skip-link {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute !important;
+    width: 1px;
+    word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+
+    &:focus {
+        background-color: black;
+        border-radius: 3px;
+        box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+        clip: auto !important;
+        clip-path: none;
+        color: white;
+        display: block;
+        font-family: $headings-font-family;
+        font-size: 1.3em;
+        font-weight: bold;
+        height: auto;
+        left: 5px;
+        line-height: normal;
+        padding: 15px 23px 14px;
+        text-decoration: none;
+        top: 5px;
+        width: auto;
+        z-index: 100000;
+    }
+}

--- a/app/views/content/dashboard.html.erb
+++ b/app/views/content/dashboard.html.erb
@@ -6,13 +6,15 @@
   </div>
 </header>
 <section class="dashboard">
+  <% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+  <p id="main" tabindex="-1" class="sr-only">Main Content</p>
   <div class="content">
     <% if @user == current_user %>
       <h2 class="casebooks">
         <%= 'Your Casebooks' %>
       </h2>
       <hr class="owned"/>
-    <%= render partial: 'content/dashboard/content_browser', locals: {content: @user.owned_casebook_compacted, section: 'owned'} %>
+      <%= render partial: 'content/dashboard/content_browser', locals: {content: @user.owned_casebook_compacted, section: 'owned'} %>
     <% else %>
       <h2 class="casebooks">
         <%= "#{@user.attribution}'s Casebooks" %>

--- a/app/views/content/dashboard.html.erb
+++ b/app/views/content/dashboard.html.erb
@@ -6,7 +6,7 @@
   </div>
 </header>
 <section class="dashboard">
-  <% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+  <% content_for :custom_skip_target do %>arbitrary text, necessary so that content_for :custom_skip_target evaluates to true<% end %>
   <p id="main" tabindex="-1" class="sr-only">Main Content</p>
   <div class="content">
     <% if @user == current_user %>

--- a/app/views/content/dashboard.html.erb
+++ b/app/views/content/dashboard.html.erb
@@ -7,7 +7,6 @@
 </header>
 <section class="dashboard">
   <div class="content">
-    <p id="main" tabindex="-1" class="sr-only">Main Content</p>
     <% if @user == current_user %>
       <h2 class="casebooks">
         <%= 'Your Casebooks' %>

--- a/app/views/content/layout.html.erb
+++ b/app/views/content/layout.html.erb
@@ -1,4 +1,3 @@
-<p id="main" tabindex="-1" class="sr-only">Main Content</p>
 <header class="content">
   <%= render partial: 'content/edit_details', locals: {content: @content} %>
 </header>

--- a/app/views/content/resources/show.html.erb
+++ b/app/views/content/resources/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+<% content_for :custom_skip_target do %>arbitrary text, necessary so that content_for :custom_skip_target evaluates to true<% end %>
 <p id="main" tabindex="-1" class="sr-only">Main Content</p>
 
 <% if @child.present? && @casebook.present? %>

--- a/app/views/content/resources/show.html.erb
+++ b/app/views/content/resources/show.html.erb
@@ -1,3 +1,6 @@
+<% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+<p id="main" tabindex="-1" class="sr-only">Main Content</p>
+
 <% if @child.present? && @casebook.present? %>
   <header class="casebook-header">
     <div class="casebook-title" href="<%= casebook_path(@casebook) %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,8 @@ var UTC_OFFSET = #{Time.zone.now.utc_offset * 1000};") %>
 </head>
 
 <body data-controller="<%= params[:controller] %>" data-action="<%= params[:action] %>" id="<%= "#{params[:controller].gsub(/\//, '_')}_#{params[:action]}" %>" class="<%= @page_cache ? 'cached_page' : '' %> <%= Rails.env == 'test' ? 'no-touch' : '' %>">
-    <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
-    <a href="#footer" class="sr-only sr-only-focusable">Skip to footer</a>
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <a href="#footer" class="skip-link">Skip to footer</a>
     <section id="shell">
     <%= render :partial => "shared/quickbar" %>
     <%= render :partial => "shared/nav" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,11 +19,15 @@ var UTC_OFFSET = #{Time.zone.now.utc_offset * 1000};") %>
 </head>
 
 <body data-controller="<%= params[:controller] %>" data-action="<%= params[:action] %>" id="<%= "#{params[:controller].gsub(/\//, '_')}_#{params[:action]}" %>" class="<%= @page_cache ? 'cached_page' : '' %> <%= Rails.env == 'test' ? 'no-touch' : '' %>">
-	<section id="shell">
+    <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
+    <a href="#footer" class="sr-only sr-only-focusable">Skip to footer</a>
+    <section id="shell">
     <%= render :partial => "shared/quickbar" %>
     <%= render :partial => "shared/nav" %>
     <div class="wrapper main_wrapper">
-
+      <% unless content_for? :custom_skip_target %>
+        <p id="main" tabindex="-1" class="sr-only">Main Content</p>
+      <% end %>
     <% if flash[:notice] && flash[:notice].match(/^Your account has not been verified/) %>
     <p id="notice"><%= raw flash[:notice] %></p>
     <% elsif flash[:notice] && !@page_cache %>
@@ -32,6 +36,7 @@ var UTC_OFFSET = #{Time.zone.now.utc_offset * 1000};") %>
 
     <%= yield %>
     </div>
+    <p id="footer" tabindex="-1" class="sr-only">Footer</p>
     <%= render :partial => 'shared/footer' %>
     <%= render :partial => 'shared/login' %>
   </section>

--- a/app/views/layouts/casebooks.html.erb
+++ b/app/views/layouts/casebooks.html.erb
@@ -42,7 +42,7 @@
       <div class="casebook-inner">
         <div class="top-strip"></div>
         <% if @casebook.present? %>
-          <% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+          <% content_for :custom_skip_target do %>arbitrary text, necessary so that content_for :custom_skip_target evaluates to true<% end %>
           <p id="main" tabindex="-1" class="sr-only">Main Content</p>
         <% end %>
         <%= yield %>

--- a/app/views/layouts/casebooks.html.erb
+++ b/app/views/layouts/casebooks.html.erb
@@ -41,6 +41,10 @@
     <div class="content">
       <div class="casebook-inner">
         <div class="top-strip"></div>
+        <% if @casebook.present? %>
+          <% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>
+          <p id="main" tabindex="-1" class="sr-only">Main Content</p>
+        <% end %>
         <%= yield %>
       </div>
       <% if @casebook.present? %>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <head>    
+  <head>
     <% if content_for :page_title %>
       <title><%= "H2O | " + yield(:page_title) %></title>
     <% elsif @page_title %>
@@ -14,6 +14,7 @@
   </head>
   <body class="view-<%= controller_name.parameterize %>-<%= action_name.parameterize %>">
     <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
+    <a href="#footer" class="sr-only sr-only-focusable">Skip to footer</a>
     <div class="overlay"></div>
     <% if content_for? :banner %>
       <%= yield(:banner) %>
@@ -22,6 +23,9 @@
       <%= render 'layouts/header' %>
     </header>
     <main>
+      <% unless content_for? :custom_skip_target %>
+        <p id="main" tabindex="-1" class="sr-only">Main Content</p>
+      <% end %>
       <section id="flash" style="height: <%= flash.keys.length * 40 %>px">
         <div class="content">
           <% flash.each do |kind, message| %>
@@ -38,6 +42,7 @@
       <% end %>
     </main>
     <footer>
+      <p id="footer" tabindex="-1" class="sr-only">Footer</p>
       <%= render 'layouts/footer' %>
     </footer>
     <%= javascript_include_tag "application" %>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -13,8 +13,8 @@
     <%= stylesheet_link_tag 'main', media: 'all' %>
   </head>
   <body class="view-<%= controller_name.parameterize %>-<%= action_name.parameterize %>">
-    <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
-    <a href="#footer" class="sr-only sr-only-focusable">Skip to footer</a>
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <a href="#footer" class="skip-link">Skip to footer</a>
     <div class="overlay"></div>
     <% if content_for? :banner %>
       <%= yield(:banner) %>


### PR DESCRIPTION
This puts a skip link and a default target for that link in the layout files where it looks like skipping might come in handy.

If a particular view's "main" content is actually further down the page than the location of the default target, the view can provide a custom target via two steps:
1. Override the default by adding the line `<% content_for :custom_skip_target do %>i'm-arbitrary-text<% end %>` to the view.
2.  Place `<p id="main" tabindex="-1" class="sr-only">Main Content</p>` in the desired location.

This is kind of a zillion little commits: happy to rebase and combine them if you want!