### PR TITLE
Simplify default section titles to avoid confusion

### DIFF
--- a/app/models/content/section.rb
+++ b/app/models/content/section.rb
@@ -29,13 +29,7 @@ class Content::Section < Content::Child
   include Content::Concerns::HasChildren
 
   def title
-    super || default_title
-  end
-
-  def default_title
-    words = I18n.t('content.section-words').take(ordinals.length)
-    words.fill words.last, words.length..(ordinals.length - 1)
-    words.zip(ordinals.map(&:humanize).map(&:capitalize)).map {|pair| pair.join ' '}.join ', '
+    super || I18n.t('content.untitled-section')
   end
 
   belongs_to :resource, polymorphic: true, optional: true

--- a/lib/locales/en/content.yml
+++ b/lib/locales/en/content.yml
@@ -125,10 +125,7 @@ en:
         link: Add a URL
         text: Create a text
     untitled-casebook: "Untitled casebook #%{id}"
-    section-words:
-      - Section
-      - Subsection
-      - Part
+    untitled-section: "Untitled section"
     titles:
       dashboard: "Dashboard"
       casebooks:


### PR DESCRIPTION
Remove ordinal-based default titles in favor of "Untitled section" default title.

Addresses #323 