### PR TITLE
Refresh .js.erb files on locale changes

### DIFF
--- a/app/assets/javascripts/lib/ui/content/add_content.js.erb
+++ b/app/assets/javascripts/lib/ui/content/add_content.js.erb
@@ -1,3 +1,5 @@
+<% depend_on Rails.root.join('lib/locales/en/content.yml') %>
+
 import {html, raw} from 'es6-string-html-template';
 import delegate from 'delegate';
 import Component from 'lib/ui/component';

--- a/app/assets/javascripts/lib/ui/content/dashboard.js.erb
+++ b/app/assets/javascripts/lib/ui/content/dashboard.js.erb
@@ -1,3 +1,5 @@
+<% depend_on Rails.root.join('lib/locales/en/content.yml') %>
+
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
 import Component from 'lib/ui/component';

--- a/app/assets/javascripts/lib/ui/content/delete_modal.js.erb
+++ b/app/assets/javascripts/lib/ui/content/delete_modal.js.erb
@@ -1,3 +1,5 @@
+<% depend_on Rails.root.join('lib/locales/en/content.yml') %>
+
 import {html, raw} from 'es6-string-html-template';
 import delegate from 'delegate';
 import Component from 'lib/ui/component';

--- a/app/assets/javascripts/lib/ui/content/export.js.erb
+++ b/app/assets/javascripts/lib/ui/content/export.js.erb
@@ -1,3 +1,5 @@
+<% depend_on Rails.root.join('lib/locales/en/content.yml') %>
+
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
 import Component from 'lib/ui/component';

--- a/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
+++ b/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
@@ -1,3 +1,5 @@
+<% depend_on Rails.root.join('lib/locales/en/content.yml') %>
+
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
 import Component from 'lib/ui/component';


### PR DESCRIPTION
As reported by Adam, changes to some of the strings in `lib/locales` weren't showing up on the dev server, even when restarting. This is because they were getting cached in .js.erb files. To fix this, .js.erb files that include locales strings should also include a `depend_on` directive to tell Sprockets to regenerate the template when the locale file changes.