### PR TITLE
Header Accessibility

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require 'jquery-readyselector'
 //= require select2
 //= require 'polyfills'
+//= require 'lib/bootstrap/dropdown'
 //= require 'lib/requests'
 //= require 'lib/ui/skip-link-focus-fix'
 //= require 'lib/ui/content'

--- a/app/assets/javascripts/lib/bootstrap/dropdown.js
+++ b/app/assets/javascripts/lib/bootstrap/dropdown.js
@@ -1,0 +1,165 @@
+/* ========================================================================
+ * Bootstrap: dropdown.js v3.3.7
+ * http://getbootstrap.com/javascript/#dropdowns
+ * ========================================================================
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // DROPDOWN CLASS DEFINITION
+  // =========================
+
+  var backdrop = '.dropdown-backdrop'
+  var toggle   = '[data-toggle="dropdown"]'
+  var Dropdown = function (element) {
+    $(element).on('click.bs.dropdown', this.toggle)
+  }
+
+  Dropdown.VERSION = '3.3.7'
+
+  function getParent($this) {
+    var selector = $this.attr('data-target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
+    }
+
+    var $parent = selector && $(selector)
+
+    return $parent && $parent.length ? $parent : $this.parent()
+  }
+
+  function clearMenus(e) {
+    if (e && e.which === 3) return
+    $(backdrop).remove()
+    $(toggle).each(function () {
+      var $this         = $(this)
+      var $parent       = getParent($this)
+      var relatedTarget = { relatedTarget: this }
+
+      if (!$parent.hasClass('open')) return
+
+      if (e && e.type == 'click' && /input|textarea/i.test(e.target.tagName) && $.contains($parent[0], e.target)) return
+
+      $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
+
+      if (e.isDefaultPrevented()) return
+
+      $this.attr('aria-expanded', 'false')
+      $parent.removeClass('open').trigger($.Event('hidden.bs.dropdown', relatedTarget))
+    })
+  }
+
+  Dropdown.prototype.toggle = function (e) {
+    var $this = $(this)
+
+    if ($this.is('.disabled, :disabled')) return
+
+    var $parent  = getParent($this)
+    var isActive = $parent.hasClass('open')
+
+    clearMenus()
+
+    if (!isActive) {
+      if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
+        // if mobile we use a backdrop because click events don't delegate
+        $(document.createElement('div'))
+          .addClass('dropdown-backdrop')
+          .insertAfter($(this))
+          .on('click', clearMenus)
+      }
+
+      var relatedTarget = { relatedTarget: this }
+      $parent.trigger(e = $.Event('show.bs.dropdown', relatedTarget))
+
+      if (e.isDefaultPrevented()) return
+
+      $this
+        .trigger('focus')
+        .attr('aria-expanded', 'true')
+
+      $parent
+        .toggleClass('open')
+        .trigger($.Event('shown.bs.dropdown', relatedTarget))
+    }
+
+    return false
+  }
+
+  Dropdown.prototype.keydown = function (e) {
+    if (!/(38|40|27|32)/.test(e.which) || /input|textarea/i.test(e.target.tagName)) return
+
+    var $this = $(this)
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    if ($this.is('.disabled, :disabled')) return
+
+    var $parent  = getParent($this)
+    var isActive = $parent.hasClass('open')
+
+    if (!isActive && e.which != 27 || isActive && e.which == 27) {
+      if (e.which == 27) $parent.find(toggle).trigger('focus')
+      return $this.trigger('click')
+    }
+
+    var desc = ' li:not(.disabled):visible a'
+    var $items = $parent.find('.dropdown-menu' + desc)
+
+    if (!$items.length) return
+
+    var index = $items.index(e.target)
+
+    if (e.which == 38 && index > 0)                 index--         // up
+    if (e.which == 40 && index < $items.length - 1) index++         // down
+    if (!~index)                                    index = 0
+
+    $items.eq(index).trigger('focus')
+  }
+
+
+  // DROPDOWN PLUGIN DEFINITION
+  // ==========================
+
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.dropdown')
+
+      if (!data) $this.data('bs.dropdown', (data = new Dropdown(this)))
+      if (typeof option == 'string') data[option].call($this)
+    })
+  }
+
+  var old = $.fn.dropdown
+
+  $.fn.dropdown             = Plugin
+  $.fn.dropdown.Constructor = Dropdown
+
+
+  // DROPDOWN NO CONFLICT
+  // ====================
+
+  $.fn.dropdown.noConflict = function () {
+    $.fn.dropdown = old
+    return this
+  }
+
+
+  // APPLY TO STANDARD DROPDOWN ELEMENTS
+  // ===================================
+
+  $(document)
+    .on('click.bs.dropdown.data-api', clearMenus)
+    .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
+    .on('click.bs.dropdown.data-api', toggle, Dropdown.prototype.toggle)
+    .on('keydown.bs.dropdown.data-api', toggle, Dropdown.prototype.keydown)
+    .on('keydown.bs.dropdown.data-api', '.dropdown-menu', Dropdown.prototype.keydown)
+
+}(jQuery);

--- a/app/assets/javascripts/lib/ui/content/dashboard.js.erb
+++ b/app/assets/javascripts/lib/ui/content/dashboard.js.erb
@@ -5,12 +5,21 @@ import delegate from 'delegate';
 import Component from 'lib/ui/component';
 
 
-delegate(document, '[data-action="show-casebook-modal"]', 'click', showCasebookModal);
+delegate(document, '[data-action="show-casebook-modal"]', 'click', (e) => showCasebookModal(e));
 
 let modal = null;
+let trigger = null;
 
-function showCasebookModal () {
+function restrictFocus (e) {
+  if (!modal.el.contains(e.target)) {
+    e.stopPropagation();
+    modal.el.focus();
+  }
+}
+
+function showCasebookModal (e) {
   modal = new NewCasebookModal;
+  trigger = e.target;
 }
 
 class NewCasebookModal extends Component {
@@ -20,24 +29,34 @@ class NewCasebookModal extends Component {
       events: {
         'click #new-casebook-modal': (e) => { if (e.target.id === 'new-casebook-modal') this.destroy()},
         'click .close': (e) => { this.destroy() },
+        'keydown #new-casebook-modal': (e) => { if (e.key=='Escape'||e.key=='Esc'||e.keyCode==27) this.destroy()},
       }
     });
-    document.body.appendChild(this.el);
+    document.body.insertBefore(this.el, document.body.firstChild);
     this.render();
+    this.el.focus();
+    document.querySelector('.modal-overlay').classList.add('open');
+    document.getElementById('non-modal').setAttribute('aria-hidden', 'true');
+    document.addEventListener('focus', restrictFocus, true);
   }
 
   destroy () {
+    document.removeEventListener('focus', restrictFocus, true);
+    document.getElementById('non-modal').removeAttribute('aria-hidden');
+    document.querySelector('.modal-overlay').classList.remove('open');
+    trigger.focus();
     super.destroy();
     modal = null;
+    trigger = null;
   }
 
   template () {
-    return html`<div class="modal fade in" id="new-casebook-modal" style="display: block">
+    return html`<div class="modal fade in" id="new-casebook-modal" style="display: block"  tabindex="-1" aria-labelledby="new-casebook-modal-title">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close"><span>&times;</span></button>
-            <h4 class="modal-title"><%= t 'content.dashboard.new-casebook-modal.title' %></h4>
+            <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 id="new-casebook-modal-title" class="modal-title"><%= t 'content.dashboard.new-casebook-modal.title' %></h4>
           </div>
           <div class="modal-body">
             <%= I18n.t 'content.dashboard.new-casebook-modal.body' %>

--- a/app/assets/stylesheets/content/modals.scss
+++ b/app/assets/stylesheets/content/modals.scss
@@ -1,8 +1,29 @@
 @import "bootstrap/modals";
 
+.modal-overlay.open {
+  background-color: white;
+  opacity: 0.85;
+  height: 100%;
+  left: 0;
+  display: flex;
+  overflow: auto;
+  position: fixed;
+  top: 0;
+  transition: opacity .2s;
+  width: 100%;
+  z-index: 2;
+}
+
+.modal .close:focus {
+  @include generic-focus-styles;
+}
+
 .modal-button {
   @extend .btn;
   @extend .btn-default;
+  &:focus {
+    @include generic-focus-styles;
+  }
 }
 
 .modal-body .results-list {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -2,7 +2,7 @@ body > main > section:last-child {
   padding-bottom: 105px;
 }
 body {
-  > footer {
+  #main-footer {
     @include make-row();
     padding: 40px 0 50px;
 

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -44,17 +44,15 @@ body {
       align-items: center;
       justify-content: center;
       @extend .pull-left;
-      > .create-casebook {
-        padding: 9px 10px;
-        font-size: 16px;
-      }
-      > a, button {
+      a, button {
         @include btn();
         @include btn-white();
+        padding: 9px 10px;
+        margin-right: 5px;
+        font-size: 16px;
         &.create-casebook {
           @extend .btn-default;
         }
-        // line-height: 40px;
       }
     }
     .user {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -12,6 +12,9 @@ body {
   > header > nav {
     @extend .container;
     margin-top: 18px;
+    *:focus {
+      @include generic-focus-styles;
+    }
     > .content {
       @extend .navbar;
       display: flex;
@@ -22,14 +25,18 @@ body {
       @extend .navbar-header;
       .logo {
         @extend .navbar-brand;
-        @include monospace(bold, 40px, 40px);
 
         width: 85px;
         margin-right: 10px;
 
+        // The text is hidden and is replaced visually by an image
         background-image: asset-url('logo.png');
         background-size: initial;
         color: transparent;
+
+        &:hover {
+          @include generic-focus-styles;
+        }
       }
     }
     .links {
@@ -82,7 +89,7 @@ body {
           margin-right: 10px;
           font-size: 100%;
         }
-        &:hover .user-links {
+        &:hover .user-links, &:focus .user-links {
           max-height: 180px;
           right: -20px;
           padding: 10px 20px 30px;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -2,14 +2,14 @@
 @import "bootstrap/navbar";
 
 body {
-  > header {
+  #main-header {
     @include make-row(2);
     background-color: white;
   }
-  &.view-base-index > header > nav {
+  &.view-base-index #main-header > nav {
     margin-top: 35px;
   }
-  > header > nav {
+  #main-header > nav {
     @extend .container;
     margin-top: 18px;
     *:focus {
@@ -48,7 +48,7 @@ body {
         padding: 9px 10px;
         font-size: 16px;
       }
-      > a, div {
+      > a, button {
         @include btn();
         @include btn-white();
         &.create-casebook {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -39,37 +39,26 @@ body {
         }
       }
     }
+    a, button {
+      @include btn();
+      @include btn-white();
+      padding: 9px 10px;
+      margin-right: 5px;
+      font-size: 16px;
+      &.create-casebook {
+        @extend .btn-default;
+      }
+    }
     .links {
       display: flex;
       align-items: center;
       justify-content: center;
       @extend .pull-left;
-      a, button {
-        @include btn();
-        @include btn-white();
-        padding: 9px 10px;
-        margin-right: 5px;
-        font-size: 16px;
-        &.create-casebook {
-          @extend .btn-default;
-        }
-      }
     }
     .user {
       // @extend .pull-right;
       margin-left: auto;
       .current-user {
-        @include sans-serif($bold, 13px, 16px);
-        color: black;
-        position: relative;
-        .name {
-          font-size: 16px;
-          display: inline-block;
-          padding: 10px 4px 0 0px;
-        }
-        .portrait {
-          display: inline-block;
-        }
         .verified {
           display: inline-block;
           width: 12px;
@@ -87,39 +76,39 @@ body {
           margin-right: 10px;
           font-size: 100%;
         }
-        &:hover .user-links, &:focus .user-links {
-          max-height: 180px;
-          right: -20px;
-          padding: 10px 20px 30px;
+        .dropdown {
+          display: inline-block;
+          button {
+            background-color: $white;
+            &:hover {
+              @include generic-focus-styles;
+            }
+            &:hover, &:focus {
+              background-color: $white;
+            }
+          }
+          &.open {
+            .caret{
+                border-top: none;
+                border-bottom: 4px solid #000000;
+            }
+          }
         }
         .user-links {
-          @include transition(max-height 0.05s linear);
-          position: absolute;
-          top: 0;
-          right: 0px;
-          margin-top: 30px;
-          padding-top: 10px;
-          max-height: 0px;
-          background-color: fade(white, 10%);
-          overflow: hidden;
-          z-index: 1;
-
-          .user-link {
-            @include sans-serif($bold, 14px, 14px);
-
-            display: block;
-            width: 100%;
-            margin: 2px 0;
-            padding: 10px 20px;
-
-            text-align: right;
-            color: black;
-            background-color: $light-gray;
-          }
-          a.user-link {
-            padding-top: 12px;
-            padding-bottom: 6px;
-          }
+          border: none;
+          box-shadow: none;
+          margin-top: 8px;
+          padding-top: 0;
+          padding-bottom: 1px;
+          min-width: 0;
+        }
+        .user-link {
+          @include sans-serif($bold, 14px, 14px);
+          background-color: $light-gray;
+          border: 1px solid white;
+          padding: 12px 20px;
+          text-align: right;
+          width: 100%;
         }
       }
       .sign-up {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -56,7 +56,6 @@ body {
       @extend .pull-left;
     }
     .user {
-      // @extend .pull-right;
       margin-left: auto;
       .current-user {
         .verified {
@@ -78,34 +77,22 @@ body {
         }
         .dropdown {
           display: inline-block;
-          button {
-            background-color: $white;
-            &:hover {
-              @include generic-focus-styles;
-            }
-            &:hover, &:focus {
-              background-color: $white;
-            }
-          }
           &.open {
             .caret{
-                border-top: none;
-                border-bottom: 4px solid #000000;
+              border-top: none;
+              border-bottom: 4px solid #000000;
             }
           }
         }
         .user-links {
           border: none;
-          box-shadow: none;
           margin-top: 8px;
           padding-top: 0;
-          padding-bottom: 1px;
-          min-width: 0;
+          padding-bottom: 0;
+          width: 100%;
         }
         .user-link {
           @include sans-serif($bold, 14px, 14px);
-          background-color: $light-gray;
-          border: 1px solid white;
           padding: 12px 20px;
           text-align: right;
           width: 100%;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -18,6 +18,11 @@ body {
   background-size: contain;
 }
 
+#non-modal[aria-hidden="true"] {
+  overflow: hidden;
+  max-height: 100vh;
+}
+
 main {
   margin-top: 20px;
 }

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -51,3 +51,10 @@
 @mixin hide {
   display: none;
 }
+
+@mixin generic-focus-styles {
+  outline-style: solid;
+  outline-color: rgba(0,0,0,0.1);
+  outline-offset: 2px !important;
+  outline-width: 5px !important;
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -25,22 +25,22 @@
               <%= t 'header.user.unverified' %>
             </div>
           <% end %>
-          <a class="wrapper" href="<%= user_path(current_user) %>">
-            <div class="name">
-              <%= current_user.display_name %>
-            </div>
-            <div class="portrait">
-              <%= image_tag current_user.image.url :thumb %>
-            </div>
-          </a>
-          <div class="user-links">
-            <a class="user-link" href="<%= root_path %>">
-              <%= t 'header.user.dashboard' %>
-            </a>
-            <a class="user-link" href="<%= edit_user_path(current_user) %>">
-              <%= t 'header.user.edit-profile' %>
-            </a>
-            <%= button_to t('header.user.sign-out'), user_session_path(current_user_session), method: 'delete', class: 'user-link' %>
+          <div class="dropdown">
+            <button type="button" id="dLabel" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" >
+              <span class="name">
+                <%= current_user.display_name %>
+              </span>
+              <span class="caret"></span>
+            </button>
+            <ul class="user-links dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
+              <li><a class="user-link" href="<%= user_path(current_user) %>">
+                <%= t 'header.user.dashboard' %>
+              </a></li>
+              <li><a class="user-link" href="<%= edit_user_path(current_user) %>">
+                <%= t 'header.user.edit-profile' %>
+              </a></li>
+              <li><%= button_to t('header.user.sign-out'), user_session_path(current_user_session), method: 'delete', class: 'user-link' %></li>
+            </ul>
           </div>
         </div>
       <% else %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="links">
       <% if current_user.present? %>
-        <div class="create-casebook" data-action="show-casebook-modal"><%= t('header.links.create-casebook') %></div>
+        <button type="button" class="create-casebook" data-action="show-casebook-modal"><%= t('header.links.create-casebook') %></button>
         <%= link_to t('header.links.search'), :search %>
       <% else %>
         <%= link_to t('header.links.search'), :search %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -32,14 +32,14 @@
               </span>
               <span class="caret"></span>
             </button>
-            <ul class="user-links dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
+            <ul class="user-links dropdown-menu" aria-labelledby="dLabel">
               <li><a class="user-link" href="<%= user_path(current_user) %>">
                 <%= t 'header.user.dashboard' %>
               </a></li>
               <li><a class="user-link" href="<%= edit_user_path(current_user) %>">
                 <%= t 'header.user.edit-profile' %>
               </a></li>
-              <li><%= button_to t('header.user.sign-out'), user_session_path(current_user_session), method: 'delete', class: 'user-link' %></li>
+              <li><%= button_to user_session_path(current_user_session), method: 'delete', class: 'user-link' do %><%=t('header.user.sign-out')%><% end %></li>
             </ul>
           </div>
         </div>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -13,13 +13,14 @@
     <%= stylesheet_link_tag 'main', media: 'all' %>
   </head>
   <body class="view-<%= controller_name.parameterize %>-<%= action_name.parameterize %>">
+  <div id="non-modal">
     <a href="#main" class="skip-link">Skip to main content</a>
     <a href="#footer" class="skip-link">Skip to footer</a>
     <div class="overlay"></div>
     <% if content_for? :banner %>
       <%= yield(:banner) %>
     <% end %>
-    <header>
+    <header id="main-header">
       <%= render 'layouts/header' %>
     </header>
     <main>
@@ -41,12 +42,14 @@
         <%= yield %>
       <% end %>
     </main>
-    <footer>
+    <footer id="main-footer">
       <p id="footer" tabindex="-1" class="sr-only">Footer</p>
       <%= render 'layouts/footer' %>
     </footer>
     <%= javascript_include_tag "application" %>
     <%= render 'layouts/analytics' %>
+  </div>
+  <div class="modal-overlay"></div>
   </body>
 </html>
 <!-- Hey I'm an easter egg -->


### PR DESCRIPTION
- Hover/focus styles for the logo link
- "Create casebook" button is a real button
- The modal that it opens has all the behavior described here: https://github.com/harvard-lil/accessibility-tools/tree/master/code/modals
- The buttons/links are all the same size
- User picture removed from display per team decision!
- Dropdown coded up as a touch- and keyboard-usable Bootstrap dropdown
- Dropdown made white and full-width per Adam.

![image](https://user-images.githubusercontent.com/11020492/40326783-815707ac-5d0e-11e8-9705-3f9cf53e3df8.png)
(The screenshot removed my cursor, which was hovering over "Edit", which is why that's gray. keyboard focus is on the button, which is why that has focus styles. )

Lemme know if you don't like anything about the way this looks!

Not in this PR:
- The modal accessibility fixes will need to be applied to every modal. So, I should abstract that out into a more generic component. If you have no objections, I'd like to do that when fixing the next modal, rather than right now. (Having two examples will make it easier to get the abstraction right, I think.)
- If the user picture is not being displayed, then the ability to upload one can probably be removed from the code base, but that feels like a separate project.
- The generic focus styles should, ideally, be applied to everything, rather than being applied to a few elements at a time, like I'm doing here. But, when I tried that, weird visual relics popped up in unexpected places. I'll fix that as I go along, and then hopefully can switch over to a general declaration.
