### PR TITLE
One collaborator always has attribution 

### DIFF
--- a/app/controllers/content/casebooks_controller.rb
+++ b/app/controllers/content/casebooks_controller.rb
@@ -6,7 +6,7 @@ class Content::CasebooksController < Content::NodeController
   before_action :require_user, only: [:clone]
 
   def new
-    @casebook = Content::Casebook.create(public: false, collaborators: [Content::Collaborator.new(user: current_user, role: 'owner')])
+    @casebook = Content::Casebook.create(public: false, collaborators: [Content::Collaborator.new(user: current_user, role: 'owner', has_attribution: true)])
     logger.debug @casebook.errors.inspect
     @content = @casebook
     redirect_to layout_casebook_path(@content)

--- a/app/models/content/casebook.rb
+++ b/app/models/content/casebook.rb
@@ -7,7 +7,7 @@ class Content::Casebook < Content::Node
   validates_length_of :ordinals, is: 0
 
   has_many :contents, -> {order :ordinals}, class_name: 'Content::Child', inverse_of: :casebook, foreign_key: :casebook_id, dependent: :delete_all
-  has_many :collaborators, -> {order role: :desc}, class_name: 'Content::Collaborator', dependent: :destroy, inverse_of: :content, foreign_key: :content_id
+  has_many :collaborators, -> {order role: :desc, has_attribution: :desc}, class_name: 'Content::Collaborator', dependent: :destroy, inverse_of: :content, foreign_key: :content_id
   has_many :unpublished_revisions, dependent: :destroy
 
   include Content::Concerns::HasCollaborators

--- a/app/models/content/child.rb
+++ b/app/models/content/child.rb
@@ -9,8 +9,8 @@ class Content::Child < Content::Node
   after_save :reflow_casebook, if: :saved_change_to_ordinals?
 
   belongs_to :casebook, class_name: 'Content::Casebook', inverse_of: :contents, required: true, touch: true
-
-  has_many :collaborators, class_name: 'Content::Collaborator', primary_key: :casebook_id, foreign_key: :content_id
+  has_many :collaborators, -> {order role: :desc, has_attribution: :desc}, class_name: 'Content::Collaborator', primary_key: :casebook_id, foreign_key: :content_id
+ 
   include Content::Concerns::HasCollaborators
 
   def section

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -60,6 +60,13 @@ module RailsAdmin
                 @no_results = true
               end
 
+            elsif request.get? # initial page load
+              # if no collaborators has attribution, the first one will recieve it
+              collaborators = @object.collaborators
+              if collaborators.present? && collaborators.first.has_attribution == false
+                collaborators.first.update(has_attribution: true)
+              end
+
             elsif request.delete? # deleting a collaborator
               collaborator_id = params[:button]
               collaborator = Content::Collaborator.find(collaborator_id)


### PR DESCRIPTION
https://github.com/harvard-lil/h2o/pull/620#issuecomment-447063264

There should alway be one user with attribution (perhaps whatever user is in the first slot of names on admin collaborator page, if none have their checkbox checked?)

#532 