### PR TITLE
Send admin email when annotations aren't shown, still show user page.

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -34,4 +34,11 @@ class Notifier < ActionMailer::Base
     @exception_backtrace = exception_backtrace
     mail(to: H2o::Application.config.admin_emails, subject: "Draft casebook merge in published failed #{@user.display_name}")
   end
+
+  def missing_annotations(owners, resource, annotation)
+    @owners = owners
+    @resource = resource
+    @annotation = annotation
+    mail(to: H2o::Application.config.admin_emails, subject: "Missing annotations for paragraph nodes")
+  end
 end

--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -29,8 +29,12 @@ class Content::Resource < Content::Child
         export_footnote_index += 1
       end
 
-      nodes[annotation.start_paragraph..annotation.end_paragraph].each_with_index do |paragraph_node, paragraph_index|
-        ApplyAnnotationToParagraphs.perform({annotation: annotation, paragraph_node: paragraph_node, paragraph_index: paragraph_index + annotation.start_paragraph, export_footnote_index: export_footnote_index, editable: editable, exporting: exporting, include_annotations: include_annotations})
+      if nodes[annotation.start_paragraph..annotation.end_paragraph].nil?
+        Notifier.missing_annotations(self.owners.pluck(:email_address, :attribution), self, annotation)
+      else
+        nodes[annotation.start_paragraph..annotation.end_paragraph].each_with_index do |paragraph_node, paragraph_index|
+          ApplyAnnotationToParagraphs.perform({annotation: annotation, paragraph_node: paragraph_node, paragraph_index: paragraph_index + annotation.start_paragraph, export_footnote_index: export_footnote_index, editable: editable, exporting: exporting, include_annotations: include_annotations})
+        end
       end
     end
 

--- a/app/views/notifier/missing_annotations.html.erb
+++ b/app/views/notifier/missing_annotations.html.erb
@@ -1,0 +1,15 @@
+<h2>Annotations not found for paragraph nodes</h2>
+<div>
+  <p>Owners:</p>
+  <%= @owners %>
+</div>
+
+<div>
+  <p>Resource:</p>
+  <%= @resource.inspect %>
+</div>
+
+<div>
+  <p>Annotation:</p>
+  <%= @annotation.inspect %>
+</div>


### PR DESCRIPTION
Need to get more data on what kind of annotations are failing. For now this will show the user the page and email admin the info of what annotations aren't able to find their placement

#585