### PR TITLE
Don't show export model option when no annotations. 

### DIFF
--- a/app/assets/javascripts/lib/ui/content/export_modal.js.erb
+++ b/app/assets/javascripts/lib/ui/content/export_modal.js.erb
@@ -3,8 +3,10 @@
 import {html} from 'es6-string-html-template';
 import delegate from 'delegate';
 import ModalComponent from 'lib/ui/modal';
+let modal = null;
 
-delegate(document, 'a.action.export', 'click', showExportModal);
+delegate(document, 'a.action.export-has-annotations', 'click', showExportModal);
+delegate(document, 'a.action.export-no-annotations', 'click', downloadFile);
 
 function resource_export_path(resourceId, format = 'docx') {
   return '<%= j resource_export_path('_ID', format: '_FORMAT') %>'.replace('_ID', resourceId).replace('_FORMAT', format);
@@ -16,7 +18,17 @@ function export_casebook_path(casebookId, format = 'docx') {
   return '<%= j export_casebook_path('_ID', format: '_FORMAT') %>'.replace('_ID', casebookId).replace('_FORMAT', format);
 }
 
-let modal = null;
+function downloadFile (e) {
+  let pageInfo = document.querySelector('main > header').dataset;
+  let includeAnnotations = <%= Rails.application.config.export_annotations_by_default %>;
+  if (pageInfo.resourceId)  {
+    e.target.href = resource_export_path(pageInfo.resourceId) + (includeAnnotations ? '': '?annotations=false');
+  } else if (pageInfo.sectionId)  {
+    e.target.href = section_export_path(pageInfo.sectionId) + (includeAnnotations ? '' : '?annotations=false');
+  } else {
+    e.target.href = export_casebook_path(pageInfo.casebookId) + (includeAnnotations ? '' : '?annotations=false');
+  }
+}
 
 function showExportModal (e) {
   new ExportModal('export-modal', e.target, {

--- a/app/assets/stylesheets/content/annotations.scss
+++ b/app/assets/stylesheets/content/annotations.scss
@@ -208,6 +208,13 @@
 }
 
 .toggle-elisions {
-  @include btn();
-  @include btn-white();
+  @extend .btn;
+  @include button-variant($light-blue, white, $light-blue);
+  @include set-font($font-family-sans-serif, 700, 14px, normal);
+  border-radius: 5px;
+  border: solid 1.5px;
+  line-height: 23px;
+  &:hover {
+    @include generic-focus-styles;
+  }
 }

--- a/app/assets/stylesheets/content/annotations.scss
+++ b/app/assets/stylesheets/content/annotations.scss
@@ -214,6 +214,7 @@
   border-radius: 5px;
   border: solid 1.5px;
   line-height: 23px;
+  margin-bottom: 20px;
   &:hover {
     @include generic-focus-styles;
   }

--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -224,7 +224,11 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_resource
-    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
+    if resource.annotations.present?
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-has-annotations')
+    else
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-no-annotations')
+    end
   end
 
   def preview_resource
@@ -263,7 +267,11 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_section
-    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
+    if section.resources_have_annotations?
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-has-annotations')
+    else
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-no-annotations')
+    end
   end
 
   def preview_section
@@ -310,7 +318,11 @@ class Content::NodeDecorator < Draper::Decorator
   end
 
   def export_casebook
-    link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export')
+    if casebook.resources_have_annotations?
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-has-annotations')
+    else
+      link_to(I18n.t('content.actions.export'), '#', class: 'action one-line export export-no-annotations')
+    end
   end
 
   def preview_casebook

--- a/app/models/content/casebook.rb
+++ b/app/models/content/casebook.rb
@@ -87,4 +87,13 @@ class Content::Casebook < Content::Node
   def building_draft?(owner, draft_mode)
     self.owner == owner && self.public && draft_mode
   end
+
+  def resources_have_annotations?
+    resources.each do |resource|
+      if resource.annotations.any?
+        return true
+      end
+    end
+    false
+  end
 end

--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -54,4 +54,8 @@ class Content::Resource < Content::Child
 
     footnote_annotations
   end
+
+  def has_elisions?
+    annotations.where(kind: ["elide", "replace"]).present?
+  end
 end

--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -56,6 +56,6 @@ class Content::Resource < Content::Child
   end
 
   def has_elisions?
-    annotations.where(kind: ["elide", "replace"]).present?
+    annotations.where(kind: ["elide", "replace"]).any?
   end
 end

--- a/app/models/content/section.rb
+++ b/app/models/content/section.rb
@@ -1,6 +1,8 @@
 class Content::Section < Content::Child
   default_scope {where(resource_id: nil)}
 
+  belongs_to :resource, polymorphic: true, optional: true
+
   has_many :contents, ->(section) {where(['ordinals[1:?] = ARRAY[?]', section.ordinals.length, section.ordinals]).where.not(id: section.id).order :ordinals}, class_name: 'Content::Child', primary_key: :casebook_id, foreign_key: :casebook_id
   include Content::Concerns::HasChildren
 
@@ -8,8 +10,16 @@ class Content::Section < Content::Child
     super || I18n.t('content.untitled-section')
   end
 
-  belongs_to :resource, polymorphic: true, optional: true
   def resource
     raise Exception.new "Section #{ordinal_string} is not a Content::Resource"
+  end
+
+  def resources_have_annotations?
+    resources.each do |resource|
+      if resource.annotations.any?
+        return true
+      end
+    end
+    false
   end
 end

--- a/app/views/content/resources/_embed.haml
+++ b/app/views/content/resources/_embed.haml
@@ -1,6 +1,6 @@
+%button.toggle-elisions
+  = "Show all elisions"
 - if resource.resource.is_a? Case
-  %button.toggle-elisions
-    = "Show all elisions"
   .resource-wrapper
     .case-text
       - resource.annotated_paragraphs(editable: editable).each_with_index do |paragraph_node, paragraph_index|

--- a/app/views/content/resources/_embed.haml
+++ b/app/views/content/resources/_embed.haml
@@ -1,4 +1,4 @@
-- if resource.annotations.present?
+- if resource.has_elisions?
   %button.toggle-elisions
     = "Show all elisions"
 - if resource.resource.is_a? Case

--- a/app/views/content/resources/_embed.haml
+++ b/app/views/content/resources/_embed.haml
@@ -1,5 +1,6 @@
-%button.toggle-elisions
-  = "Show all elisions"
+- if resource.annotations.present?
+  %button.toggle-elisions
+    = "Show all elisions"
 - if resource.resource.is_a? Case
   .resource-wrapper
     .case-text

--- a/lib/locales/en/content.yml
+++ b/lib/locales/en/content.yml
@@ -29,7 +29,7 @@ en:
         url-placeholder: Enter a URL to add it to your casebook
         save-button: Add linked resource
     publish-modal:
-      title: Confirm Publish
+      title: Export Type
       body: Are you ready to share this book with the world?
       confirm: 'Yes'
       cancel: 'No'

--- a/test/files/osx/test_export_casebook.docx
+++ b/test/files/osx/test_export_casebook.docx
@@ -79,7 +79,7 @@
       </div>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="no-headnote"></section>

--- a/test/files/osx/test_export_section.docx
+++ b/test/files/osx/test_export_section.docx
@@ -79,7 +79,7 @@
   </h1>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="headnote">

--- a/test/files/osx/test_export_section_2.docx
+++ b/test/files/osx/test_export_section_2.docx
@@ -84,7 +84,7 @@
   </h1>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="headnote">
@@ -98,10 +98,7 @@
     </p>
   </section>
 <section class="resource">
-  <button class='toggle-elisions'>
-Show all elisions
-</button>
-<div class='resource-wrapper'>
+  <div class='resource-wrapper'>
 <div class='case-text'>
 <div class='p-handle'>
 <div class='p-number'>1</div>

--- a/test/files/travis/test_export_casebook.docx
+++ b/test/files/travis/test_export_casebook.docx
@@ -10,7 +10,7 @@
     <link href="/assets/favicon-0af50b37a8d06c45d92419fe3d2c7817348bd30b7890fda411235aeaf283d2db.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"></link>
 
 
-    <link rel="stylesheet" media="all" href="/assets/main-019f03d8b8a377adc65beb181763e46256c417e762d90fda9b7091179bf63bf5.css" />
+    <link rel="stylesheet" media="all" href="/assets/main-4b0bc38e0d915649a0e95d1c9070517de74fd4b52ae590c08bd8ce3b3141ffb0.css" />
     <link rel="stylesheet" media="screen" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy" />
     <link rel="stylesheet" media="screen" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" />
   </head>
@@ -79,7 +79,7 @@
       </div>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="no-headnote"></section>
@@ -182,7 +182,7 @@
 </div>
 
     </footer>
-    <script src="/assets/application-63ae578b2d6926c4e0a4f1d610c15ef52dcf22440a4fad59f05374c14a646a14.js"></script>
+    <script src="/assets/application-bb20d5bd8d914298a5bda23dfbcbf0b80e6ad1fd501cb14678246f85b2a75f91.js"></script>
     
   </div>
   <div class="modal-overlay"></div>

--- a/test/files/travis/test_export_section.docx
+++ b/test/files/travis/test_export_section.docx
@@ -10,7 +10,7 @@
     <link href="/assets/favicon-0af50b37a8d06c45d92419fe3d2c7817348bd30b7890fda411235aeaf283d2db.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"></link>
 
 
-    <link rel="stylesheet" media="all" href="/assets/main-019f03d8b8a377adc65beb181763e46256c417e762d90fda9b7091179bf63bf5.css" />
+    <link rel="stylesheet" media="all" href="/assets/main-4b0bc38e0d915649a0e95d1c9070517de74fd4b52ae590c08bd8ce3b3141ffb0.css" />
     <link rel="stylesheet" media="screen" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy" />
     <link rel="stylesheet" media="screen" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" />
   </head>
@@ -79,7 +79,7 @@
   </h1>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="headnote">
@@ -172,7 +172,7 @@
 </div>
 
     </footer>
-    <script src="/assets/application-63ae578b2d6926c4e0a4f1d610c15ef52dcf22440a4fad59f05374c14a646a14.js"></script>
+    <script src="/assets/application-bb20d5bd8d914298a5bda23dfbcbf0b80e6ad1fd501cb14678246f85b2a75f91.js"></script>
     
   </div>
   <div class="modal-overlay"></div>

--- a/test/files/travis/test_export_section_2.docx
+++ b/test/files/travis/test_export_section_2.docx
@@ -10,7 +10,7 @@
     <link href="/assets/favicon-0af50b37a8d06c45d92419fe3d2c7817348bd30b7890fda411235aeaf283d2db.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"></link>
 
 
-    <link rel="stylesheet" media="all" href="/assets/main-019f03d8b8a377adc65beb181763e46256c417e762d90fda9b7091179bf63bf5.css" />
+    <link rel="stylesheet" media="all" href="/assets/main-4b0bc38e0d915649a0e95d1c9070517de74fd4b52ae590c08bd8ce3b3141ffb0.css" />
     <link rel="stylesheet" media="screen" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy" />
     <link rel="stylesheet" media="screen" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" />
   </head>
@@ -84,7 +84,7 @@
   </h1>
 </header>
   <aside class="casebook-actions">
-    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export" href="#">Export</a>
+    <form class="clone-casebook" method="post" action="/casebooks/91670752-public-casebook-1/clone"><input class="action clone-casebook" type="submit" value="Clone" /></form><a class="action one-line export export-no-annotations" href="#">Export</a>
 
   </aside>
   <section class="headnote">
@@ -98,10 +98,7 @@
     </p>
   </section>
 <section class="resource">
-  <button class='toggle-elisions'>
-Show all elisions
-</button>
-<div class='resource-wrapper'>
+  <div class='resource-wrapper'>
 <div class='case-text'>
 <div class='p-handle'>
 <div class='p-number'>1</div>
@@ -161,7 +158,7 @@ Show all elisions
 </div>
 
     </footer>
-    <script src="/assets/application-63ae578b2d6926c4e0a4f1d610c15ef52dcf22440a4fad59f05374c14a646a14.js"></script>
+    <script src="/assets/application-bb20d5bd8d914298a5bda23dfbcbf0b80e6ad1fd501cb14678246f85b2a75f91.js"></script>
     
   </div>
   <div class="modal-overlay"></div>


### PR DESCRIPTION
Address comments in #552 

- styling to elisions toggle button
- don't show export modal when there are no annotations in casebooks, sections and resources 
- show toggle button for text blocks 