### PR TITLE
Duplicate casebooks on create

### DIFF
--- a/app/assets/javascripts/lib/ui/content/save_details.js.erb
+++ b/app/assets/javascripts/lib/ui/content/save_details.js.erb
@@ -3,6 +3,7 @@ import delegate from 'delegate';
 delegate(document, '.submit-edit-details', 'click', submitEditDetailsForm);
 delegate(document, '.submit-section-details', 'click', submitSectionDetailsForm);
 delegate(document, '.submit-casebook-details', 'click', submitCasebookDetailsForm);
+delegate(document, '.cancel-casebook-details', 'click', cancelCasebookDetailsForm);
 
 function submitEditDetailsForm (e) {
   e.preventDefault();
@@ -17,4 +18,9 @@ function submitSectionDetailsForm (e) {
 function submitCasebookDetailsForm (e) {
   e.preventDefault();
   document.querySelector('form.edit_content_casebook').submit();
+}
+
+function cancelCasebookDetailsForm (e) {
+  e.preventDefault();
+  window.location.reload(true);
 }

--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -17,22 +17,15 @@ class Content::CasebooksController < Content::NodeController
     render 'content/show'
   end
 
-  # def edit
-  #   @casebook.update_attributes public: false
-  #   @content = @casebook
-  #   redirect_to layout_casebook_path(@content)
-  # end
-
   def edit
-    # editing a casebook takes you to a cloned casebook and
-    # the original casebook stays published
-    @clone = @casebook.clone(owner: current_user, draft_mode: true)
-    redirect_to layout_casebook_path(@clone)
+    @casebook.update_attributes public: false
+    @content = @casebook
+    redirect_to layout_casebook_path(@content)
   end
 
-  def revise
-    # revise without creating a draft
-    redirect_to layout_casebook_path(@casebook)
+  def create_draft
+    @clone = @casebook.clone(owner: current_user, draft_mode: true)
+    redirect_to layout_casebook_path(@clone)
   end
 
   def clone

--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -8,13 +8,20 @@ class Content::CasebooksController < Content::NodeController
   def new
     @casebook = Content::Casebook.create(public: false, collaborators: [Content::Collaborator.new(user: current_user, role: 'owner')])
     logger.debug @casebook.errors.inspect
-    redirect_to edit_casebook_path @casebook
+    @content = @casebook
+    redirect_to layout_casebook_path(@content)
   end
 
   def show
     @decorated_content = @casebook.decorate(context: {action_name: action_name, casebook: @casebook, type: 'casebooks'})
     render 'content/show'
   end
+
+  # def edit
+  #   @casebook.update_attributes public: false
+  #   @content = @casebook
+  #   redirect_to layout_casebook_path(@content)
+  # end
 
   def edit
     # editing a casebook takes you to a cloned casebook and

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -278,7 +278,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def create_draft
-    link_to(I18n.t('content.actions.revise'), create_draft_casebook_path(casebook), class: 'action edit one-line create-draft')
+    link_to(I18n.t('content.actions.revise'), create_draft_casebook_path(casebook), method: :post, class: 'action edit one-line create-draft')
   end
 
   def edit_casebook

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -310,11 +310,11 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def save_casebook
-    link_to(I18n.t('content.actions.save'), edit_casebook_path(casebook), class: 'action one-line save submit-casebook-details')
+    link_to(I18n.t('content.actions.save'), 'submit-casebook-details', class: 'action one-line save submit-casebook-details')
   end
 
-  def cancel_casebook
-    link_to(I18n.t('content.actions.cancel'), edit_casebook_path(casebook), class: 'action one-line cancel')
+  def cancel_casebook 
+    link_to(I18n.t('content.actions.cancel'), 'cancel-casebook-details', class: 'action one-line cancel cancel-casebook-details')
   end
 
   ######

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -103,7 +103,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_published_with_draft
     if owner?
-      revise_draft +
+      edit_draft +
       clone_casebook +
       export_casebook
     else
@@ -114,7 +114,7 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_published
     if owner?
-      edit_casebook_draft +
+      create_draft +
       clone_casebook +
       export_casebook
     else
@@ -172,13 +172,13 @@ class Content::NodeDecorator < Draper::Decorator
 
   def casebook_preview_of_published_casebook
     publish_changes_to_casebook +
-    edit_casebook_draft +
+    create_draft +
     export_casebook
   end
 
   def casebook_preview
     publish_casebook +
-    revise_casebook +
+    edit_casebook +
     clone_casebook +
     export_casebook
   end
@@ -277,16 +277,16 @@ class Content::NodeDecorator < Draper::Decorator
     button_to(I18n.t('content.actions.publish'), casebook_path(casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line')
   end
 
-  def edit_casebook_draft
-    link_to(I18n.t('content.actions.revise'), edit_casebook_path(casebook), class: 'action edit one-line create-draft')
+  def create_draft
+    link_to(I18n.t('content.actions.revise'), create_draft_casebook_path(casebook), class: 'action edit one-line create-draft')
   end
 
-  def revise_casebook
-    link_to(I18n.t('content.actions.revise'), revise_casebook_path(casebook), class: 'action edit one-line')
+  def edit_casebook
+    link_to(I18n.t('content.actions.revise'), edit_casebook_path(casebook), class: 'action edit one-line')
   end
 
-  def revise_draft
-    link_to(I18n.t('content.actions.revise-draft'), layout_casebook_path(draft), class: 'action edit one-line')
+  def edit_draft
+    link_to(I18n.t('content.actions.revise-draft'), edit_casebook_path(draft), class: 'action edit one-line')
   end
 
   def clone_casebook

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ H2o::Application.routes.draw do
         get 'layout'
         get 'details'
         get 'revise'
+        post 'create_draft'
         patch 'reorder/:child_ordinals', as: :reorder, action: :reorder, child_ordinals: /.*/
         resources :sections, except: [:index], param: :section_ordinals, section_ordinals: /.*/ do
           member do


### PR DESCRIPTION
#337 

When creating a new casebook from scratch, two casebooks were being created. 

The casebook methods were pretty confusingly named. So I renamed / simplified them.  