### PR TITLE
Add chars for h2 tags, but not for blockquotes.

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/placement.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/placement.js
@@ -75,9 +75,14 @@ export function offsetInParagraph(paragraph, targetNode, nodeOffset) {
     let testAnnotatedText = (node) => {
       // if the parentElement is a blockquote, count the newlines between paragraphs in the nodeOffset. 
 
-      for (let className of ['annotation-button', 'note-icon', 'note-content', 'text']) {
-        if (node.parentElement.classList.contains(className) && node.parentElement.tagName != "BLOCKQUOTE") { return true; }
+      if (node.parentNode.nodeName == "H2" ){
+        return true;
       }
+
+      for (let className of ['annotation-button', 'note-icon', 'note-content', 'text']) {
+        if (node.parentElement.classList.contains(className)) { return true; }
+      }
+
       return false;
     };
 


### PR DESCRIPTION
#511 
and run query to replace `\r\n` when deploying 