### PR TITLE
Remove cruft

### DIFF
--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -35,7 +35,8 @@ class Content::Resource < Content::Child
       end
     end
 
-    HTMLHelpers.filter_empty_nodes!(nodes)
+    # remove any empty nodes, usually paragraphs that were fully elided in the prev step
+    nodes.filter(":not(:empty)")
   end
 
   def title

--- a/app/models/content/resource.rb
+++ b/app/models/content/resource.rb
@@ -15,14 +15,10 @@ class Content::Resource < Content::Child
       Nokogiri::HTML(resource.content) {|config| config.strict.noblanks})
   end
 
-  def annotated_paragraphs(editable: false, exporting: false, include_annotations: include_annotations)
+  def annotated_paragraphs
     nodes = paragraph_nodes
     #export_footnote_index determines how many astericks are next to a link or note annotation in the exported version of a resource
     export_footnote_index = 0
-
-    nodes.each_with_index do |p_node, p_idx|
-      p_node['data-p-idx'] = p_idx
-    end
 
     annotations.all.sort_by{|annotation| annotation.start_paragraph}.each_with_index do |annotation|
       if annotation.kind.in? %w(note link)
@@ -33,7 +29,7 @@ class Content::Resource < Content::Child
         Notifier.missing_annotations(self.users.pluck(:email_address, :attribution), self, annotation)
       else
         nodes[annotation.start_paragraph..annotation.end_paragraph].each_with_index do |paragraph_node, paragraph_index|
-          ApplyAnnotationToParagraphs.perform({annotation: annotation, paragraph_node: paragraph_node, paragraph_index: paragraph_index + annotation.start_paragraph, export_footnote_index: export_footnote_index, editable: editable, exporting: exporting, include_annotations: include_annotations})
+          ApplyAnnotationToParagraphs.perform({annotation: annotation, paragraph_node: paragraph_node, paragraph_index: paragraph_index + annotation.start_paragraph, export_footnote_index: export_footnote_index})
         end
       end
     end

--- a/app/services/apply_annotation_to_paragraphs.rb
+++ b/app/services/apply_annotation_to_paragraphs.rb
@@ -1,6 +1,6 @@
 ## This class applies an annotation to it's corresponding paragraph nodes (created by nokogiri). An annotation can span multiple paragraphs. 
 class ApplyAnnotationToParagraphs
-  attr_accessor :annotation, :paragraph_node, :paragraph_index, :export_footnote_index, :editable, :exporting, :start_paragraph, :end_paragraph, :start_offset, :end_offset, :kind, :id, :content, :include_annotations
+  attr_accessor :annotation, :paragraph_node, :paragraph_index, :export_footnote_index, :start_paragraph, :end_paragraph, :start_offset, :end_offset, :kind, :id, :content
 
   def self.perform(params)
     new(params).perform
@@ -11,9 +11,6 @@ class ApplyAnnotationToParagraphs
     @paragraph_node = params[:paragraph_node]
     @paragraph_index = params[:paragraph_index]
     @export_footnote_index = params[:export_footnote_index]
-    @editable = params[:editable]
-    @exporting = params[:exporting]
-    @include_annotations = params[:include_annotations]
     @start_paragraph = annotation.start_paragraph
     @end_paragraph = annotation.end_paragraph
     @start_offset = annotation.start_offset
@@ -24,15 +21,9 @@ class ApplyAnnotationToParagraphs
   end
 
   def perform
-    # Adds data-p-idx to paragraph HTML tag 
-    paragraph_node['data-p-idx'] = paragraph_index
-
     if (paragraph_index != start_paragraph && paragraph_index != end_paragraph) || (paragraph_index == end_paragraph && paragraph_index != start_paragraph && end_offset == paragraph_node.text.length)
       # wrap entire p node in annotation
-      paragraph_node.children = annotate_html(paragraph_node.inner_html, handle: false)
-      if kind.in? %w{elide replace}
-        paragraph_node['data-elided-annotation'] = id
-      end
+      paragraph_node.children = annotate_html(paragraph_node.inner_html)
       return
     end
 
@@ -43,10 +34,6 @@ class ApplyAnnotationToParagraphs
     paragraph_node.traverse do |node|
       next unless node.text?
 
-      if node.parent['data-exclude-from-offset-calcs']&.downcase == "true"
-        next
-      end
-
       if noninitial
         if middle_paragraph?(node, paragraph_offset)
           wrap_middle_paragraph(node)
