### PR TITLE
Improve search ux

### DIFF
--- a/app/views/content/dashboard.html.erb
+++ b/app/views/content/dashboard.html.erb
@@ -1,9 +1,4 @@
 <header class="dashboard">
-  <div class="content">
-    <div class="content-inner">
-      <%= render 'content/search' %>
-    </div>
-  </div>
 </header>
 <section class="dashboard">
   <% content_for :custom_skip_target do %>arbitrary text, necessary so that content_for :custom_skip_target evaluates to true<% end %>
@@ -11,7 +6,7 @@
   <div class="content">
     <% if @user == current_user %>
       <h2 class="casebooks">
-        <%= 'Your Casebooks' %>
+        <%= 'My Casebooks' %>
       </h2>
       <hr class="owned"/>
       <%= render partial: 'content/dashboard/content_browser', locals: {content: @user.owned_casebook_compacted, section: 'owned'} %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,9 +8,9 @@
     <div class="links">
       <% if current_user.present? %>
         <div class="create-casebook" data-action="show-casebook-modal"><%= t('header.links.create-casebook') %></div>
-        <%= link_to t('header.links.search'), :browse %>
+        <%= link_to t('header.links.search'), :search %>
       <% else %>
-        <%= link_to t('header.links.search'), :browse %>
+        <%= link_to t('header.links.search'), :search %>
       <% end %>
     </div>
     <div class="user">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,9 +8,9 @@
     <div class="links">
       <% if current_user.present? %>
         <div class="create-casebook" data-action="show-casebook-modal"><%= t('header.links.create-casebook') %></div>
-        <%= link_to t('header.links.browse'), :browse %>
+        <%= link_to t('header.links.search'), :browse %>
       <% else %>
-        <%= link_to t('header.links.browse'), :browse %>
+        <%= link_to t('header.links.search'), :browse %>
       <% end %>
     </div>
     <div class="user">

--- a/app/views/layouts/casebooks.html.erb
+++ b/app/views/layouts/casebooks.html.erb
@@ -27,7 +27,6 @@
   <header class="<%= @casebook_class %> casebook"  data-editable="<%= @editable || '' %>" data-casebook-id="<%= @casebook.try(:id) %>"  data-section-id="<%= @section.try(:id) %>" data-resource-id="<%= @resource.try(:id) %>">
     <div class="content">
       <div class="casebook-inner">
-        <%= render 'content/search' %>
         <% if @casebook.present? %>
           <div class="tabs">
             <%= render 'content/tabs' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ H2o::Application.routes.draw do
   end
 
   resource :search, only: [:show, :index]
-  get '/browse', to: 'searches#index'
+  get '/search', to: 'searches#index'
 
   resources :cases do
     member do

--- a/lib/locales/en/header.yml
+++ b/lib/locales/en/header.yml
@@ -3,7 +3,7 @@ en:
     brand: H2O
     links:
       create-casebook: Create casebook
-      browse: Browse
+      search: Search
       help: Help
       sign-up: Sign up for free
       sign-in: Sign in

--- a/test/system/cases_test.rb
+++ b/test/system/cases_test.rb
@@ -8,7 +8,7 @@ class CaseSystemTest < ApplicationSystemTestCase
     end
 
     scenario 'searching for a case', solr: true do
-      visit browse_path
+      visit search_path
       search_label = [*'XA'..'XZ'].sample
       fill_in 'q', with: "Case #{search_label}"
       page.submit find('form.search')


### PR DESCRIPTION
This PR address two confusing things about search:

**Browse is weird**
Replacing the header link "Browse" with good ole, familiar "Search"

**Search form on casebook show and edit is confusing**
When we put the search form/bar on pages where authors can add sections or resources, it's easy to accidentally do a search, when what you want is to search for a case to add. Better to strip the search form off all the casebook views. If users want to search DB they can always access search via the "Search" link in the header.