### PR TITLE
First pass, elision accessibility

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/elide.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/elide.js
@@ -19,5 +19,6 @@ delegate(document, '.annotate.elide', 'click', e => {
   for (let el of elisions) {
     el.classList.toggle('revealed');
     el.parentElement.classList.toggle('revealed');
+    el.parentElement.previousElementSibling.classList.toggle('revealed');
   }
 });

--- a/app/assets/javascripts/lib/ui/content/annotations/elide.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/elide.js
@@ -18,5 +18,6 @@ delegate(document, '.annotate.elide', 'click', e => {
   }
   for (let el of elisions) {
     el.classList.toggle('revealed');
+    el.parentElement.classList.toggle('revealed');
   }
 });

--- a/app/assets/javascripts/lib/ui/content/annotations/elide.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/elide.js
@@ -8,7 +8,14 @@ delegate(document, '.annotate.elide', 'click', e => {
   let annotationId = e.target.dataset.annotationId;
   let elisions = document.querySelectorAll(`.annotate.elided[data-annotation-id="${annotationId}"]`);
 
-  e.target.classList.toggle('revealed')
+  e.target.classList.toggle('revealed');
+  if (e.target.classList.contains('revealed')){
+    e.target.setAttribute('aria-expanded', 'true');
+    elisions[elisions.length - 1].insertAdjacentHTML('afterend', `<span class="annotate elided revealed sr-only" data-annotation-id="${annotationId}">(end of elided text)</span>`);
+  } else {
+    e.target.setAttribute('aria-expanded', 'false');
+    elisions[elisions.length - 1].remove();
+  }
   for (let el of elisions) {
     el.classList.toggle('revealed');
   }

--- a/app/assets/stylesheets/casebook.scss
+++ b/app/assets/stylesheets/casebook.scss
@@ -544,7 +544,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
     position: relative;
     top: 10px;
 
-    &[data-elided-annotation] {
+    &[data-elided-annotation]:not(.revealed){
       display: none;
     }
   }

--- a/app/assets/stylesheets/content/annotations.scss
+++ b/app/assets/stylesheets/content/annotations.scss
@@ -79,6 +79,17 @@
     padding: 3px 0 3px;
   } // etc
 
+  /* hacks for misbehaving blockquotes */
+  blockquote {
+    span p {
+      display: inline; // yes, p in span is illegal, but we have them
+    }
+    &[data-elided-annotation]:not(.revealed){
+      margin: 0;
+      padding: 0;
+    }
+  }
+
   .annotate {
     display: inline;
 
@@ -121,6 +132,8 @@
     }
     &.elided, &.replaced {
       display: none;
+      padding: 0;
+      margin: 0;
       &.revealed {
         padding: 7px;
         display: inline;
@@ -148,6 +161,7 @@
 
       &::before {
         content: '...';
+        font-size: 19px;
       }
       &.revealed::before {
         content: 'hide';

--- a/app/assets/stylesheets/content/annotations.scss
+++ b/app/assets/stylesheets/content/annotations.scss
@@ -137,10 +137,14 @@
 
       cursor: zoom-in;
 
-      border-radius: 3px;
+      border: none;
       background-color: $light-gray;
       color: $light-blue;
       font-weight: $bold;
+
+      &:focus {
+        @include generic-focus-styles;
+      }
 
       &::before {
         content: '...';

--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -81,7 +81,7 @@ class Content::Annotation < ApplicationRecord
   end
 
   def copy_of
-    resource.copy_of.annotations.where(start_p: self.start_p, end_p: self.end_p, 
+    resource.copy_of.annotations.where(start_p: self.start_p, end_p: self.end_p,
           start_offset: self.start_offset, end_offset: self.end_offset, kind: self.kind).first
   end
 
@@ -94,7 +94,8 @@ class Content::Annotation < ApplicationRecord
   def annotate_html inner, handle: true, final: false
     case kind
     when 'elide' then
-      "#{handle ? "<span class='annotate elide' data-annotation-id='#{id}'></span>" : ''}<span class='annotate elided' data-annotation-id='#{id}'>#{inner}</span>"
+      "#{handle ? "<button class='annotate elide' data-annotation-id='#{id}' aria-label='elided text' aria-expanded='false'></button>" : ''}" +
+      "<span class='annotate elided' data-annotation-id='#{id}'>#{inner}</span>"
     when 'replace' then
       "#{handle ? "<span class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"
     when 'highlight' then


### PR DESCRIPTION
This makes the button that reveals/hides elided text into an html button so that it is accessible by keyboard, and it adds a label for screen reader users. It also adds a little hidden note at the end of elided text notifying screen reader users that they've reached the end of elided text. 

This still lacks some important features: all the buttons have the same label (how could I make them different? Paragraph number might be good, but I can't figure out how to expose paragraph number to the annotation code....), and, the labels are quite different visually and in the markup, which can/will be confusing both for people using Dragon Speak Naturally or similar, and for screen reader users following along with the H2O docs, which will certainly reference the visible label. But, I think I got as far as we can without major surgery.

While I was in there, I took a pass at hiding the borders of blockquotes, which currently display even when elisions are hidden. If an elision starts inside an inline element, but also includes a blockquote, it doesn't quite work, due to the way elisions are recorded, but now, you'll see at most one stray border, instead of a list.

before:
![image](https://user-images.githubusercontent.com/11020492/40750292-d3eedd14-6434-11e8-8c03-43083d25249a.png)

after:
![image](https://user-images.githubusercontent.com/11020492/40750108-2983a99a-6434-11e8-97d9-380dc8badfae.png)

`<br>` and other block-level elements inside elisions might/will still leak through sometimes, but I don't think it's something I can fix without major surgery.

While I was in there, I also set paragraph numbers to display when elided text is revealed.