@@ -56,16 +43,14 @@ class ApplyAnnotationToParagraphs
         end
       else
         if paragraph_offset_ready?(node, paragraph_offset)
-          annotation_button = get_annotation_button_and_note_wrapper
-
           if only_paragraph? && partial_paragraph?(node, paragraph_offset)
-            selected_text = annotate_html(node.text[start_offset - paragraph_offset...end_offset - paragraph_offset], final: true)
-            node.replace "#{node.text[0...start_offset - paragraph_offset]}#{annotation_button}#{selected_text}#{node.text[end_offset - paragraph_offset..-1]}"
+            selected_text = annotate_html(node.text[start_offset - paragraph_offset...end_offset - paragraph_offset])
+            node.replace "#{node.text[0...start_offset - paragraph_offset]}#{selected_text}#{node.text[end_offset - paragraph_offset..-1]}"
             break
           else
             noninitial = true
             selected_text = annotate_html(node.text[start_offset - paragraph_offset..-1])
-            node.replace "#{node.text[0...start_offset - paragraph_offset]}#{annotation_button}#{selected_text}"
+            node.replace "#{node.text[0...start_offset - paragraph_offset]}#{selected_text}"
           end
         end
       end
@@ -75,42 +60,16 @@ class ApplyAnnotationToParagraphs
 
   private
 
-  # The edit icon that shows up next to an annotation when in draft mode.
-  def get_annotation_button_and_note_wrapper
-    if kind == 'note'
-      if editable
-        "<span class='annotate note-content-wrapper' data-annotation-id='#{id}'><span class='note-icon' data-annotation-id='#{id}' data-exclude-from-offset-calcs='true'><i class='fas fa-paperclip'></i></span><span class='note-content' data-exclude-from-offset-calcs='true'>#{escaped_content}</span></span>"
-      # Show notes only when not exporting, or exporting with annotations
-      elsif !exporting || (exporting && include_annotations)
-        "<span class='annotate note-content-wrapper' data-annotation-id='#{id}'><span class='note-icon' data-annotation-id='#{id}' data-exclude-from-offset-calcs='true'><i class='fas fa-paperclip'></i></span><span class='note-content' data-exclude-from-offset-calcs='true'>#{escaped_content}</span></span>"
-      end
-    else
-      ""
-    end
-  end
-
-  # NB: the export to docx code is tightly coupled with this markup. Test thoroughly if altering.
-  def annotate_html(selected_text, handle: true, final: false)
+  def annotate_html(selected_text)
+    suffix = ['link', 'note'].include?(kind) ? '*' * export_footnote_index : ''
+    cssClass = {'elide' => 'elided',
+                'replace' => 'replaced',
+                'highlight' => 'highlighted'}[kind] || kind
     case kind
-    when 'elide' then
-      "#{handle ? "<span role='button' tabindex='0' class='annotate elide' data-annotation-id='#{id}' aria-label='elided text' aria-expanded='false'></span>" : ''}" +
-      "<span class='annotate elided' data-annotation-id='#{id}'>#{selected_text}</span>"
-    when 'replace' then
-      "#{handle ? "<span role='button' tabindex='0' aria-expanded='false' class='annotate replacement' data-annotation-id='#{id}'><span class='text' data-annotation-id='#{id}' data-exclude-from-offset-calcs='true'>#{escaped_content}</span></span>" : ''}<span class='annotate replaced' data-annotation-id='#{id}'>#{selected_text}</span>"
-    when 'highlight' then
-      "<span tabindex='-1' class='annotate highlighted' data-annotation-id='#{id}'>#{selected_text}</span>"
     when 'link' then
-      if exporting && paragraph_index == end_paragraph && include_annotations
-        "<a href='#{escaped_content}' target='_blank' class='annotate link' data-annotation-id='#{id}'>#{selected_text}</a>#{'*' * export_footnote_index}"
-      else
-        "<a href='#{escaped_content}' target='_blank' class='annotate link' data-annotation-id='#{id}'>#{selected_text}</a>"
-      end
-    when 'note' then
-      if exporting && paragraph_index == end_paragraph && include_annotations
-        "<span tabindex='-1' class='annotate note' data-annotation-id='#{id}'>#{selected_text}</span>#{'*' * export_footnote_index}"
-      else
-        "<span tabindex='-1' class='annotate note' data-annotation-id='#{id}'>#{selected_text}</span>"
-      end
+      "<a href='#{escaped_content}' class='annotate #{cssClass}'>#{selected_text}</a>#{suffix}"
+    else
+      "<span class='annotate #{cssClass}'>#{selected_text}</span>#{suffix}"
     end
   end
 
