### PR TITLE
Edit link annotations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ gem 'wkhtmltopdf-binary', require: false
 # gem 'minitest-rails-capybara'
 # gem 'quiet_assets'
 
-gem 'pry-byebug'
 
 group :development do
   gem 'annotate'
@@ -87,6 +86,7 @@ group :development do
   gem 'guard-minitest'
   gem 'guard-sunspot', git: 'https://github.com/smit1625/guard-sunspot.git', ref: 'd7b24d8' # fork with Guard 2 support
   gem 'terminal-notifier-guard'
+  gem 'pry-byebug'
 end
 
 group :development, :test do

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -5,11 +5,19 @@ import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
 import delegate from 'delegate';
 import {offsetsForRange, closestP, getCaretCharacterOffsetWithin, offsetInParagraph} from 'lib/ui/content/annotations/placement';
+import stageChangeToAnnotation from 'lib/ui/content/annotations';
 
+let editLinkAttrs;
 let Axios = AxiosConfig.create({
   headers: {
     'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').getAttribute('content')
   },
+});
+
+delegate(document, 'form.update-link', 'input', e => {
+  let editLinkAttrs = e.target.value
+  console.log(editLinkAttrs);
+  // annotator.changeAnnotation(e.target.parentElement.previousElementSibling, {content: e.target.innerText});
 });
 
 export class Annotator extends Component {
@@ -18,7 +26,13 @@ export class Annotator extends Component {
       id: 'annotator',
       events: {
         'click .annotator-action': e => { this.doAnnotationAction(e); },
-        'submit .create-form': e => { this.submitAnnotationForm(e); e.preventDefault(); }
+        'submit .create-form': e => { this.submitAnnotationForm(e); e.preventDefault(); },
+        'submit .update-link': e=> { 
+          e.preventDefault();
+          e.stopPropagation();
+          debugger;
+          this.updateAnnotation(this.handle.dataset.annotationId, editLinkAttrs);
+        }
       }
     });
 
@@ -81,22 +95,10 @@ export class Annotator extends Component {
     .then( _ => window.getSelection().removeAllRanges());
   }
 
