### PR TITLE
Disable prefixing for user-select to sidestep Firefox bug

### DIFF
--- a/app/assets/stylesheets/casebook.scss
+++ b/app/assets/stylesheets/casebook.scss
@@ -542,7 +542,9 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
   .p-handle {
     @include size(0px, 0px);
 
+    /* autoprefixer: off */
     user-select: none;
+    /* autoprefixer: on */
 
     float: left;
     position: relative;


### PR DESCRIPTION
Before switching to webpack, this property was not vendor prefixed, leading to
it having an effect in Chrome and Safari but not Firefox. After the
switch, the vendor prefix meant Firefox was correctly disabling select
on paragraph numbers but this lead selections that spanned
paragraphs to register their end range as the enclosing `div.case-text`
rather than the actual paragraph in which the selection ended. Not
sure why Firefox behaves this way -- maybe there's a proper work
around to that behavior -- but this commit restores the pre-webpack
behavior for better or worse (seems to be for better).

Side note: I couldn't get `/* autoprefixer: ignore next */` to
work as outlined in their readme, hence the `off` then `on` statements.