### PR TITLE
Upgrade ckeditor as per secuirty vulnerbility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem 'bcrypt'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'cancancan'
 gem 'capapi', git: 'https://github.com/leppert/capapi-ruby.git'
-gem 'ckeditor', git: 'https://github.com/harvard-lil/ckeditor.git', branch: 'rails-5-1', ref: '8f6ff82'
+gem 'ckeditor'
+# gem 'ckeditor', git: 'https://github.com/harvard-lil/ckeditor.git', branch: 'rails-5-1', ref: '8f6ff82'
 gem 'coveralls', require: false
 gem 'daemons', '1.0.10'
 gem 'delayed_job_active_record'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'cancancan'
 gem 'capapi', git: 'https://github.com/leppert/capapi-ruby.git'
 gem 'ckeditor'
-# gem 'ckeditor', git: 'https://github.com/harvard-lil/ckeditor.git', branch: 'rails-5-1', ref: '8f6ff82'
 gem 'coveralls', require: false
 gem 'daemons', '1.0.10'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,6 @@ GIT
     will_paginate (3.1.5)
 
 GIT
-  remote: https://github.com/harvard-lil/ckeditor.git
-  revision: 8f6ff8256d9fd0a699196224a9aee5ce72e9b732
-  ref: 8f6ff82
-  branch: rails-5-1
-  specs:
-    ckeditor (4.2.2)
-      cocaine
-      orm_adapter (~> 0.5.0)
-
-GIT
   remote: https://github.com/leppert/capapi-ruby.git
   revision: 8acf041b1d3358b43ca5bebf4007ae1137ca08d8
   specs:
@@ -132,6 +122,9 @@ GEM
       xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    ckeditor (4.2.4)
+      cocaine
+      orm_adapter (~> 0.5.0)
     climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
@@ -528,7 +521,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   cancancan
   capapi!
-  ckeditor!
+  ckeditor
   coveralls
   daemons (= 1.0.10)
   delayed_job

--- a/app/views/content/_collaborators.html.erb
+++ b/app/views/content/_collaborators.html.erb
@@ -1,4 +1,4 @@
-<% content.users.each do |user| %>
+<% content.owners.each do |user| %>
   <div class="user <% if user.verified_professor? %> verified <% end %>">
     <%= link_to user.display_name, user_path(user) %>
   </div>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -235,7 +235,7 @@ RailsAdmin.config do |config|
     edit do
       field :title
       field :subtitle
-      field :headnote
+      field :headnote, :ck_editor
       field :public
       field :ancestry do
         read_only true


### PR DESCRIPTION
Also ckeditor wasn't showing up in admin previously and now it is 

Test
Rich text editors have same functionality overall 
- Editing a headnote and save
- Editing text block content
- ^ Both look correct in preview
- rich text editor box shows up in admin for case text, casebook headnotes, text blocks 