### PR TITLE
Prevent annotations when logged out.

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/index.js
+++ b/app/assets/javascripts/lib/ui/content/annotations/index.js
@@ -29,9 +29,11 @@ window.addEventListener('load', () => {
   }
 });
 
-$('.view-resources-annotate').ready(e => {
-  annotator = new Annotator();
-  makeReplacementsContenteditable();
+$(document).ready(e => {
+  if($('.view-resources-annotate').length){
+    annotator = new Annotator();
+    makeReplacementsContenteditable();
+  }
 });
 
 delegate(document, '.annotate.replacement', 'focus', e => {


### PR DESCRIPTION
It appears this was a misuse of `$().ready` that became important when
jQuery was upgraded. In short, `ready` should only be used with
`$(document)` and should not be used to test whether an element on the
page has become ready. In this case, it was being used in hopes of
triggering the callback only when the body contained a class that's
applied for logged in users.

Here is the relevant jQuery documentation:
https://api.jquery.com/ready/

> jQuery offers several ways to attach a function that will run when the DOM is ready. All of the following syntaxes are equivalent:
> 
> $( handler )
> $( document ).ready( handler )
> $( "document" ).ready( handler )
> $( "img" ).ready( handler )
> $().ready( handler )
> As of jQuery 3.0, only the first syntax is recommended; the other syntaxes still work but are deprecated. This is because the selection has no bearing on the behavior of the .ready() method, which is inefficient and can lead to incorrect assumptions about the method's behavior. For example, the third syntax works with "document" which selects nothing. The fourth syntax waits for the document to be ready but implies (incorrectly) that it waits for images to become ready.