### PR TITLE
Create specific revise routes so that sections and casebooks aren't cloned when editing a casebook from preview mode

### DIFF
--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -23,6 +23,11 @@ class Content::CasebooksController < Content::NodeController
     redirect_to layout_casebook_path(@clone)
   end
 
+  def revise
+    # revise without creating a draft]
+    redirect_to layout_casebook_path(@casebook)
+  end
+
   def clone
     @clone = @casebook.clone(owner: current_user)
     redirect_to layout_casebook_path(@clone)

--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -24,7 +24,7 @@ class Content::CasebooksController < Content::NodeController
   end
 
   def revise
-    # revise without creating a draft]
+    # revise without creating a draft
     redirect_to layout_casebook_path(@casebook)
   end
 

--- a/app/controllers/content/sections_controller.rb
+++ b/app/controllers/content/sections_controller.rb
@@ -59,6 +59,10 @@ class Content::SectionsController < Content::NodeController
     redirect_to layout_section_path(@casebook, @section) 
   end
 
+  def revise
+    redirect_to layout_section_path(@casebook, @section) 
+  end
+
   def show
     @decorated_content = @content.decorate(context: {action_name: action_name, casebook: @casebook, section: @section, type: 'section'})
     render 'content/show'

--- a/app/controllers/content/sections_controller.rb
+++ b/app/controllers/content/sections_controller.rb
@@ -60,6 +60,7 @@ class Content::SectionsController < Content::NodeController
   end
 
   def revise
+    # revise without creating a draft
     redirect_to layout_section_path(@casebook, @section) 
   end
 

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -114,7 +114,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_published
     if owner?
-      edit_casebook +
+      edit_casebook_draft +
       clone_casebook +
       export_casebook
     else
@@ -136,7 +136,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def section_published
     if owner?
-      revise_section +
+      create_section_draft +
       clone_section +
       export_section
     else
@@ -172,7 +172,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_preview_of_published_casebook
     publish_changes_to_casebook +
-    edit_casebook +
+    edit_casebook_draft +
     export_casebook
   end
 
@@ -234,8 +234,12 @@ class Content::NodeDecorator < Draper::Decorator
   #############
   ## Section
 
-  def revise_section
+  def create_section_draft
     link_to(I18n.t('content.actions.revise'), edit_section_path(casebook, section), class: 'action edit one-line create-draft')
+  end
+
+  def revise_section
+    link_to(I18n.t('content.actions.revise'), revise_section_path(casebook, section), class: 'action edit one-line')
   end
 
   def clone_section
@@ -273,7 +277,7 @@ class Content::NodeDecorator < Draper::Decorator
     button_to(I18n.t('content.actions.publish'), casebook_path(casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line')
   end
 
-  def edit_casebook
+  def edit_casebook_draft
     link_to(I18n.t('content.actions.revise'), edit_casebook_path(casebook), class: 'action edit one-line create-draft')
   end
 

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -114,7 +114,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_published
     if owner?
-      revise_casebook +
+      edit_casebook +
       clone_casebook +
       export_casebook
     else
@@ -172,7 +172,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_preview_of_published_casebook
     publish_changes_to_casebook +
-    revise_casebook +
+    edit_casebook +
     export_casebook
   end
 
@@ -273,8 +273,12 @@ class Content::NodeDecorator < Draper::Decorator
     button_to(I18n.t('content.actions.publish'), casebook_path(casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line')
   end
 
-  def revise_casebook
+  def edit_casebook
     link_to(I18n.t('content.actions.revise'), edit_casebook_path(casebook), class: 'action edit one-line create-draft')
+  end
+
+  def revise_casebook
+    link_to(I18n.t('content.actions.revise'), revise_casebook_path(casebook), class: 'action edit one-line')
   end
 
   def revise_draft

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -136,7 +136,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def section_published
     if owner?
-      create_section_draft +
+      edit_section_draft +
       clone_section +
       export_section
     else
@@ -234,7 +234,7 @@ class Content::NodeDecorator < Draper::Decorator
   #############
   ## Section
 
-  def create_section_draft
+  def edit_section_draft
     link_to(I18n.t('content.actions.revise'), edit_section_path(casebook, section), class: 'action edit one-line create-draft')
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ H2o::Application.routes.draw do
             get 'details'
             get 'layout'
             get 'clone'
+            get 'revise'
           end
         end
         resources :resources, param: :resource_ordinals, resource_ordinals: /.*/ do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ H2o::Application.routes.draw do
         get 'export'
         get 'layout'
         get 'details'
+        get 'revise'
         patch 'reorder/:child_ordinals', as: :reorder, action: :reorder, child_ordinals: /.*/
         resources :sections, except: [:index], param: :section_ordinals, section_ordinals: /.*/ do
           member do


### PR DESCRIPTION
Resolves #321 