@@ -118,38 +77,17 @@ class ApplyAnnotationToParagraphs
     ApplicationController.helpers.send(:html_escape, content)
   end
 
-  # If it's a multi-paragraph annotation and this paragraph is in the middle, annotate the entire paragraph
-  def full_paragraph_node_annotated?
-    (!first_paragraph? && !last_paragraph?) || (paragraph_index == end_paragraph && paragraph_index != start_paragraph && end_offset == paragraph_node.text.length)
-  end
-
-  def first_paragraph?
-    paragraph_index == start_paragraph
-  end
-
-  def last_paragraph?
-    paragraph_index == end_paragraph
-  end
-
-  def wrap_paragraph_node
-    paragraph_node.children = annotate_html(paragraph_node.inner_html, handle: false)
-    if kind.in? %w{elide replace}
-      paragraph_node['data-elided-annotation'] = id
-    end
-    return
-  end
-
   def middle_paragraph?(node, paragraph_offset)
     paragraph_index != end_paragraph || end_offset > paragraph_offset + node.text.length
   end
 
   def wrap_middle_paragraph(node)
-    node.replace annotate_html(node.text, handle: false)
+    node.replace annotate_html(node.text)
   end
 
   # This is the last paragraph, apply the annotation to the remaining characters.  
   def wrap_last_paragraph(node, paragraph_offset)
-    selected_text = annotate_html(node.text[0...end_offset - paragraph_offset], handle: false, final: true)
+    selected_text = annotate_html(node.text[0...end_offset - paragraph_offset])
     node.replace "#{node.text[0...0]}#{selected_text}#{node.text[end_offset - paragraph_offset..-1]}"
   end
 

--- a/app/services/apply_annotation_to_paragraphs.rb
+++ b/app/services/apply_annotation_to_paragraphs.rb
@@ -21,7 +21,8 @@ class ApplyAnnotationToParagraphs
   end
 
   def perform
-    if (paragraph_index != start_paragraph && paragraph_index != end_paragraph) || (paragraph_index == end_paragraph && paragraph_index != start_paragraph && end_offset == paragraph_node.text.length)
+    if (paragraph_index != start_paragraph || start_offset == 0) &&
+       (paragraph_index != end_paragraph || end_offset == paragraph_node.text.length)
       # wrap entire p node in annotation
       # if it's an elision, exclude it entirely
       paragraph_node.children = kind == 'elide' ? '' : annotate_html(paragraph_node.inner_html)

--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -25,7 +25,7 @@
       %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
