### PR TITLE
Use retrofitted spans instead of buttons so docx export works.

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/elide.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/elide.js
@@ -4,11 +4,20 @@ import throttle from 'lodash.throttle';
 import Component from 'lib/ui/component'
 import delegate from 'delegate';
 
-delegate(document, '.annotate.elide', 'click', e => {
+// Respond to click, spacebar, or enter, like a real html button would
+delegate(document, '.annotate.elide', 'click', e => handleElideButtonPressed(e));
+delegate(document, '.annotate.elide', 'keypress', e => {
+  if (e.key=='Enter'||e.key==' '||e.keyCode==13||e.keyCode==32){
+    e.preventDefault();
+    handleElideButtonPressed(e);
+  }
+});
+
+function handleElideButtonPressed(e){
   let annotationId = e.target.dataset.annotationId;
   let elisions = document.querySelectorAll(`.annotate.elided[data-annotation-id="${annotationId}"]`);
   toggleElisionVisibility(annotationId, 'elide', e.target, elisions);
-});
+}
 
 export function toggleElisionVisibility(annotationId, annotationType, toggleButton, toggledContentNodes){
   toggleButton.classList.toggle('revealed');

--- a/app/assets/javascripts/lib/ui/content/annotations/replace.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/replace.js
@@ -12,6 +12,7 @@ import {toggleElisionVisibility} from 'lib/ui/content/annotations/elide';
 delegate(document, '.annotate.replacement', 'click', e => handleReplaceButtonPressed(e));
 delegate(document, '.annotate.replacement', 'keypress', e => {
   if (e.key=='Enter'||e.key==' '||e.keyCode==13||e.keyCode==32){
+    e.preventDefault();
     handleReplaceButtonPressed(e);
   }
 });

--- a/app/models/content/annotation.rb
+++ b/app/models/content/annotation.rb
@@ -95,10 +95,11 @@ class Content::Annotation < ApplicationRecord
 
   private
 
+  # NB: the export to docx code is tightly coupled with this markup. Test thoroughly if altering.
   def annotate_html inner, handle: true, final: false
     case kind
     when 'elide' then
-      "#{handle ? "<button class='annotate elide' data-annotation-id='#{id}' aria-label='elided text' aria-expanded='false'></button>" : ''}" +
+      "#{handle ? "<span role='button' tabindex='0' class='annotate elide' data-annotation-id='#{id}' aria-label='elided text' aria-expanded='false'></span>" : ''}" +
       "<span class='annotate elided' data-annotation-id='#{id}'>#{inner}</span>"
     when 'replace' then
       "#{handle ? "<span role='button' tabindex='0' aria-expanded='false' class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{inner}</span>"


### PR DESCRIPTION
https://github.com/harvard-lil/h2o/commit/7c335c41a4357c2a7124ec9611cfd3810c50ade9#diff-f87f5ba9f384eda55270ae286585b500L97 switched from plain spans to html buttons so that elisions could be toggled by people using input devices other than mice.

The export code is looking for spans (https://github.com/harvard-lil/h2o/blob/master/lib/htmltoword/xslt/h2o/export.xslt#L133), so this transformation wasn't run any more. I do not know why this test (https://github.com/harvard-lil/h2o/blob/master/test/system/export_test.rb#L21) did not catch the change.

Switching the export code to look for buttons instead of spans creates corrupt docx files. 

`¯\_(ツ)_/¯`

This PR switches back to a span, but retrofits the span to behave like a button. 