### PR TITLE
tweaked modals

### DIFF
--- a/app/assets/javascripts/lib/ui/content/clone_modal.js
+++ b/app/assets/javascripts/lib/ui/content/clone_modal.js
@@ -1,27 +1,16 @@
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
-import Component from 'lib/ui/component';
+import ModalComponent from 'lib/ui/modal';
 
 delegate(document, '.clone-casebook', 'submit', showCloneModal);
 
-let modal = null;
-
 function showCloneModal (e) {
-  modal = new CloneModal;
+  new CloneModal('clone-modal', e.target);
 }
 
-class CloneModal extends Component {
-  constructor () {
-    super({
-      id: 'clone-modal',
-      events: {}
-    });
-    document.body.appendChild(this.el);
-    this.render();
-  }
-
+class CloneModal extends ModalComponent {
   template () {
-    return html`<div class="modal fade in" id="publish-modal" style="display: block">
+    return html`<div class="modal fade in" id="${this.id}" tabindex="-1" aria-label="Cloning Casebook" style="display: block">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="spinner-group">

--- a/app/assets/javascripts/lib/ui/content/dashboard.js.erb
+++ b/app/assets/javascripts/lib/ui/content/dashboard.js.erb
@@ -2,56 +2,18 @@
 
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
-import Component from 'lib/ui/component';
+import ModalComponent from 'lib/ui/modal';
 
 
 delegate(document, '[data-action="show-casebook-modal"]', 'click', (e) => showCasebookModal(e));
 
-let modal = null;
-let trigger = null;
-
-function restrictFocus (e) {
-  if (!modal.el.contains(e.target)) {
-    e.stopPropagation();
-    modal.el.focus();
-  }
-}
-
 function showCasebookModal (e) {
-  modal = new NewCasebookModal;
-  trigger = e.target;
+  new NewCasebookModal('new-casebook-modal', e.target);
 }
 
-class NewCasebookModal extends Component {
-  constructor () {
-    super({
-      id: 'new-casebook-modal',
-      events: {
-        'click #new-casebook-modal': (e) => { if (e.target.id === 'new-casebook-modal') this.destroy()},
-        'click .close': (e) => { this.destroy() },
-        'keydown #new-casebook-modal': (e) => { if (e.key=='Escape'||e.key=='Esc'||e.keyCode==27) this.destroy()},
-      }
-    });
-    document.body.insertBefore(this.el, document.body.firstChild);
-    this.render();
-    this.el.focus();
-    document.querySelector('.modal-overlay').classList.add('open');
-    document.getElementById('non-modal').setAttribute('aria-hidden', 'true');
-    document.addEventListener('focus', restrictFocus, true);
-  }
-
-  destroy () {
-    document.removeEventListener('focus', restrictFocus, true);
-    document.getElementById('non-modal').removeAttribute('aria-hidden');
-    document.querySelector('.modal-overlay').classList.remove('open');
-    trigger.focus();
-    super.destroy();
-    modal = null;
-    trigger = null;
-  }
-
+class NewCasebookModal extends ModalComponent {
   template () {
-    return html`<div class="modal fade in" id="new-casebook-modal" style="display: block"  tabindex="-1" aria-labelledby="new-casebook-modal-title">
+    return html`<div class="modal fade in" id="${this.id}" style="display: block"  tabindex="-1" aria-labelledby="new-casebook-modal-title">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">

--- a/app/assets/javascripts/lib/ui/content/dashboard.js.erb
+++ b/app/assets/javascripts/lib/ui/content/dashboard.js.erb
@@ -13,12 +13,12 @@ function showCasebookModal (e) {
 
 class NewCasebookModal extends ModalComponent {
   template () {
-    return html`<div class="modal fade in" id="${this.id}" style="display: block"  tabindex="-1" aria-labelledby="new-casebook-modal-title">
+    return html`<div class="modal fade in" id="${this.id}" style="display: block"  tabindex="-1" aria-labelledby="${this.id}-title">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 id="new-casebook-modal-title" class="modal-title"><%= t 'content.dashboard.new-casebook-modal.title' %></h4>
+            <h4 id="${this.id}-title" class="modal-title"><%= t 'content.dashboard.new-casebook-modal.title' %></h4>
           </div>
           <div class="modal-body">
             <%= I18n.t 'content.dashboard.new-casebook-modal.body' %>

--- a/app/assets/javascripts/lib/ui/content/export.js.erb
+++ b/app/assets/javascripts/lib/ui/content/export.js.erb
@@ -15,13 +15,13 @@ function export_casebook_path(casebookId, format = 'docx') {
 }
 
 function downloadFile (e) {
-  let pageInfo = document.querySelector('main > header').dataset;;
+  let pageInfo = document.querySelector('main > header').dataset;
   let includeAnnotations = <%= Rails.application.config.export_annotations_by_default %>;
   if (pageInfo.resourceId)  {
-    window.location = resource_export_path(pageInfo.resourceId) + (includeAnnotations ? '': '?annotations=false');
+    e.target.href = resource_export_path(pageInfo.resourceId) + (includeAnnotations ? '': '?annotations=false');
   } else if (pageInfo.sectionId)  {
-    window.location = section_export_path(pageInfo.sectionId) + (includeAnnotations ? '' : '?annotations=false');
+    e.target.href = section_export_path(pageInfo.sectionId) + (includeAnnotations ? '' : '?annotations=false');
   } else {
-    window.location = export_casebook_path(pageInfo.casebookId) + (includeAnnotations ? '' : '?annotations=false');
+    e.target.href = export_casebook_path(pageInfo.casebookId) + (includeAnnotations ? '' : '?annotations=false');
   }
 }

--- a/app/assets/javascripts/lib/ui/content/export.js.erb
+++ b/app/assets/javascripts/lib/ui/content/export.js.erb
@@ -1,10 +1,8 @@
 <% depend_on Rails.root.join('lib/locales/en/content.yml') %>
 
-import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
-import Component from 'lib/ui/component';
 
-delegate(document, 'a.action.export', 'click', showExportModal);
+delegate(document, 'a.action.export', 'click', downloadFile);
 
 function resource_export_path(resourceId, format = 'docx') {
   return '<%= j resource_export_path('_ID', format: '_FORMAT') %>'.replace('_ID', resourceId).replace('_FORMAT', format);
@@ -16,76 +14,14 @@ function export_casebook_path(casebookId, format = 'docx') {
   return '<%= j export_casebook_path('_ID', format: '_FORMAT') %>'.replace('_ID', casebookId).replace('_FORMAT', format);
 }
 
-let modal = null;
-
-function showExportModal (e) {
-  e.preventDefault();
-  e.stopPropagation();
-  modal = new ExportModal;
-}
-
-class ExportModal extends Component {
-  constructor () {
-    super({
-      id: 'export-modal',
-      events: {
-        'click #export-modal': (e) => { if (e.target.id === 'export-modal') this.destroy()},
-        'click .close': (e) => { this.destroy() },
-        'click .cancel': (e) => { this.destroy() },
-        'click .export': (e) => {
-          let resourceId = document.querySelector('main > header').dataset.resourceId;
-          let sectionId = document.querySelector('main > header').dataset.sectionId;
-          let casebookId = document.querySelector('main > header').dataset.casebookId;
-          let includeAnnotations = this.el.querySelector('[name="include-annotations"]').checked;
-          if (resourceId)  {
-            window.open(resource_export_path(resourceId) + (includeAnnotations ? '' : '?annotations=false'));
-          } else if (sectionId)  {
-            window.open(section_export_path(sectionId) + (includeAnnotations ? '' : '?annotations=false'));
-          } else {
-            window.open(export_casebook_path(casebookId) + (includeAnnotations ? '' : '?annotations=false'));
-          }
-        },
-      }
-    });
-    document.body.appendChild(this.el);
-    this.render();
-  }
-
-  casebookId () {
-    return document.querySelector('header.casebook').dataset.casebookId;
-  }
-
-  sectionId () {
-    return document.querySelector('header.casebook').dataset.sectionId;
-  }
-
-  template () {
-    return html`<div class="modal fade in" id="export-modal" style="display: block">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close"><span>&times;</span></button>
-            <h4 class="modal-title"><%= t 'content.export-modal.title' %></h4>
-          </div>
-          <div class="modal-body">
-            <input type="hidden" name="include-annotations" value="yes" checked />
-            <% if false %>
-              <label>
-                <input type="checkbox" name="include-annotations" checked />
-              <%= I18n.t 'content.export-modal.include-annotations' %>
-              </label>
-              <br />
-            <% end %>
-            <label>
-              <%= I18n.t 'content.export-modal.format' %>
-              <span>Word</span>
-            </label>
-          </div>
-          <div class="modal-footer">
-            <%= link_to t('content.export-modal.export'), '#', class: 'modal-button export' %>
-          </div>
-        </div>
-      </div>
-    </div>`
+function downloadFile (e) {
+  let pageInfo = document.querySelector('main > header').dataset;;
+  let includeAnnotations = <%= Rails.application.config.export_annotations_by_default %>;
+  if (pageInfo.resourceId)  {
+    window.location = resource_export_path(pageInfo.resourceId) + (includeAnnotations ? '': '?annotations=false');
+  } else if (pageInfo.sectionId)  {
+    window.location = section_export_path(pageInfo.sectionId) + (includeAnnotations ? '' : '?annotations=false');
+  } else {
+    window.location = export_casebook_path(pageInfo.casebookId) + (includeAnnotations ? '' : '?annotations=false');
   }
 }

--- a/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
+++ b/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
@@ -2,21 +2,23 @@
 
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
-import Component from 'lib/ui/component';
+import ModalComponent from 'lib/ui/modal';
 import {patch} from 'lib/requests';
 
-delegate(document, 'input.action.publish', 'click', showPublishModal);
-
-let modal = null;
+delegate(document, 'button.action.publish', 'click', showPublishModal);
 
 function casebook_path(resourceId, format = 'pdf') {
   return '<%= j casebook_path('_ID') %>'.replace('_ID', resourceId);
 }
 
 function showPublishModal (e) {
-  e.preventDefault();
-  e.stopPropagation();
-  modal = new PublishModal;
+  new PublishModal('publish-modal', e.target, {
+    'click .confirm': (e) => {
+      showSpinner();
+      let casebookId = document.querySelector('main > header').dataset.casebookId;
+      patch(casebook_path(casebookId), {content_casebook: {public: true}});
+    },
+  });
 }
 
 function showSpinner (e) {
@@ -28,24 +30,7 @@ function showSpinner (e) {
   $(".spinner-header").show();
 }
 
-class PublishModal extends Component {
-  constructor () {
-    super({
-      id: 'publish-modal',
-      events: {
-        'click #publish-modal': (e) => { if (e.target.id === 'publish-modal') this.destroy()},
-        'click .close': (e) => {this.destroy()},
-        'click .cancel': (e) => { this.destroy() },
-        'click .confirm': (e) => {
-          showSpinner();
-          let casebookId = document.querySelector('main > header').dataset.casebookId;
-          patch(casebook_path(casebookId), {content_casebook: {public: true}}, {modal: this});
-        },
-      }
-    });
-    document.body.appendChild(this.el);
-    this.render();
-  }
+class PublishModal extends ModalComponent {
 
   casebookId () {
     return document.querySelector('header.casebook').dataset.casebookId;
@@ -56,12 +41,12 @@ class PublishModal extends Component {
   }
 
   template () {
-    return html`<div class="modal fade in" id="publish-modal" style="display: block">
+    return html`<div class="modal fade in" id="${this.id}" style="display: block"  tabindex="-1" aria-labelledby="${this.id}-title">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close"><span>&times;</span></button>
-            <h4 class="modal-title"><%= t 'content.publish-modal.title' %></h4>
+            <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 id="${this.id}-title" class="modal-title"><%= t 'content.publish-modal.title' %></h4>
           </div>
           <div class="publish">
             <div class="spinner-group">
@@ -77,8 +62,8 @@ class PublishModal extends Component {
             <%= I18n.t 'content.publish-modal.body' %>
           </div>
           <div class="modal-footer">
-            <%= link_to t('content.publish-modal.cancel'), '#', class: 'modal-button cancel' %>
-            <%= link_to t('content.publish-modal.confirm'), '#', class: 'modal-button confirm', input_html: { 'data-toggle' => 'modal' }%>
+            <button class="modal-button cancel"><%= t('content.publish-modal.cancel') %></button>
+            <button class="modal-button confirm"><%= t('content.publish-modal.confirm') %></button>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/lib/ui/modal.js
+++ b/app/assets/javascripts/lib/ui/modal.js
@@ -13,6 +13,7 @@ export default class ModalComponent extends Component {
       id: id,
       events: Object.assign(customEvents || {}, {
         'click .close': (e) => { this.destroy() },
+        'click .cancel': (e) => { this.destroy() },
         [`click #${id}`]: (e) => { if (e.target.id === id) this.destroy() },
         [`keydown #${id}`]: (e) => { if (e.key=='Escape'||e.key=='Esc'||e.keyCode==27) this.destroy()}
       })

--- a/app/assets/javascripts/lib/ui/modal.js
+++ b/app/assets/javascripts/lib/ui/modal.js
@@ -1,0 +1,41 @@
+import Component from 'lib/ui/component';
+
+function restrictFocus (e) {
+  if (!this.el.contains(e.target)) {
+    e.stopPropagation();
+    this.el.focus();
+  }
+}
+
+export default class ModalComponent extends Component {
+  constructor (id, trigger, customEvents) {
+    super({
+      id: id,
+      events: Object.assign(customEvents || {}, {
+        'click .close': (e) => { this.destroy() },
+        [`click #${id}`]: (e) => { if (e.target.id === id) this.destroy() },
+        [`keydown #${id}`]: (e) => { if (e.key=='Escape'||e.key=='Esc'||e.keyCode==27) this.destroy()}
+      })
+    });
+    this.id = id;
+    this.trigger = trigger;
+    this.handleFocus = restrictFocus.bind(this);
+
+    // DOM
+    document.body.insertBefore(this.el, document.body.firstChild);
+    this.render();
+    this.el.focus();
+    document.querySelector('.modal-overlay').classList.add('open');
+    document.getElementById('non-modal').setAttribute('aria-hidden', 'true');
+    document.addEventListener('focus', this.handleFocus, true);
+  }
+
+  destroy () {
+    document.removeEventListener('focus', this.handleFocus, true);
+    document.getElementById('non-modal').removeAttribute('aria-hidden');
+    document.querySelector('.modal-overlay').classList.remove('open');
+    this.trigger.focus();
+    super.destroy();
+  }
+
+}

--- a/app/assets/stylesheets/casebook.scss
+++ b/app/assets/stylesheets/casebook.scss
@@ -100,7 +100,7 @@ main > header.casebook {
   a.action {
     padding-top: 16px !important;
   }
-  input.action, a.action {
+  button.action, input.action, a.action {
     @include sans-serif($bold, 14px, 14px);
     @include transition(background-size 0.05s linear, background-position 0.05s linear);
     display: block;

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -270,7 +270,7 @@ class Content::NodeDecorator < Draper::Decorator
   ## Casebook
 
   def publish_changes_to_casebook
-    button_to(I18n.t('content.actions.publish-changes'), casebook_path(casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line')
+    button_tag(I18n.t('content.actions.publish-changes'), {name: nil, type:"button", class: 'action publish one-line'})
   end
 
   def publish_casebook

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -274,7 +274,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def publish_casebook
-    button_to(I18n.t('content.actions.publish'), casebook_path(casebook), method: :patch, params: {content_casebook: {public: true}}, class: 'action publish one-line')
+    button_tag(I18n.t('content.actions.publish'), {name: nil, type:"button", class: 'action publish one-line'})
   end
 
   def create_draft

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -216,7 +216,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_resource
-    link_to(I18n.t('content.actions.export'), resource_export_path(resource), class: 'action one-line export')
+    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
   end
 
   def preview_resource
@@ -251,7 +251,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_section
-    link_to(I18n.t('content.actions.export'), section_export_path(section), class: 'action one-line export')
+    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
   end
 
   def preview_section
@@ -294,7 +294,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_casebook
-    link_to(I18n.t('content.actions.export'), export_casebook_path(casebook), class: 'action one-line export')
+    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
   end
 
   def preview_casebook
@@ -313,7 +313,7 @@ class Content::NodeDecorator < Draper::Decorator
     link_to(I18n.t('content.actions.save'), 'submit-casebook-details', class: 'action one-line save submit-casebook-details')
   end
 
-  def cancel_casebook 
+  def cancel_casebook
     link_to(I18n.t('content.actions.cancel'), 'cancel-casebook-details', class: 'action one-line cancel cancel-casebook-details')
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,6 @@ module H2o
 
     config.action_mailer.default_url_options = { :host => 'localhost' }
     config.user_verification_recipients = ['cgruppioni@law.harvard.edu']
+    config.export_annotations_by_default = true
   end
 end

--- a/test/helpers/phantomjs/polyfills.js
+++ b/test/helpers/phantomjs/polyfills.js
@@ -5,14 +5,6 @@ document.addEventListener('turbolinks:before-visit', function (e) {
   location.href = event.data.url;
 });
 
-window._test_window_urls = []
-window._open = window.open;
-window.open = function (path) {
-  if (path[0] === '/') { path = location.origin + path; }
-  window._test_window_urls.push(path);
-  window._open.apply(window, arguments);
-}
-
 if (!String.prototype.startsWith) {
     String.prototype.startsWith = function(searchString, position){
       position = position || 0;

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -15,12 +15,6 @@ class ExportSystemTest < ApplicationSystemTestCase
     sign_in user = users(:verified_student)
     visit path
     click_link 'Export'
- 
-    within '#export-modal' do
-      assert_content 'Export Casebook'
-      click_link 'Export'
-    end
-
     exported_file_url = evaluate_script('_test_window_urls').last
     downloaded_path = download_file exported_file_url, to: file
     assert_equal File.size?(expected_file_path(file)), File.size?(downloaded_path)

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -15,7 +15,7 @@ class ExportSystemTest < ApplicationSystemTestCase
     sign_in user = users(:verified_student)
     visit path
     click_link 'Export'
-    exported_file_url = evaluate_script('_test_window_urls').last
+    exported_file_url = find_link('Export')['href']
     downloaded_path = download_file exported_file_url, to: file
     assert_equal File.size?(expected_file_path(file)), File.size?(downloaded_path)
     assert_equal Digest::SHA256.file(expected_file_path(file)).hexdigest, Digest::SHA256.file(downloaded_path).hexdigest


### PR DESCRIPTION
This take the code from `dashboard.js.erb` that made THAT modal accessible, and abstracts it out into its own class, a subclass of Component.  So, now you can make any modal accessible by just inheriting from ModalComponent instead of Component (and making sure your template includes a tabindex of -1 at the top, and a label). 

This PR switches the clone modal and the publish modal to inherit from ModalComponent. Unfortunately I didn't get to any of the others yet.

This also makes the export button a one-click thing: export immediately instead of triggering a modal window.