### PR TITLE
Preview button label

### DIFF
--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -216,12 +216,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def annotate_resource
-    if draft_mode_of_published_casebook
-      #button has different wording
-      link_to(I18n.t('content.actions.revise-draft'), annotate_resource_path(casebook, resource), class: 'action edit one-line')
-    else
-      link_to(I18n.t('content.actions.revise'), annotate_resource_path(casebook, resource), class: 'action edit one-line')
-    end
+    link_to(I18n.t('content.actions.revise-draft'), annotate_resource_path(casebook, resource), class: 'action edit one-line')
   end
 
   def clone_resource

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -252,7 +252,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def revise_section
-    link_to(I18n.t('content.actions.revise'), revise_section_path(casebook, section), class: 'action edit one-line')
+    link_to(I18n.t('content.actions.revise-draft'), revise_section_path(casebook, section), class: 'action edit one-line')
   end
 
   def clone_section

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -299,7 +299,7 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def edit_casebook
-    link_to(I18n.t('content.actions.revise'), edit_casebook_path(casebook), class: 'action edit one-line')
+    link_to(I18n.t('content.actions.revise-draft'), edit_casebook_path(casebook), class: 'action edit one-line')
   end
 
   def edit_draft


### PR DESCRIPTION
A few more tweaks to this button labeling issue, to ensure that when previewing any draft casebook/section/resource, the button label says "Return to Draft" rather than "Revise."

"Revise" button applies only when something is published and the author wants to revise it, and that button triggers build of a draft.