### PR TITLE
Replacement toggling

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -5,6 +5,7 @@ import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
 
 import {offsetsForRange, closestP, getCaretCharacterOffsetWithin, offsetInParagraph} from 'lib/ui/content/annotations/placement';
+import {toggleElisionVisibility} from 'lib/ui/content/annotations/elide';
 
 let Axios = AxiosConfig.create({
   headers: {
@@ -49,7 +50,7 @@ export class Annotator extends Component {
       this.convertAnnotation(this.handle.dataset.annotationId, e.target.dataset.annotationType);
       break;
     case 'reveal':
-      this.revealElidedText(this.handle.dataset.annotationId);
+      this.revealReplacedText(this.handle.dataset.annotationId);
       break;
     case 'save-changes':
       this.updateAnnotation(this.handle.dataset.annotationId, this.stagedChanges);
@@ -92,14 +93,12 @@ export class Annotator extends Component {
     .then( _ => window.getSelection().removeAllRanges());
   }
 
-  revealElidedText(annotationId) {
-    let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
-    let replacement = document.querySelector(`.annotate.replacement[data-annotation-id="${annotationId}"]`);
 
-    replacement.classList.toggle('revealed')
-    for (let el of elisions) {
-      el.classList.toggle('revealed');
-    }
+
+  revealReplacedText(annotationId) {
+    let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
+    let button = document.querySelector(`.annotate.replacement[data-annotation-id="${annotationId}"]`);
+    toggleElisionVisibility(annotationId, 'replace', button, elisions);
   }
 
   updateAnnotation (annotationId, attrs) {

--- a/app/assets/javascripts/lib/ui/content/annotations/elide.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/elide.js
@@ -7,18 +7,21 @@ import delegate from 'delegate';
 delegate(document, '.annotate.elide', 'click', e => {
   let annotationId = e.target.dataset.annotationId;
   let elisions = document.querySelectorAll(`.annotate.elided[data-annotation-id="${annotationId}"]`);
+  toggleElisionVisibility(annotationId, 'elide', e.target, elisions);
+});
 
-  e.target.classList.toggle('revealed');
-  if (e.target.classList.contains('revealed')){
-    e.target.setAttribute('aria-expanded', 'true');
-    elisions[elisions.length - 1].insertAdjacentHTML('afterend', `<span class="annotate elided revealed sr-only" data-annotation-id="${annotationId}">(end of elided text)</span>`);
+export function toggleElisionVisibility(annotationId, annotationType, toggleButton, toggledContentNodes){
+  toggleButton.classList.toggle('revealed');
+  if (toggleButton.classList.contains('revealed')){
+    toggleButton.setAttribute('aria-expanded', 'true');
+    toggledContentNodes[toggledContentNodes.length - 1].insertAdjacentHTML('afterend', `<span class="annotate ${annotationType}d revealed sr-only" data-annotation-id="${annotationId}">(end of ${annotationType}d text)</span>`);
   } else {
-    e.target.setAttribute('aria-expanded', 'false');
-    elisions[elisions.length - 1].remove();
+    toggleButton.setAttribute('aria-expanded', 'false');
+    toggledContentNodes[toggledContentNodes.length - 1].remove();
   }
-  for (let el of elisions) {
+  for (let el of toggledContentNodes) {
     el.classList.toggle('revealed');
     el.parentElement.classList.toggle('revealed');
     el.parentElement.previousElementSibling.classList.toggle('revealed');
   }
-});
+}

--- a/app/assets/javascripts/lib/ui/content/annotations/replace.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/replace.js
@@ -5,6 +5,7 @@ import Component from 'lib/ui/component'
 import delegate from 'delegate';
 import debounce from 'debounce';
 import {editAnnotationHandle, stageChangeToAnnotation, stagePreviousContent, isEditable} from 'lib/ui/content/annotations';
+import {toggleElisionVisibility} from 'lib/ui/content/annotations/elide';
 import {getQueryStringDict} from 'lib/helpers';
 
 
@@ -45,23 +46,12 @@ function handleReplaceButtonPressed(e){
     stagePreviousContent(e.target.innerText);
     setFocus(e.target.firstElementChild);
   }
+  // this handles on/off for non-editable, and off for editable
   if (!isEditable() || e.target.classList.contains('revealed')) {
     let annotationId = e.target.dataset.annotationId;
     let elisions = document.querySelectorAll(`.annotate.replaced[data-annotation-id="${annotationId}"]`);
+    toggleElisionVisibility(annotationId, 'replace', e.target, elisions);
 
-    e.target.classList.toggle('revealed');
-    if (e.target.classList.contains('revealed')){
-      e.target.setAttribute('aria-expanded', 'true');
-      elisions[elisions.length - 1].insertAdjacentHTML('afterend', `<span class="annotate replaced revealed sr-only" data-annotation-id="${annotationId}">(end of replaced text)</span>`);
-    } else {
-      e.target.setAttribute('aria-expanded', 'false');
-      elisions[elisions.length - 1].remove();
-    }
-    for (let el of elisions) {
-      el.classList.toggle('revealed');
-      el.parentElement.classList.toggle('revealed');
-      el.parentElement.previousElementSibling.classList.toggle('revealed');
-    }
   }
 }
 


### PR DESCRIPTION
I had noticed weird overlapping paragraph numbers in https://github.com/harvard-lil/h2o/issues/373; turns out this was caused by my failure to completely handle the toggling of replacement annotations for authors. 

This PR abstracts out the logic needed to toggle elisions/replacements into a function, and uses that function in the 3 spots toggling happens.

It should fix the overlapping paragraph numbers I caused, and should finish up https://github.com/harvard-lil/h2o/issues/300