### PR TITLE
Replace button a11y first pass

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require 'jquery-readyselector'
 //= require 'polyfills'
 //= require 'lib/bootstrap/dropdown'
+//= require 'lib/helpers'
 //= require 'lib/requests'
 //= require 'lib/ui/skip-link-focus-fix'
 //= require 'lib/ui/content'

--- a/app/assets/javascripts/lib/helpers.js
+++ b/app/assets/javascripts/lib/helpers.js
@@ -1,0 +1,15 @@
+
+export function getQueryStringDict(){
+  let queryString = window.location.search.substring(1);
+  if (queryString){
+      let queryDict = {};
+      let queries = queryString.split("&");
+      queries.forEach((query) =>{
+        let split = query.split('=');
+        queryDict[split[0]] = split[1];
+      })
+      return queryDict;
+  } else {
+      return {};
+  }
+}

--- a/app/assets/javascripts/lib/ui/content/annotations/replace.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/replace.js
@@ -5,7 +5,20 @@ import Component from 'lib/ui/component'
 import delegate from 'delegate';
 import debounce from 'debounce';
 import {editAnnotationHandle, stageChangeToAnnotation, stagePreviousContent, isEditable} from 'lib/ui/content/annotations';
+import {getQueryStringDict} from 'lib/helpers';
 
+
+// Set focus to a particular replace on page load if specified in query string
+window.addEventListener('load', () => {
+  let query = getQueryStringDict();
+  if (query['annotation-id']) {
+    let annotation = document.querySelector(`.annotate.replacement[data-annotation-id="${query['annotation-id']}"]`);
+    if (annotation){
+      setFocus(annotation);
+      annotation.scrollIntoView(true);
+    };
+  }
+})
 
 // Respond to click, spacebar, or enter, like a real html button would
 delegate(document, '.annotate.replacement', 'click', e => handleReplaceButtonPressed(e));

--- a/app/assets/javascripts/lib/ui/content/annotations/replace.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/replace.js
@@ -6,7 +6,27 @@ import delegate from 'delegate';
 import debounce from 'debounce';
 import {editAnnotationHandle, stageChangeToAnnotation, stagePreviousContent, isEditable} from 'lib/ui/content/annotations';
 
