### PR TITLE
Improved text on create-casebook modal

### DIFF
--- a/lib/locales/en/content.yml
+++ b/lib/locales/en/content.yml
@@ -49,10 +49,10 @@ en:
         owned-casebooks: Your Casebooks
         followed-casebooks: Casebooks you follow
       new-casebook-modal:
-        title: Create a new casebook.
-        body: Would you like to create a casebook from scratch or adapt an existing casebook?
-        from-scratch: From Scratch
-        adapt-existing: Adapt Existing
+        title: Create a Casebook
+        body: Would you like to make a new casebook from scratch or search for a casebook you can copy and customize?
+        from-scratch: Make a New Casebook
+        adapt-existing: Search Casebooks
     errors:
       not-signed-in: You must sign in to access that page.
       unauthorized: That page is only available to casebook editors.

--- a/test/system/casebooks_test.rb
+++ b/test/system/casebooks_test.rb
@@ -31,7 +31,7 @@ class CasebookSystemTest < ApplicationSystemTestCase
       visit root_path
 
       find('.create-casebook').trigger 'click'
-      click_link 'From Scratch'
+      click_link 'Make a New Casebook'
 
       fill_in 'content_casebook_title', with: 'Test casebook title'
       fill_in 'content_casebook_subtitle', with: 'Test casebook subtitle'


### PR DESCRIPTION
Resolves https://github.com/harvard-lil/h2o/issues/319 and addresses Becky's note about confusing UX of adapt -> search terminology