### PR TITLE
Remove safeguard when deleting a casebook 

### DIFF
--- a/app/models/content/casebook.rb
+++ b/app/models/content/casebook.rb
@@ -115,13 +115,13 @@ class Content::Casebook < Content::Node
     "#{id}-#{slug}"
   end
 
-  def destroy
-    if self.descendants.present?
-     raise "Cannot delete a casebook with active descendants"
-    else
-      super
-    end
-  end
+  # def destroy
+  #   if self.descendants.present?
+  #    raise "Cannot delete a casebook with active descendants"
+  #   else
+  #     super
+  #   end
+  # end
 
   def draft
     descendants.where(draft_mode_of_published_casebook: true).where(copy_of_id: self.id).first


### PR DESCRIPTION
This was needed when resources were dependent on the original resource -- and so if you deleted a case in a casebook it would delete all of the copies of that case in the casebook's ancestry. 

Now deleting a casebook has no effect on other casebooks in it's lineage. 