### PR TITLE
Add JS versions of html_helpers.rb

### DIFF
--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -14,6 +14,11 @@
 </template>
 
 <script>
+import { unwrapUndesiredTags,
+         emptyUlToP,
+         wrapBareInlineTags,
+         removeEmptyNodes } from "../libs/html_helpers.js";
+
 import { createNamespacedHelpers } from "vuex";
 const { mapActions } = createNamespacedHelpers("annotations");
 
@@ -37,18 +42,22 @@ export default {
   computed: {
     sections() {
       const parser = new DOMParser();
-      let children = parser.parseFromString(this.resource.content, "text/html").body.children;
+      let doc = parser.parseFromString(this.resource.content, "text/html");
 
       // Some resources are pure text without a wrapping HTML doc.
       // In this case, body.children will return an empty array.
       // Wrap that text in a div so that ResourceSection can expect HTMLElements
-      if(children.length == 0) {
+      if(doc.body.children.length == 0) {
         let div = document.createElement("div");
         div.appendChild(document.createTextNode(this.resource.content));
-        children = [div];
+        return [div];
+      } else {
+        unwrapUndesiredTags(doc);
+        emptyUlToP(doc);
+        wrapBareInlineTags(doc);
+        removeEmptyNodes(doc);
+        return doc.body.children;
       }
-
-      return children;
     }
   },
   methods: {

--- a/app/webpacker/libs/html_helpers.js
+++ b/app/webpacker/libs/html_helpers.js
@@ -1,0 +1,36 @@
+const replaceTag = (el, newTag) => {
+  let newEl = document.createElement(newTag);
+  newEl.innerHTML = el.innerHTML;
+  el.parentNode.replaceChild(newEl, el);
+};
+
+const unwrap = (el) => {
+  let parent = el.parentNode;
+  while (el.firstChild) parent.insertBefore(el.firstChild, el);
+  parent.removeChild(el);
+};
+
+export const unwrapUndesiredTags = (doc) => {
+  doc.querySelectorAll("article, section, aside").forEach(unwrap);
+  return doc;
+};
+
+export const emptyUlToP = (doc) => {
+  Array.from(doc.querySelectorAll("ul"))
+       .filter((ul) => ul.querySelector(":not(li)") || ul.children.length == 0)
+    .forEach(ul => replaceTag(ul, "p"));
+  return doc;
+};
+
+export const wrapBareInlineTags = (doc) => {
+  doc.querySelectorAll("body > :not(p):not(center):not(blockquote):not(article)")
+      .forEach(el => replaceTag(el, "p"));
+  return doc;
+};
+
+export const removeEmptyNodes = (doc) => {
+  while(doc.querySelectorAll(":empty").length){
+    doc.querySelectorAll(":empty").forEach(el => el.remove());
+  };
+  return doc;
+};


### PR DESCRIPTION
Some of the Ruby functions aren't needed because of the way we're
selecting elements in the JS. For instance, we don't need to filter
out comment nodes because we're using el.children which only returns
element nodes.