### PR TITLE
HTTP requirement doesn't pop up when creating a link annotation

### DIFF
--- a/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
+++ b/app/assets/javascripts/lib/ui/content/annotations/annotator.js.erb
@@ -119,7 +119,7 @@ export class Annotator extends Component {
     case 'link':
       return html`
         <form class="create-form" data-annotation-type="link">
-          <input name="content" id="link-form" type="url" placeholder="Paste URL"  />
+          <input name="content" id="link-form" placeholder="Paste URL"  />
         </form>`;
     case 'note':
       return html`

--- a/app/controllers/content/annotations_controller.rb
+++ b/app/controllers/content/annotations_controller.rb
@@ -6,7 +6,13 @@ class Content::AnnotationsController < ApplicationController
   before_action :find_resource, only: [:create, :destroy, :update]
 
   def create
-    annotation = Content::Annotation.create! annotation_params.merge(resource: @resource)
+    params = annotation_params
+
+    if params[:kind] == 'link'
+      params[:content] = UrlDomainFormatter.format(params[:content])
+    end
+
+    annotation = Content::Annotation.create! params.merge(resource: @resource)
     respond_to do |format|
       format.json { render json: {annotation_id: annotation.id}}
       format.html {redirect_to annotate_resource_path(@resource.casebook, @resource)}

--- a/app/webpacker/components/AnnotationHandle.vue
+++ b/app/webpacker/components/AnnotationHandle.vue
@@ -21,7 +21,7 @@
 
     <ContextMenu ref="linkMenu" v-bind:closeOnClick="false">
       <form v-on:submit.prevent="submitUpdate">
-        <input name="content" type="url" placeholder="Url to link to..." v-model="content"/>
+        <input name="content" id="link-form" placeholder="Url to link to..." v-model="content"/>
       </form>
     </ContextMenu>
   </span>

--- a/test/system/annotations_test.rb
+++ b/test/system/annotations_test.rb
@@ -64,6 +64,16 @@ class AnnotationsSystemTest < ApplicationSystemTestCase
       assert_link "content to link", href: "https://testlink.org"
     end
 
+    scenario 'adding a link without http', js: true do
+      select_text 'content to link'
+      find('a[data-annotation-type=link]').click
+
+      fill_in 'link-form', with: 'testlink.org'
+      find('#link-form').send_keys :enter
+
+      assert_link "content to link", href: "http://testlink.org"
+    end
+
     scenario 'adding a note', js: true do
       select_text 'content to note'
       find('a[data-annotation-type=note]').click

--- a/test/system/annotations_test.rb
+++ b/test/system/annotations_test.rb
@@ -61,7 +61,7 @@ class AnnotationsSystemTest < ApplicationSystemTestCase
       fill_in 'link-form', with: 'https://testlink.org'
       find('#link-form').send_keys :enter
 
-      assert_link "content to link", href: "https://testlink.org"
+      has_link?('content to link', href: 'https://testlink.org')
     end
 
     scenario 'adding a link without http', js: true do
@@ -71,7 +71,7 @@ class AnnotationsSystemTest < ApplicationSystemTestCase
       fill_in 'link-form', with: 'testlink.org'
       find('#link-form').send_keys :enter
 
-      assert_link "content to link", href: "http://testlink.org"
+      has_link?('content to link', href: 'http://testlink.org')
     end
 
     scenario 'adding a note', js: true do


### PR DESCRIPTION
 - can input a link annotation without htto (ie: `asdasdasd.com`) and it adds http while creating it, resulting in `http://asdasdasd.com`
- can input a standard https link and the result matches the input (input: `https://asdasd.com`, result: `https://asdasd.com`
- can input an incorrect url (ie: `asdasdasd`) and after saving, you can manually edit the link to be correct. 

#433 