-delegate(document, '.annotate.replacement', 'click', e => {
+
+// Respond to click, spacebar, or enter, like a real html button would
+delegate(document, '.annotate.replacement', 'click', e => handleReplaceButtonPressed(e));
+delegate(document, '.annotate.replacement', 'keypress', e => {
+  if (e.key=='Enter'||e.key==' '||e.keyCode==13||e.keyCode==32){
+    handleReplaceButtonPressed(e);
+  }
+});
+
+// Pressing enter or spacebar in the contenteditable region shouldn't press the containing button
+delegate(document, '.annotate.replacement .text', 'keypress', e => {
+  if (e.key=='Enter'||e.key==' '||e.keyCode==13||e.keyCode==32){
+    e.stopPropagation();
+  }
+}, true);
+
+delegate(document, '.annotate.replacement .text', 'input', e => {
+  stageChangeToAnnotation(e.target.parentElement.previousElementSibling, {content: e.target.innerText});
+});
+
+function handleReplaceButtonPressed(e){
   if (isEditable()) {
     editAnnotationHandle(e.target.previousElementSibling);
     stagePreviousContent(e.target.innerText);
@@ -21,11 +41,7 @@ delegate(document, '.annotate.replacement', 'click', e => {
       el.classList.toggle('revealed');
     }
   }
-});
-
-delegate(document, '.annotate.replacement .text', 'input', e => {
-  stageChangeToAnnotation(e.target.parentElement.previousElementSibling, {content: e.target.innerText});
-});
+}
 
 function setFocus(el) {
     if (document.activeElement === el) { return; }

--- a/app/assets/javascripts/lib/ui/content/annotations/replace.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/replace.js
@@ -49,9 +49,18 @@ function handleReplaceButtonPressed(e){
     let annotationId = e.target.dataset.annotationId;
     let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
 
-    e.target.classList.toggle('revealed')
+    e.target.classList.toggle('revealed');
+    if (e.target.classList.contains('revealed')){
+      e.target.setAttribute('aria-expanded', 'true');
+      elisions[elisions.length - 1].insertAdjacentHTML('afterend', `<span class="annotate replaced revealed sr-only" data-annotation-id="${annotationId}">(end of replaced text)</span>`);
+    } else {
+      e.target.setAttribute('aria-expanded', 'false');
+      elisions[elisions.length - 1].remove();
+    }
     for (let el of elisions) {
       el.classList.toggle('revealed');
+      el.parentElement.classList.toggle('revealed');
+      el.parentElement.previousElementSibling.classList.toggle('revealed');
     }
   }
 }

--- a/app/assets/stylesheets/content/annotations.scss
+++ b/app/assets/stylesheets/content/annotations.scss
@@ -88,26 +88,23 @@
       box-shadow: -1px 0 0 $highlight, 1px 0 0 $highlight;
     }
     &.replacement {
-      @include sans-serif($regular, 12px, 12px);
-
-      padding: 5px 10px;
-      margin: 0 5px;
-
-      cursor: text;
-
-      border-radius: 3px;
+      display: inline-block;
+      margin: 0 6px;
+      padding: 0 6px;
       background-color: $light-gray;
       color: $light-blue;
 
       .text {
         pointer-events: none;
       }
+      &:focus {
+        @include generic-focus-styles;
+      }
       &.revealed .text {
         display: none;
       }
       &.revealed::before {
         content: 'hide';
-        cursor: zoom-out;
       }
       .text:empty::before {
         content: 'Enter text to replace...';

--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -96,7 +96,7 @@ class Content::Annotation < ApplicationRecord
     when 'elide' then
       "#{handle ? "<span class='annotate elide' data-annotation-id='#{id}'></span>" : ''}<span class='annotate elided' data-annotation-id='#{id}'>#{inner}</span>"
     when 'replace' then
-      "#{handle ? "<span role='button' tabindex='0' class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"
+      "#{handle ? "<span role='button' tabindex='0' aria-expanded='false' class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"
     when 'highlight' then
       "<span class='annotate highlighted' data-annotation-id='#{id}'>#{inner}</span>"
     when 'link' then

--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -96,7 +96,7 @@ class Content::Annotation < ApplicationRecord
     when 'elide' then
       "#{handle ? "<span class='annotate elide' data-annotation-id='#{id}'></span>" : ''}<span class='annotate elided' data-annotation-id='#{id}'>#{inner}</span>"
     when 'replace' then
-      "#{handle ? "<span class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"
+      "#{handle ? "<span role='button' tabindex='0' class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"
     when 'highlight' then
       "<span class='annotate highlighted' data-annotation-id='#{id}'>#{inner}</span>"
     when 'link' then


### PR DESCRIPTION
I could not make this into a real html button. I could not get contenteditable to work reliably across browsers in combination with real buttons: hitting the spacebar presses the button, despite all the fancy javascript I could think of. It might be worth another try later... Instead, I added a bunch of stuff to make the `span` behave like a real button: added it to the tab order using tabindex, added event handlers for space and enter (which real buttons have automagically, when you assign a click handler), and added the `button` aria role. Good enough, methinks.

So, now it can receive focus. That's an accessibility win, and should help with the problem you are having related to page refreshes, until there's time to move to AJAX: we can use JS to set focus to an annotation on page load, if an annotation-id is specified in the query string. This PR doesn't do anything to get an annotation-id into the query string, but it DOES include code for setting focus, if one is there. You can add one manually in your browser's URL bar to see it work.

As with the elision PR, there's still some work to do to improve the experience for people using screen readers. It's not clear that the button, not pressed, is replacement text, but when pressed, says "hide" and is followed by original text. It would be better if this button behaved like the regular elision button, with some sort of clear label, and the button was followed by either the replacement text or the original text, depending on whether the button had been pressed or not. But that's relatively major surgery, and a design change: the whole flow + contenteditable would change. TBD when convenient, later.