-        - content.annotated_paragraphs(editable: false, exporting: true, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
+        - content.annotated_paragraphs(editable: false, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
           = paragraph_node.to_html.html_safe
         - if @include_annotations
           %div= content.footnote_annotations

--- a/app/views/content/casebooks/export.haml
+++ b/app/views/content/casebooks/export.haml
@@ -25,8 +25,8 @@
       %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
-        - content.annotated_paragraphs(editable: false, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
-          = paragraph_node.to_html.html_safe
+        - content.send(@include_annotations ? :annotated_paragraphs : :paragraph_nodes).each do |node|
+          = node.to_html.html_safe
         - if @include_annotations
           %div= content.footnote_annotations
     - elsif content.resource.is_a? Default

--- a/app/views/content/resources/export.haml
+++ b/app/views/content/resources/export.haml
@@ -17,7 +17,7 @@
     %p.ResourceHeadnote= content.formatted_headnote
   - if content.resource.class.in? [Case, TextBlock]
     %resource-body
-      - content.annotated_paragraphs(editable: false, exporting: true, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
+      - content.annotated_paragraphs(editable: false, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
         = paragraph_node.to_html.html_safe
       - if @include_annotations
         %div= content.footnote_annotations

--- a/app/views/content/resources/export.haml
+++ b/app/views/content/resources/export.haml
@@ -17,8 +17,8 @@
     %p.ResourceHeadnote= content.formatted_headnote
   - if content.resource.class.in? [Case, TextBlock]
     %resource-body
-      - content.annotated_paragraphs(editable: false, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
-        = paragraph_node.to_html.html_safe
+      - content.send(@include_annotations ? :annotated_paragraphs : :paragraph_nodes).each do |node|
+        = node.to_html.html_safe
       - if @include_annotations
         %div= content.footnote_annotations
   - elsif content.resource.is_a? Default

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -19,8 +19,8 @@
       %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
-        - content.annotated_paragraphs.each_with_index do |paragraph_node, paragraph_index|
-          = paragraph_node.to_html.html_safe
+        - content.send(@include_annotations ? :annotated_paragraphs : :paragraph_nodes).each do |node|
+          = node.to_html.html_safe
         - if @include_annotations
           %div= content.footnote_annotations
     - elsif content.resource.is_a? Default

--- a/app/views/content/sections/export.haml
+++ b/app/views/content/sections/export.haml
@@ -19,7 +19,7 @@
       %p.ResourceHeadnote= content.formatted_headnote
     - if content.resource.class.in? [Case, TextBlock]
       %resource-body
-        - content.annotated_paragraphs(editable: false, exporting: true, include_annotations: @include_annotations).each_with_index do |paragraph_node, paragraph_index|
+        - content.annotated_paragraphs.each_with_index do |paragraph_node, paragraph_index|
           = paragraph_node.to_html.html_safe
         - if @include_annotations
           %div= content.footnote_annotations

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -75,11 +75,6 @@ a:active {
   /* counteract styles that might come from the enclosing section */
   font-style: normal;
   text-align: left;
-
-  /* TODO is this needed? */
-  &.revealed {
-    display: none;
-  }
 }
 .note-icon {
   position: absolute;

--- a/app/webpacker/components/ResourceSectionWrapper.vue
+++ b/app/webpacker/components/ResourceSectionWrapper.vue
@@ -42,10 +42,6 @@ export default {
 
   float: left;
   position: relative;
-
-  &[data-elided-annotation]:not(.revealed){
-    display: none;
-  }
 }
 .number {
   @include sans-serif($regular, 12px, 12px);

--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -126,10 +126,6 @@ export default {
     span p {
       display: inline; // yes, p in span is illegal, but we have them
     }
-    &[data-elided-annotation]:not(.revealed){
-      margin: 0;
-      padding: 0;
-    }
   }
 }
 </style>

--- a/lib/htmltoword/xslt/no-annotations/base.xslt
+++ b/lib/htmltoword/xslt/no-annotations/base.xslt
@@ -46,7 +46,6 @@
     <w:p>
       <xsl:call-template name="text-alignment" />
       <w:r>
-        <xsl:call-template name="run-style" />
         <w:t xml:space="preserve"><xsl:value-of select="."/></w:t>
       </w:r>
     </w:p>
@@ -270,7 +269,6 @@
       </xsl:comment>
     <w:p>
       <w:r>
-        <xsl:call-template name="run-style" />
         <w:t xml:space="preserve">text not parent and h2 - <xsl:value-of select="."/></w:t>
       </w:r>
     </w:p>
@@ -345,9 +343,6 @@
           <xsl:if test="ancestor::sup">
             <w:vertAlign w:val="superscript"/>
           </xsl:if>
-          <xsl:if test="ancestor::span[contains(@class, 'annotate replacement')]">
-            <w:rStyle w:val="ReplacementText"/>
-          </xsl:if>
         </w:rPr>
         <w:t xml:space="preserve"><xsl:value-of select="."/></w:t>
       </w:r>
@@ -387,14 +382,6 @@
         <xsl:if test="ancestor::center[parent::resource-body] and not(ancestor::center[parent::resource-body][preceding-sibling::*[not(self::center | self::header)]])">
           <w:pStyle w:val="CaseHeader"/>
         </xsl:if>
-      </w:pPr>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template name="run-style">
-    <xsl:if test="ancestor::span[contains(concat(' ', @class, ' '), ' annotate highlighted ')]">
-      <w:pPr>
-        <w:highlight w:val="yellow" />
       </w:pPr>
     </xsl:if>
   </xsl:template>

--- a/lib/htmltoword/xslt/no-annotations/cleanup.xslt
+++ b/lib/htmltoword/xslt/no-annotations/cleanup.xslt
@@ -11,10 +11,6 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <!-- Paragraphs elided by annotations -->
-  <xsl:template match="resource-body/*[@data-elided-annotation and not(descendant)]" />
-  <xsl:template match="resource-body/*[not(string())]" />
-
   <xsl:template match="head"/>
 
   <!-- Elements not supported -->

--- a/lib/htmltoword/xslt/no-annotations/h2o/export.xslt
+++ b/lib/htmltoword/xslt/no-annotations/h2o/export.xslt
@@ -131,7 +131,7 @@
   </xsl:template>
 
 
-  <xsl:template match="p[not(ancestor::blockquote|ancestor::li|ancestor::p|ancestor::tr|ancestor::center[not(ancestor::h1|ancestor::h2|ancestor::h3|ancestor::h4|ancestor::h5|ancestor::h6) and not(ancestor::center) and not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not(descendant::pre)]) and not(@data-elided-annotation)]">
+  <xsl:template match="p[not(ancestor::blockquote|ancestor::li|ancestor::p|ancestor::tr|ancestor::center[not(ancestor::h1|ancestor::h2|ancestor::h3|ancestor::h4|ancestor::h5|ancestor::h6) and not(ancestor::center) and not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not(descendant::pre)])]">
     <w:p>
       <w:pPr>
 
@@ -147,9 +147,6 @@
       <xsl:apply-templates />
     </w:p>
   </xsl:template>
-
-  <!-- hide annotation replacement text, show the original text -->
-  <xsl:template match="span[contains(concat(' ', @class, ' '), ' annotate replacement ')]"></xsl:template>
 
   <xsl:template match="body/header">
     <xsl:param name="class" select="@class" />

--- a/lib/htmltoword/xslt/with-annotations/cleanup.xslt
+++ b/lib/htmltoword/xslt/with-annotations/cleanup.xslt
@@ -11,8 +11,7 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <!-- Paragraphs elided by annotations -->
-  <xsl:template match="resource-body/*[@data-elided-annotation and not(descendant)]" />
+  <!-- Empty paragraphs -->
   <xsl:template match="resource-body/*[not(string())]" />
 
   <xsl:template match="head"/>

--- a/lib/htmltoword/xslt/with-annotations/h2o/export.xslt
+++ b/lib/htmltoword/xslt/with-annotations/h2o/export.xslt
@@ -139,7 +139,7 @@
     </w:r>
   </xsl:template>
 
-  <xsl:template match="p[not(ancestor::blockquote|ancestor::li|ancestor::p|ancestor::tr|ancestor::center[not(ancestor::h1|ancestor::h2|ancestor::h3|ancestor::h4|ancestor::h5|ancestor::h6) and not(ancestor::center) and not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not(descendant::pre)]) and not(@data-elided-annotation)]">
+  <xsl:template match="p[not(ancestor::blockquote|ancestor::li|ancestor::p|ancestor::tr|ancestor::center[not(ancestor::h1|ancestor::h2|ancestor::h3|ancestor::h4|ancestor::h5|ancestor::h6) and not(ancestor::center) and not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not(descendant::pre)])]">
     <w:p>
       <w:pPr>
 

--- a/lib/htmltoword/xslt/with-annotations/h2o/export.xslt
+++ b/lib/htmltoword/xslt/with-annotations/h2o/export.xslt
@@ -139,16 +139,6 @@
     </w:r>
   </xsl:template>
 
-
-  <!-- <xsl:template match="span[contains(concat(' ', @class, ' '), ' annotate highlighted ') and not(ancestor::*[@data-elided-annotation]) and not(descendant::h1|descendant::h2|descendant::h3|descendant::h4|descendant::h5|descendant::h6)]">
-    <w:r>
-      <w:rPr>
-        <w:highlight w:val="yellow" />
-      </w:rPr>
-        <w:t xml:space="preserve"><xsl:value-of select="."/></w:t>
-    </w:r>
-  </xsl:template> -->
-
   <xsl:template match="p[not(ancestor::blockquote|ancestor::li|ancestor::p|ancestor::tr|ancestor::center[not(ancestor::h1|ancestor::h2|ancestor::h3|ancestor::h4|ancestor::h5|ancestor::h6) and not(ancestor::center) and not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not(descendant::pre)]) and not(@data-elided-annotation)]">
     <w:p>
       <w:pPr>


### PR DESCRIPTION
Since this code is now only used for exports, we can remove much of the logic and markup associated with front-end rendering. This also fixes #660.

@cgruppioni I wanted to remove the `include_annotations` flag from `apply_annotation_to_paragraphs` (and a few other places; not everywhere) but couldn't totally figure out why there are two export code paths there to begin with. Why not just bypass applying annotations entirely rather than execute `apply_annotation_to_paragraphs` while passing a flag that actually doesn't apply annotations to paragraphs?