### PR TITLE
First pass at a Dockerized development environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM ruby:2.4.1-stretch
+
+RUN mkdir /h2o
+WORKDIR /h2o
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y libpq-dev
+
+# Get Node 10 instead of version in APT repository.
+# Downloads an installation script, which ends by running
+# apt-get update: no need to re-run at this layer.
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs
+
+# Get yarn.
+# Removes cmdtest due to conflicting command name
+# https://github.com/yarnpkg/yarn/issues/2821
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get remove cmdtest \
+    && apt-get install --no-install-recommends -y yarn
+
+# Ruby dependencies
+COPY Gemfile /h2o/Gemfile
+COPY Gemfile.lock /h2o/Gemfile.lock
+# Pin bundler for now: guard-bundler wants version ~>1.0
+RUN gem install bundler -v '1.17.3' && bundle install
+
+# Node dependencies
+COPY package.json /h2o/package.json
+COPY yarn.lock /h2o/yarn.lock
+RUN yarn install --frozen-lockfile
+
+# solr_sunspot needs Java
+RUN apt-get update \
+    && apt-get install -y ca-certificates-java \
+    && apt-get install -y openjdk-8-jre \
+    && apt-get install -y openjdk-8-jre-headless \
+    && apt-get install -y openjdk-8-jdk \
+    && apt-get install -y openjdk-8-jdk-headless
+
+# Chrome for test:system
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get -y install google-chrome-stable \
+    && wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip \
+    && apt-get -y install unzip \
+    && unzip chromedriver_linux64.zip \
+    && mv chromedriver /usr/bin/chromedriver \
+    && chmod +x /usr/bin/chromedriver

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ## Contents
 
 1. [Live version](#live-version)
-2. [Development: manual setup](#development)
-2. [Development: using Docker](#development)
+2. [Development: manual setup](#development-manual-setup)
+2. [Development: using Docker](#development-docker-experimental)
 3. [Testing](#testing)
 3. [Migration](#migration)
 3. [Contributions](#contributions)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## Contents
 
 1. [Live version](#live-version)
-2. [Development](#development)
+2. [Development: manual setup](#development)
+2. [Development: using Docker](#development)
 3. [Testing](#testing)
 3. [Migration](#migration)
 3. [Contributions](#contributions)
@@ -17,7 +18,7 @@
 Auto-deploy of the latest master. If the build is green, it's up-to-date.
 
 
-## Development
+## Development: manual setup
 
 > TODO: These instructions are incomplete for dev platforms other than OS X, and probably lack steps needed on a fresh machine.
 
@@ -69,6 +70,65 @@ with `brew cask install java`
 
 1. e.g. OS X: `echo 127.0.0.1 h2o-dev.local | sudo tee -a /etc/hosts`
 2. Go to [http://h2o-dev.local:8000](http://h2o-dev.local:8000)
+
+
+## Development: Docker (experimental)
+
+### Hosts
+
+To ensure that URLs resolve correctly, add the following domain to your computer's hosts file:
+
+127.0.0.1 h2o-dev.local
+
+For additional information on modifying your hosts file, [try this help doc](http://www.rackspace.com/knowledge_center/article/how-do-i-modify-my-hosts-file).
+
+### Spin up some containers
+
+Start up the Docker containers in the background:
+
+    $ docker-compose up -d
+
+The first time this runs, it will build the 2.33GB Docker image, which
+may take several minutes. (After the first time, it should only take
+1-3 seconds.)
+
+Finally, initialize the database:
+
+    $ bash init.sh
+
+
+### Run some commands
+You should now have a working installation of H2O!
+
+Spin up the development server:
+
+    $ docker-compose exec web rails sunspot:solr:start
+    $ bundle exec rails s -p 8000 -b '0.0.0.0'"
+    $ docker-compose exec web rails sunspot:solr:stop
+
+Cleanup the server pid, if something goes wrong:
+
+    $ docker-compose exec web rm -f tmp/pids/server.pid
+
+Run the tests:
+
+    $ docker-compose exec web rails sunspot:solr:start
+    $ docker-compose exec web yarn test
+    $ docker-compose exec web rails test
+    $ docker-compose exec web rails test:system
+    $ docker-compose exec web rails sunspot:solr:stop
+
+When you are finished, spin down Docker containers by running:
+
+    $ docker-compose down
+
+### Clean up everything, so you can start fresh
+
+    $ docker-compose down
+    $ docker volume rm h2o-docker_node_modules
+    $ rm -rf ./tmp/db
+    $ echo "some command to delete solr index, maybe?"
+
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You should now have a working installation of H2O!
 Spin up the development server:
 
     $ docker-compose exec web rails sunspot:solr:start
-    $ bundle exec rails s -p 8000 -b '0.0.0.0'"
+    $ docker-compose exec web bundle exec rails s -p 8000 -b '0.0.0.0'"
     $ docker-compose exec web rails sunspot:solr:stop
 
 Cleanup the server pid, if something goes wrong:

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,10 +13,13 @@ staging:
 development:
   adapter: postgresql
   database: h2o_dev
-  host: localhost
+  host: <%= ENV['DB_HOSTNAME'] || 'localhost' %>
+  username: <%= ENV['DB_USERNAME'] %>
   pool: 5
 
 test:
   adapter: postgresql
   database: h2o_test
+  host: <%= ENV['DB_HOSTNAME'] || 'localhost' %>
+  username: <%= ENV['DB_USERNAME'] %>
   pool: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.5.15
+    volumes:
+      # Use a bind mount, to follow rails convention
+      - ./tmp/db:/var/lib/postgresql/data:delegated
+  web:
+    build: .
+    image: h2o:0.1
+    tty: true
+    command: bash
+    # command: bash -c "rm -f tmp/pids/server.pid && rails sunspot:solr:start && bundle exec rails s -p 8000 -b '0.0.0.0'"
+    environment:
+    - DOCKERIZED=true
+    - DB_HOSTNAME=db
+    - DB_USERNAME=postgres
+    extra_hosts:
+    - "h2o-dev.local:127.0.0.1"
+    volumes:
+      # Use a named volume for node_modules so mounting `.` to `/h2o/` doesn't clobber it.
+      # I attempted customizing `--modules-folder` with `.yarnrc`, but didn't work in all contexts.
+      # This solution isn't great, but works for now.
+      - node_modules:/h2o/node_modules
+      - .:/h2o
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+volumes:
+  node_modules:

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+docker-compose exec web rails sunspot:solr:start
+docker-compose exec web rails db:setup
+docker-compose exec web rails sunspot:solr:stop

--- a/test/helpers/drivers.rb
+++ b/test/helpers/drivers.rb
@@ -2,6 +2,19 @@ module H2o::Test::Helpers::Drivers
   def self.included(base)
     Capybara.default_max_wait_time = 10.seconds
     Capybara.save_path = Rails.root.join 'tmp/screenshots'
+
+    if ENV['DOCKERIZED'].present?
+      Capybara.register_driver :selenium_chrome_headless do |app|
+        Capybara::Selenium::Driver.load_selenium
+        browser_options = ::Selenium::WebDriver::Chrome::Options.new
+        browser_options.args << '--headless'
+        browser_options.args << '--disable-gpu'
+        # Sandbox cannot be used inside privileged Docker container
+        browser_options.args << '--no-sandbox'
+        Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+      end
+    end
+
     javascript_driver = base.driven_by :selenium_chrome_headless
     static_driver = base.driven_by :rack_test
 


### PR DESCRIPTION
This PR adds the ability to spin up a disposable, working development environment via Docker.

It's pretty clunky at present (mounts the entire `.` into the web container, which includes the whole `./tmp` directory; unusual work around for `node_modules`, etc.), but should functionally operate like a local installation.

This should not affect anybody's local installations: everything should still work fine.... Since I don't have a working local installation, I can't personally confirm that https://github.com/harvard-lil/h2o/compare/master...rebeccacremona:docker-setup?expand=1#diff-e31bdf70b15c8f84344c332efe06900d is correct, but I have compared the error messages: they are identical if I run a) WITHOUT my changes, and b) with my changes, but with the Docker-specific env vars unset. I'm pretty sure that means I haven't changed anything 😉 

See README for some basic instructions.