### PR TITLE
CAP API cases render with name abbreviation instead of full name 

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -34,7 +34,7 @@ class Case < ApplicationRecord
   end
 
   def title
-    name
+    name_abbreviation
   end
 
   def date_year

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -33,15 +33,12 @@ class Case < ApplicationRecord
     nil
   end
 
-  def title
-    name_abbreviation
-  end
-
   def date_year
     decision_date.try :year
   end
 
   alias :to_s :display_name
+  alias :title :display_name
 
   nilify_blanks only: [:docket_number]
   

--- a/app/views/searches/_results.html.erb
+++ b/app/views/searches/_results.html.erb
@@ -24,7 +24,7 @@
         <a href="<%= case_path(result.id) %>" class="wrapper" data-result-id="<%= result.id %>">
           <div class="results-entry">
             <div class="title">
-              <%= result.name %>
+              <%= result.display_name %>
             </div>
             <div class="citation">
               <%= result.indexable_case_citations %>

--- a/app/views/searches/_results.html.erb
+++ b/app/views/searches/_results.html.erb
@@ -38,7 +38,7 @@
         <a href="#" class="wrapper" data-result-id="<%= result.id %>" data-result-type="<%= result.class.name.underscore %>">
           <div class="results-entry">
             <div class="title">
-              <%= result.name %>
+              <%= result.name_abbreviation %>
             </div>
             <div class="citation">
               <%= result.citations[0]&.cite %>

--- a/test/system/cases_test.rb
+++ b/test/system/cases_test.rb
@@ -15,8 +15,7 @@ class CaseSystemTest < ApplicationSystemTestCase
 
       assert_content "Cases (1)"
       click_link "Cases (1)"
-
-      find('div.title', text: "Case #{search_label} in the Haystack").click
+      find('div.title', text: "Haystack Case (#{search_label})").click
 
       # Can't find a private case!
       # TODO: You really should be able to find a private case that belongs to you.
@@ -36,14 +35,14 @@ class CaseSystemTest < ApplicationSystemTestCase
 
       assert_content "Cases (1)"
       click_link "Cases (1)"
-      assert_content "Updated Haystack Case (#{search_label})"
+      assert_content "Haystack Case (#{search_label})"
     end
 
     scenario 'reading a case', js: true do
       public_case = cases :public_case_1
       visit case_path(public_case)
 
-      assert_content public_case.name
+      assert_content public_case.name_abbreviation
       assert_content public_case.content
 
       # annotations are visible


### PR DESCRIPTION
#689 

Name abbreviation shows in: 
- [ ] main search results
- [ ] cap api adding a resource search results
- [ ] table of contents
- [ ] viewing the case in a casebook
- [ ] viewing a case on it's own 