### PR TITLE
Calc handle offsets using button el

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -177,7 +177,6 @@ export class Annotator extends Component {
   changeAnnotation (field, attrs) {
     this.annotationId = field.dataset.annotationId;
     this.handle = field.parentElement.previousElementSibling;
-    console.log(this.handle);
     this.stagedChanges = attrs;
     this.mode = 'save-changes';
     this.render();

--- a/app/webpacker/components/AnnotationHandle.vue
+++ b/app/webpacker/components/AnnotationHandle.vue
@@ -75,7 +75,7 @@ export default {
   },
   mounted() {
     // Push over annotation margin handles which land on the same line
-    const top = this.$el.getBoundingClientRect().top;
+    const top = this.$el.getElementsByTagName("button")[0].getBoundingClientRect().top;
     window.handlePositions = window.handlePositions || {};
     window.handlePositions[top] = (window.handlePositions[top] || 0) + 1
     this.offsetRight = -25 - (30 * window.handlePositions[top]);


### PR DESCRIPTION
Chrome places the wrapper `<span>` at the top left of the parent
element, causing an undesired result from
getBoundingClientRect(). Calculating from the `<button>` consistently
returns the desired result.