-  editLink () {
-    this.mode = 'edit-link';
-    this.render();
-  }
-
   convertAnnotation (annotationId, type) {
     patch(this.annotationPath(annotationId), {
       annotation: { kind: type }}, { scroll: false })
     .then( _ => window.getSelection().removeAllRanges());
-  }
-
-  edit (handle) {
-    this.mode = 'edit-handle';
-    this.handle = handle;
-    this.range = null;
-    this.render();
   }
 
   revealElidedText(annotationId) {
@@ -144,6 +146,7 @@ export class Annotator extends Component {
       break;
     case 'edit-link':
       inner = this.editLinkTemplate();
+      // {content: e.target.innerText}
       break;
     case 'save-changes':
       inner = this.saveTemplate();
@@ -209,7 +212,7 @@ export class Annotator extends Component {
 
   editLinkTemplate() {
     return html`
-      <form class="save-changes" data-annotation-type="link">
+      <form class="update-link" data-annotation-type="link">
         <input name="content" type="url" placeholder="Url to link to..." value=${(this.getLinkValue())} />
       </form>`;
   }
@@ -261,14 +264,13 @@ export class Annotator extends Component {
       this.targetRect.bottom - wrapperRect.top);
   }
 
-  // used in annotations/index.js
+  // the following functions are used in annotations/index.js
   changeAnnotation (annotationId, attrs) {
     this.stagedChanges = attrs;
     this.mode = 'save-changes';
     this.render();
   } 
 
-  // used in annotations/index.js
   select (range) {
     this.mode = 'create-menu';
     this.handle = null;
@@ -277,5 +279,13 @@ export class Annotator extends Component {
     this.range = range;
     this.render();
   }
+
+  edit (handle) {
+    this.mode = 'edit-handle';
+    this.handle = handle;
+    this.range = null;
+    this.render();
+  }
+  // 
 }
 

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -22,7 +22,7 @@ export class Annotator extends Component {
     });
 
     this.updateScroll = throttle(this.render, 100, {leading: true, trailing: true});
-
+    
     document.querySelector('.resource-wrapper').appendChild(this.el);
     this.mode = 'inactive';
     this.render();
@@ -46,6 +46,9 @@ export class Annotator extends Component {
       break;
     case 'new-form':
       inner = this.newTemplate();
+      break;
+    case 'edit-link':
+      inner = this.editLinkTemplate();
       break;
     case 'save-changes':
       inner = this.saveTemplate();
@@ -79,7 +82,7 @@ export class Annotator extends Component {
     case 'link':
       return html`
         <a class="annotator-action" data-annotate-action="destroy">Remove link</a>
-        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="link">Edit link</a>
+        <a class="annotator-action edit-link" data-annotate-action="edit-link" data-annotation-type="link">Edit link</a>
       `;
     case 'note':
       return html`
@@ -94,6 +97,14 @@ export class Annotator extends Component {
       <a class="annotator-action" data-annotate-action="save-changes">Save</a>
       <a class="annotator-action" data-annotate-action="cancel-changes" data-annotation-type="elide">Cancel</a>
     `;
+  }
+
+  editLinkTemplate() {
+    return html`
+      <form class="create-form" data-annotation-type="link">
+        <input name="content" type="url" placeholder="Url to link to..." value=${(this.getLinkValue())} />
+      </form>
+  `;
   }
 
   newTemplate () {
@@ -163,6 +174,12 @@ export class Annotator extends Component {
     this.render();
   }
 
+  editLink () {
+    this.mode = 'edit-link';
+
+    this.render();
+  }
+
   deactivate () {
     this.mode = 'inactive';
     this.handle = null;
@@ -185,6 +202,9 @@ export class Annotator extends Component {
       break;
     case 'new':
       this.new(e.target.dataset.annotationType);
+      return;
+    case 'edit-link':
+      this.editLink();
       return;
     case 'reveal':
       this.revealElidedText(this.handle.dataset.annotationId);
@@ -248,12 +268,6 @@ export class Annotator extends Component {
     this.render();
   }
 
-  changeAnnotation (annotationId, attrs) {
-    this.stagedChanges = attrs;
-    this.mode = 'save-changes';
-    this.render();
-  }
-
   updateAnnotation (annotationId, attrs) {
     Axios.patch(this.annotationPath(annotationId + '.json'), {
       annotation: attrs
@@ -276,6 +290,10 @@ export class Annotator extends Component {
 
   resourceId () {
     return document.querySelector('header.casebook').dataset.resourceId;
+  }
+
+  getLinkValue () {
+    return this.handle.nextElementSibling.href;
   }
 }
 

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -3,21 +3,14 @@ import {html, raw} from 'es6-string-html-template';
 import {post, patch, rest_delete} from 'lib/requests';
 import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
-import delegate from 'delegate';
+
 import {offsetsForRange, closestP, getCaretCharacterOffsetWithin, offsetInParagraph} from 'lib/ui/content/annotations/placement';
 import stageChangeToAnnotation from 'lib/ui/content/annotations';
 
-let editLinkAttrs;
 let Axios = AxiosConfig.create({
   headers: {
     'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').getAttribute('content')
   },
-});
-
-delegate(document, 'form.update-link', 'input', e => {
-  let editLinkAttrs = e.target.value
-  console.log(editLinkAttrs);
-  // annotator.changeAnnotation(e.target.parentElement.previousElementSibling, {content: e.target.innerText});
 });
 
 export class Annotator extends Component {
@@ -31,7 +24,7 @@ export class Annotator extends Component {
           e.preventDefault();
           e.stopPropagation();
           debugger;
-          this.updateAnnotation(this.handle.dataset.annotationId, editLinkAttrs);
+          this.updateAnnotation(this.handle.dataset.annotationId, {content: e.target[0].value});
         }
       }
     });
@@ -115,6 +108,8 @@ export class Annotator extends Component {
     Axios.patch(this.annotationPath(annotationId + '.json'), 
       { annotation: attrs }, { scroll: false })
     .then( _ => this.deactivate() );
+
+    window.location.reload(true)
   }
 
   deactivate () {

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -101,7 +101,7 @@ export class Annotator extends Component {
     case 'link':
       return html`
         <form class="create-form" data-annotation-type="link">
-          <input name="content" placeholder="Url to link to..."  />
+          <input name="content" type="url" placeholder="Url to link to..."  />
         </form>
       `;
     case 'note':

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -4,6 +4,7 @@ import {post, patch, rest_delete} from 'lib/requests';
 import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
 import delegate from 'delegate';
+import {offsetsForRange, closestP, getCaretCharacterOffsetWithin, offsetInParagraph} from 'lib/ui/content/annotations/placement';
 
 let Axios = AxiosConfig.create({
   headers: {
@@ -22,15 +23,109 @@ export class Annotator extends Component {
     });
 
     this.updateScroll = throttle(this.render, 100, {leading: true, trailing: true});
-    
     document.querySelector('.resource-wrapper').appendChild(this.el);
     this.mode = 'inactive';
     this.render();
   }
 
-  destroy () {
-    super.destroy();
+  doAnnotationAction (e) {
+    switch (e.target.dataset.annotateAction) {
+    case 'new':
+      this.new(e.target.dataset.annotationType);
+      return;
+    case 'create':
+      this.saveAnnotation(e.target.dataset.annotationType, this.offsets);
+      break;
+    case 'edit-link':
+      this.mode = 'edit-link';
+      this.render();
+      return;
+    case 'convert':
+      this.convertAnnotation(this.handle.dataset.annotationId, e.target.dataset.annotationType);
+      break;
+    case 'reveal':
+      this.revealElidedText(this.handle.dataset.annotationId);
+      break;
+    case 'save-changes':
+      this.updateAnnotation(this.handle.dataset.annotationId, this.stagedChanges);
+      return;
+    case 'cancel-changes':
+      if (this.handle.dataset.annotationType === 'replace') {
+        this.handle.nextElementSibling.querySelector('.text').innerText = this.previousContent;
+      }
+      break;
+    case 'destroy':
+      this.destroyAnnotation(this.handle.dataset.annotationId);
+      break;
+    }
+    this.deactivate();
+  }
+
+  new (type) {
+    this.mode = 'new-form';
+    this.newAnnotationType = type;
+    this.render();
+  }
+
+  saveAnnotation (type, offsets, content = null) {
+    post(this.annotationsPath(), {
+      annotation: {
+        kind: type,
+        content: content,
+        start_p: offsets.start.p,
+        start_offset: offsets.start.offset,
+        end_p: offsets.end.p,
+        end_offset: offsets.end.offset
+      }
+    }, { scroll: false })
+    .then( _ => window.getSelection().removeAllRanges());
+  }
+
+  editLink () {
+    this.mode = 'edit-link';
+    this.render();
+  }
+
+  convertAnnotation (annotationId, type) {
+    patch(this.annotationPath(annotationId), {
+      annotation: { kind: type }}, { scroll: false })
+    .then( _ => window.getSelection().removeAllRanges());
+  }
+
+  edit (handle) {
+    this.mode = 'edit-handle';
+    this.handle = handle;
+    this.range = null;
+    this.render();
+  }
+
+  revealElidedText(annotationId) {
+    let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
+    let replacement = document.querySelector(`.annotate.replacement[data-annotation-id="${annotationId}"]`);
+
+    replacement.classList.toggle('revealed')
+    for (let el of elisions) {
+      el.classList.toggle('revealed');
+    }
+  }
+
+  updateAnnotation (annotationId, attrs) {
+    Axios.patch(this.annotationPath(annotationId + '.json'), 
+      { annotation: attrs }, { scroll: false })
+    .then( _ => this.deactivate() );
+  }
+
+  deactivate () {
+    this.mode = 'inactive';
+    this.handle = null;
+    this.range = null;
     this.updateScroll.cancel();
+    this.render();
+  }
+
+  destroyAnnotation (annotationId) {
+    rest_delete(this.annotationPath(annotationId), {}, { scroll: false })
+    .then( _ => window.getSelection().removeAllRanges());
   }
 
   template () {
@@ -61,50 +156,13 @@ export class Annotator extends Component {
     </div>`;
   }
 
-  editTemplate () {
-    switch (this.handle.dataset.annotationType) {
-    case 'highlight':
-      return html`
-        <a class="annotator-action" data-annotate-action="destroy">Remove highlight</a>
-      `;
-      // <a class="annotator-action" data-annotate-action="convert" data-annotation-type="note">Add note</a>
-    case 'elide':
-      return html`
-        <a class="annotator-action" data-annotate-action="destroy">Restore original</a>
-        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="replace">Replace text</a>
-      `;
-    case 'replace':
-      return html`
-        <a class="annotator-action" data-annotate-action="reveal">Reveal text</a>
-        <a class="annotator-action" data-annotate-action="destroy">Restore original</a>
-        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="elide">Elide text</a>
-      `;
-    case 'link':
-      return html`
-        <a class="annotator-action" data-annotate-action="destroy">Remove link</a>
-        <a class="annotator-action edit-link" data-annotate-action="edit-link" data-annotation-type="link">Edit link</a>
-      `;
-    case 'note':
-      return html`
-        <a class="annotator-action" data-annotate-action="destroy">Restore text</a>
-        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="elide">Elide text</a>
-      `;
-    }
-  }
-
-  saveTemplate () {
+  menuTemplate () {
     return html`
-      <a class="annotator-action" data-annotate-action="save-changes">Save</a>
-      <a class="annotator-action" data-annotate-action="cancel-changes" data-annotation-type="elide">Cancel</a>
-    `;
-  }
-
-  editLinkTemplate() {
-    return html`
-      <form class="save-changes" data-annotation-type="link">
-        <input name="content" type="url" placeholder="Url to link to..." value=${(this.getLinkValue())} />
-      </form>
-  `;
+      <a class="annotator-action" data-annotate-action="create" data-annotation-type="highlight">Highlight</a>
+      <a class="annotator-action" data-annotate-action="create" data-annotation-type="elide">Elide</a>
+      <a class="annotator-action" data-annotate-action="create" data-annotation-type="replace">Replace...</a>
+      <a class="annotator-action" data-annotate-action="new" data-annotation-type="link">Add link...</a>
+      <a class="annotator-action" data-annotate-action="new" data-annotation-type="note">Add note...</a>`;
   }
 
   newTemplate () {
@@ -113,122 +171,53 @@ export class Annotator extends Component {
       return html`
         <form class="create-form" data-annotation-type="link">
           <input name="content" type="url" placeholder="Url to link to..."  />
-        </form>
-      `;
+        </form>`;
     case 'note':
       return html`
         <form class="create-form" data-annotation-type="note">
           <textarea name="content" placeholder="Note text..."></textarea>
           <input type="submit" value="Save note" />
-        </form>
-      `;
+        </form>`;
     }
   }
 
-  menuTemplate () {
+  editTemplate () {
+    switch (this.handle.dataset.annotationType) {
+    case 'highlight':
+      return html`
+        <a class="annotator-action" data-annotate-action="destroy">Remove highlight</a>`;
+      // <a class="annotator-action" data-annotate-action="convert" data-annotation-type="note">Add note</a>
+    case 'elide':
+      return html`
+        <a class="annotator-action" data-annotate-action="destroy">Restore original</a>
+        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="replace">Replace text</a>`;
+    case 'replace':
+      return html`
+        <a class="annotator-action" data-annotate-action="reveal">Reveal text</a>
+        <a class="annotator-action" data-annotate-action="destroy">Restore original</a>
+        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="elide">Elide text</a>`;
+    case 'link':
+      return html`
+        <a class="annotator-action" data-annotate-action="destroy">Remove link</a>
+        <a class="annotator-action edit-link" data-annotate-action="edit-link" data-annotation-type="link">Edit link</a>`;
+    case 'note':
+      return html`
+        <a class="annotator-action" data-annotate-action="destroy">Restore text</a>
+        <a class="annotator-action" data-annotate-action="convert" data-annotation-type="elide">Elide text</a>`;
+    }
+  }
+
+  editLinkTemplate() {
     return html`
-      <a class="annotator-action" data-annotate-action="create" data-annotation-type="highlight">Highlight</a>
-      <a class="annotator-action" data-annotate-action="create" data-annotation-type="elide">Elide</a>
-      <a class="annotator-action" data-annotate-action="create" data-annotation-type="replace">Replace...</a>
-      <a class="annotator-action" data-annotate-action="new" data-annotation-type="link">Add link...</a>
-      <a class="annotator-action" data-annotate-action="new" data-annotation-type="note">Add note...</a>
-    `;
+      <form class="save-changes" data-annotation-type="link">
+        <input name="content" type="url" placeholder="Url to link to..." value=${(this.getLinkValue())} />
+      </form>`;
   }
 
-  calcTopOffset() {
-    let wrapperRect = document.querySelector('.resource-wrapper').getBoundingClientRect();
-    let viewportTop = window.scrollY - (wrapperRect.top + window.scrollY);
-
-    let target = this.range || this.handle;
-    this.targetRect = target ? target.getBoundingClientRect() : this.targetRect || {top: 0, bottom: 0};
-
-    return Math.min(Math.max(this.targetRect.top - wrapperRect.top,
-      viewportTop + 20),
-      this.targetRect.bottom - wrapperRect.top);
-  }
-
-  select (range) {
-    this.mode = 'create-menu';
-    this.handle = null;
-
-    this.offsets = offsetsForRange(range);
-    if (!this.offsets) { return this.deactivate(); }
-
-    this.range = range;
-
-    this.render();
-  }
-
-  edit (handle) {
-    this.mode = 'edit-handle';
-    this.handle = handle;
-    this.range = null;
-
-    this.render();
-  }
-
-  new (type) {
-    this.mode = 'new-form';
-    this.newAnnotationType = type;
-
-    this.render();
-  }
-
-  editLink () {
-    this.mode = 'edit-link';
-
-    this.render();
-  }
-
-  deactivate () {
-    this.mode = 'inactive';
-    this.handle = null;
-    this.range = null;
-    this.updateScroll.cancel();
-
-    this.render();
-  }
-
-  doAnnotationAction (e) {
-    switch (e.target.dataset.annotateAction) {
-    case 'create':
-      this.saveAnnotation(e.target.dataset.annotationType, this.offsets);
-      break;
-    case 'destroy':
-      this.destroyAnnotation(this.handle.dataset.annotationId);
-      break;
-    case 'convert':
-      this.convertAnnotation(this.handle.dataset.annotationId, e.target.dataset.annotationType);
-      break;
-    case 'new':
-      this.new(e.target.dataset.annotationType);
-      return;
-    case 'edit-link':
-      this.editLink();
-      return;
-    case 'reveal':
-      this.revealElidedText(this.handle.dataset.annotationId);
-      break;
-    case 'save-changes':
-      this.updateAnnotation(this.handle.dataset.annotationId, this.stagedChanges);
-      return;
-    case 'cancel-changes':
-      if (this.handle.dataset.annotationType === 'replace') {
-        this.handle.nextElementSibling.querySelector('.text').innerText = this.previousContent;
-      }
-      break;
-    }
-    this.deactivate();
-  }
-
-  revealElidedText(annotationId) {
-    let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
-    let replacement = document.querySelector(`.annotate.replacement[data-annotation-id="${annotationId}"]`);
-
-    replacement.classList.toggle('revealed')
-    for (let el of elisions) {
-      el.classList.toggle('revealed');
-    }
+  saveTemplate () {
+    return html`
+      <a class="annotator-action" data-annotate-action="save-changes">Save</a>
+      <a class="annotator-action" data-annotate-action="cancel-changes" data-annotation-type="elide">Cancel</a>`;
   }
 
   submitAnnotationForm (e) {
@@ -239,45 +228,9 @@ export class Annotator extends Component {
     e.preventDefault();
   }
 
-  saveAnnotation (type, offsets, content = null) {
-    post(this.annotationsPath(), {
-      annotation: {
-        kind: type,
-        content: content,
-        start_p: offsets.start.p,
-        start_offset: offsets.start.offset,
-        end_p: offsets.end.p,
-        end_offset: offsets.end.offset
-      }
-    }, { scroll: false })
-    .then( _ => window.getSelection().removeAllRanges());
-  }
-
-  convertAnnotation (annotationId, type) {
-    patch(this.annotationPath(annotationId), {
-      annotation: {
-        kind: type
-      }
-    }, { scroll: false })
-    .then( _ => window.getSelection().removeAllRanges());
-  }
-
-  changeAnnotation (annotationId, attrs) {
-    this.stagedChanges = attrs;
-    this.mode = 'save-changes';
-    this.render();
-  } 
-
-  updateAnnotation (annotationId, attrs) {
-    Axios.patch(this.annotationPath(annotationId + '.json'), {
-      annotation: attrs
-    }, { scroll: false })
-    .then( _ => this.deactivate() );
-  }
-
-  destroyAnnotation (annotationId) {
-    rest_delete(this.annotationPath(annotationId), {}, { scroll: false })
-    .then( _ => window.getSelection().removeAllRanges());
+  destroy () {
+    super.destroy();
+    this.updateScroll.cancel();
   }
 
   annotationsPath () {
@@ -295,108 +248,34 @@ export class Annotator extends Component {
   getLinkValue () {
     return this.handle.nextElementSibling.href;
   }
-}
 
-// Find the start and end paragraph and offset for a selection
-function offsetsForRange(range) {
-  if (!(range.commonAncestorContainer.nodeType === document.TEXT_NODE ||
-    range.commonAncestorContainer.tagName === 'P' ||
-    range.commonAncestorContainer.classList.contains('case-text'))) {
-    return null;
+  calcTopOffset() {
+    let wrapperRect = document.querySelector('.resource-wrapper').getBoundingClientRect();
+    let viewportTop = window.scrollY - (wrapperRect.top + window.scrollY);
+
+    let target = this.range || this.handle;
+    this.targetRect = target ? target.getBoundingClientRect() : this.targetRect || {top: 0, bottom: 0};
+
+    return Math.min(Math.max(this.targetRect.top - wrapperRect.top,
+      viewportTop + 20),
+      this.targetRect.bottom - wrapperRect.top);
   }
-  if (range.collapsed) { return null; }
 
-  let startP = closestP(range.startContainer);
-  let endP = closestP(range.endContainer);
-  let startOffset = offsetInParagraph(startP, range.startContainer, range.startOffset);
-  let endOffset = offsetInParagraph(endP, range.endContainer, range.endOffset);
-  return  {
-    start: {
-      p: startP.dataset.pIdx,
-      offset: startOffset
-    },
-    end: {
-      p: endP.dataset.pIdx,
-      offset: endOffset
-    }
-  };
-}
+  // used in annotations/index.js
+  changeAnnotation (annotationId, attrs) {
+    this.stagedChanges = attrs;
+    this.mode = 'save-changes';
+    this.render();
+  } 
 
-// Find the closest containing tag for the given element or text node
-function closestP(node) {
-  if (node.nodeType === document.TEXT_NODE) {
-    return node.parentElement.closest('.case-text > *');
-  } else {
-    return node.closest('.case-text > *');
+  // used in annotations/index.js
+  select (range) {
+    this.mode = 'create-menu';
+    this.handle = null;
+    this.offsets = offsetsForRange(range);
+    if (!this.offsets) { return this.deactivate(); }
+    this.range = range;
+    this.render();
   }
 }
 
-
-function getCaretCharacterOffsetWithin(element) {
-    var caretOffset = 0;
-    var doc = element.ownerDocument || element.document;
-    var win = doc.defaultView || doc.parentWindow;
-    var sel;
-    if (typeof win.getSelection != "undefined") {
-        sel = win.getSelection();
-        if (sel.rangeCount > 0) {
-            var range = win.getSelection().getRangeAt(0);
-            var preCaretRange = range.cloneRange();
-            preCaretRange.selectNodeContents(element);
-            preCaretRange.setEnd(range.endContainer, range.endOffset);
-            caretOffset = preCaretRange.toString().length;
-        }
-    } else if ( (sel = doc.selection) && sel.type != "Control") {
-        var textRange = sel.createRange();
-        var preCaretTextRange = doc.body.createTextRange();
-        preCaretTextRange.moveToElementText(element);
-        preCaretTextRange.setEndPoint("EndToEnd", textRange);
-        caretOffset = preCaretTextRange.text.length;
-    }
-    return caretOffset;
-}
-
-// Find the paragraph offset for an offset relative to the given text node
-function offsetInParagraph(paragraph, targetNode, nodeOffset) {
-  if (paragraph === targetNode) { // nodeOffset is the offset of the child node selected to
-    let textOffset = 0;
-    for (let childNode of paragraph.childNodes) {
-      if (nodeOffset-- <= 0) { break; }
-      textOffset += childNode.textContent.length;
-    }
-    return textOffset;
-  } else if (targetNode.nodeType === document.TEXT_NODE) {
-    let walker = document.createTreeWalker(
-      paragraph,
-      NodeFilter.SHOW_TEXT,
-      null,
-      false
-    );
-    let testAnnotatedText = (node) => {
-      for (let className of ['annotation-button', 'note-icon', 'note-content', 'text']) {
-        if (node.parentElement.classList.contains(className)) { return true; }
-      }
-      return false;
-    };
-
-    for (let node = walker.nextNode(); node !== targetNode; node = walker.nextNode()) {
-      if (testAnnotatedText(node)) { continue; }
-      nodeOffset += node.length;
-      // if (walked++ > 100) throw new Error;
-    }
-    return nodeOffset;
-  } else {
-    let textOffset = 0;
-    let walker = document.createTreeWalker(
-      paragraph,
-      NodeFilter.SHOW_ALL,
-      null,
-      false
-    );
-    for (let node = walker.nextNode(); node !== targetNode; node = walker.nextNode()) {
-      if (node.nodeType === document.TEXT_NODE) { textOffset += node.length; }
-      // if (walked++ > 100) throw new Error;
-    }
-    return textOffset;
-  }
-}

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -101,7 +101,7 @@ export class Annotator extends Component {
 
   editLinkTemplate() {
     return html`
-      <form class="create-form" data-annotation-type="link">
+      <form class="save-changes" data-annotation-type="link">
         <input name="content" type="url" placeholder="Url to link to..." value=${(this.getLinkValue())} />
       </form>
   `;
@@ -266,7 +266,7 @@ export class Annotator extends Component {
     this.stagedChanges = attrs;
     this.mode = 'save-changes';
     this.render();
-  }
+  } 
 
   updateAnnotation (annotationId, attrs) {
     Axios.patch(this.annotationPath(annotationId + '.json'), {

--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -5,7 +5,6 @@ import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
 
 import {offsetsForRange, closestP, getCaretCharacterOffsetWithin, offsetInParagraph} from 'lib/ui/content/annotations/placement';
-import stageChangeToAnnotation from 'lib/ui/content/annotations';
 
 let Axios = AxiosConfig.create({
   headers: {
@@ -23,7 +22,6 @@ export class Annotator extends Component {
         'submit .update-link': e=> { 
           e.preventDefault();
           e.stopPropagation();
-          debugger;
           this.updateAnnotation(this.handle.dataset.annotationId, {content: e.target[0].value});
         }
       }
@@ -141,7 +139,6 @@ export class Annotator extends Component {
       break;
     case 'edit-link':
       inner = this.editLinkTemplate();
-      // {content: e.target.innerText}
       break;
     case 'save-changes':
       inner = this.saveTemplate();

--- a/app/assets/javascripts/lib/ui/content/annotations/index.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/index.js
@@ -10,6 +10,7 @@ import 'lib/ui/content/annotations/elide';
 import 'lib/ui/content/annotations/replace';
 import 'lib/ui/content/annotations/note';
 import 'lib/ui/content/annotations/footnotes';
+import 'lib/ui/content/annotations/placement';
 
 let annotator = null;
 

--- a/app/assets/javascripts/lib/ui/content/annotations/placement.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/placement.js
@@ -1,0 +1,102 @@
+// Find the start and end paragraph and offset for a selection
+export function offsetsForRange(range) {
+  if (!(range.commonAncestorContainer.nodeType === document.TEXT_NODE ||
+    range.commonAncestorContainer.tagName === 'P' ||
+    range.commonAncestorContainer.classList.contains('case-text'))) {
+    return null;
+  }
+  if (range.collapsed) { return null; }
+
+  let startP = closestP(range.startContainer);
+  let endP = closestP(range.endContainer);
+  let startOffset = offsetInParagraph(startP, range.startContainer, range.startOffset);
+  let endOffset = offsetInParagraph(endP, range.endContainer, range.endOffset);
+  return  {
+    start: {
+      p: startP.dataset.pIdx,
+      offset: startOffset
+    },
+    end: {
+      p: endP.dataset.pIdx,
+      offset: endOffset
+    }
+  };
+}
+
+// Find the closest containing tag for the given element or text node
+export function closestP(node) {
+  if (node.nodeType === document.TEXT_NODE) {
+    return node.parentElement.closest('.case-text > *');
+  } else {
+    return node.closest('.case-text > *');
+  }
+}
+
+export function getCaretCharacterOffsetWithin(element) {
+    var caretOffset = 0;
+    var doc = element.ownerDocument || element.document;
+    var win = doc.defaultView || doc.parentWindow;
+    var sel;
+    if (typeof win.getSelection != "undefined") {
+        sel = win.getSelection();
+        if (sel.rangeCount > 0) {
+            var range = win.getSelection().getRangeAt(0);
+            var preCaretRange = range.cloneRange();
+            preCaretRange.selectNodeContents(element);
+            preCaretRange.setEnd(range.endContainer, range.endOffset);
+            caretOffset = preCaretRange.toString().length;
+        }
+    } else if ( (sel = doc.selection) && sel.type != "Control") {
+        var textRange = sel.createRange();
+        var preCaretTextRange = doc.body.createTextRange();
+        preCaretTextRange.moveToElementText(element);
+        preCaretTextRange.setEndPoint("EndToEnd", textRange);
+        caretOffset = preCaretTextRange.text.length;
+    }
+    return caretOffset;
+}
+
+// Find the paragraph offset for an offset relative to the given text node
+export function offsetInParagraph(paragraph, targetNode, nodeOffset) {
+  if (paragraph === targetNode) { // nodeOffset is the offset of the child node selected to
+    let textOffset = 0;
+    for (let childNode of paragraph.childNodes) {
+      if (nodeOffset-- <= 0) { break; }
+      textOffset += childNode.textContent.length;
+    }
+    return textOffset;
+  } else if (targetNode.nodeType === document.TEXT_NODE) {
+    let walker = document.createTreeWalker(
+      paragraph,
+      NodeFilter.SHOW_TEXT,
+      null,
+      false
+    );
+    let testAnnotatedText = (node) => {
+      for (let className of ['annotation-button', 'note-icon', 'note-content', 'text']) {
+        if (node.parentElement.classList.contains(className)) { return true; }
+      }
+      return false;
+    };
+
+    for (let node = walker.nextNode(); node !== targetNode; node = walker.nextNode()) {
+      if (testAnnotatedText(node)) { continue; }
+      nodeOffset += node.length;
+      // if (walked++ > 100) throw new Error;
+    }
+    return nodeOffset;
+  } else {
+    let textOffset = 0;
+    let walker = document.createTreeWalker(
+      paragraph,
+      NodeFilter.SHOW_ALL,
+      null,
+      false
+    );
+    for (let node = walker.nextNode(); node !== targetNode; node = walker.nextNode()) {
+      if (node.nodeType === document.TEXT_NODE) { textOffset += node.length; }
+      // if (walked++ > 100) throw new Error;
+    }
+    return textOffset;
+  }
+}

--- a/app/controllers/content/annotations_controller.rb
+++ b/app/controllers/content/annotations_controller.rb
@@ -25,16 +25,6 @@ class Content::AnnotationsController < ApplicationController
   end
 
   def update
-    console.log("********")
-    console.log("********")
-    console.log("********")
-    console.log(params)
-    console.log(params.inspect)
-    console.log(annotation_params)
-    console.log(annotation_params.inspect)
-    console.log("********")
-    console.log("********")
-    console.log("********")
     @annotation.update_attributes annotation_params
     respond_to do |format|
       format.html { redirect_to annotate_resource_path(@resource.casebook, @resource) }

--- a/app/controllers/content/annotations_controller.rb
+++ b/app/controllers/content/annotations_controller.rb
@@ -25,6 +25,16 @@ class Content::AnnotationsController < ApplicationController
   end
 
   def update
+    console.log("********")
+    console.log("********")
+    console.log("********")
+    console.log(params)
+    console.log(params.inspect)
+    console.log(annotation_params)
+    console.log(annotation_params.inspect)
+    console.log("********")
+    console.log("********")
+    console.log("********")
     @annotation.update_attributes annotation_params
     respond_to do |format|
       format.html { redirect_to annotate_resource_path(@resource.casebook, @resource) }

--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -100,7 +100,7 @@ class Content::Annotation < ApplicationRecord
     when 'highlight' then
       "<span class='annotate highlighted' data-annotation-id='#{id}'>#{inner}</span>"
     when 'link' then
-      "<a href='#{escaped_content}' class='annotate link' data-annotation-id='#{id}'>#{inner}</a>"
+      "<a href='#{escaped_content}' target='_blank' class='annotate link' data-annotation-id='#{id}'>#{inner}</a>"
     when 'note' then
       "<span class='annotate highlighted' data-annotation-id='#{id}'>#{inner}#{final ? "<span class='annotate note-icon' data-annotation-id='#{id}'>[see note]</span>" : ''}</span>#{final ? "<span class='annotate note-content-wrapper' data-annotation-id='#{id}'><span class='note-content'>#{escaped_content}</span></span>" : ''}"
     else


### PR DESCRIPTION
TODO before peer review: move e.stopDefault() calls 

#301 

Previously clicking edit link for an annotation sent an empty request and didn't update the annotation. I created an `'edit-link'` case that renders the editLinkTemplate with the link filled in and the class has a listener `'update-link'` to update the annotation. 

I found the `Annotator` class confusing because it is so large so I reorganized the functions to be in more of an order of operations. 

The flow for this ticket is 
1. Click on ‘edit link’
2. `doAnnotationAction `triggered with case ‘edit-link’
3. Template `edit-link`
4. `editLinkTemplate()`
5. `submit .update-link'`
6. `updateAnnotation()`

Other:
* I refactored a few methods that were outside of the Annotator component into another file `lib/ui/content/annotations/placement` 
* "No warning that prefix is required (h2o just redirects un-prefixed links to the preview mode of the resource)"
** Fixed by adding `type="url"` 
* Links open in new tab