### PR TITLE
Option to initialize dev database w/ data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ The first time this runs, it will build the 2.33GB Docker image, which
 may take several minutes. (After the first time, it should only take
 1-3 seconds.)
 
-Finally, initialize the database:
+Finally, initialize an empty database...
 
     $ bash docker/init.sh
+
+...or a database seeded with data from a pg_dump file:
+
+    $ bash docker/init.sh -f ~/database.dump
 
 ### Run some commands
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,6 +1,64 @@
 #!/usr/bin/env bash
 set -e
 
-docker-compose exec web rails sunspot:solr:start
-docker-compose exec web rails db:setup
-docker-compose exec web rails sunspot:solr:stop
+display_usage() {
+    echo "Create dev and test databases. Dev database may optionally be seeded with data from a pg_dump file."
+    echo
+    echo "Usage:"
+    echo "  bash docker/init.sh [-f dump_file]"
+}
+
+function stop_solr {
+  echo "Stopping solr ..."  && docker-compose exec web rails sunspot:solr:stop
+}
+
+# Help
+if [[ ( $1 == "--help") ||  ($1 == "-h")]]; then
+    display_usage
+    exit 0
+fi
+
+# Optional flag to use dump file
+if [[ $# -gt 0 ]]; then
+    getopts ":f:" opt || true;
+    case $opt in
+        f)
+            if [ -f "$OPTARG" ]
+            then
+                FILE=$OPTARG
+            else
+                echo "Invalid path."
+                exit 1
+            fi
+            ;;
+        \?)
+            # illegal option or argument
+            display_usage
+            exit 1
+            ;;
+        :)
+            # -f present, but no path provided
+            echo "Please specify the path."
+            exit 1
+            ;;
+    esac
+    if [[ $((OPTIND - $#)) -ne 1 ]]; then
+        # too many args
+        display_usage
+        exit 1
+    fi
+fi
+
+echo "Starting solr ..." && docker-compose exec web rails sunspot:solr:start
+trap stop_solr EXIT
+
+echo "Creating databases ..." && docker-compose exec web rails db:setup
+if [ "$FILE" ]; then
+    echo "Loading data from $FILE ..."
+    docker cp $FILE "$(docker-compose ps -q db)":/tmp/data.dump
+    # temporarily forcing the next line to return 0, until we understand
+    # the key constraint errors we are getting ("WARNING: errors ignored on restore: 4")
+    docker-compose exec db pg_restore --username=postgres --verbose --data-only --no-owner -h localhost -d h2o_dev /tmp/data.dump || true;
+    docker-compose exec db rm -f /tmp/data.dump
+    echo "Building solr index ..." && docker-compose exec web rails sunspot:solr:reindex
+fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,11 +2,11 @@
 set -e
 
 function cleanup {
-  docker-compose exec web rails sunspot:solr:stop
+  echo "Stopping solr ..."  && docker-compose exec web rails sunspot:solr:stop
   docker-compose exec web rm -f tmp/pids/server.pid
 }
 trap cleanup EXIT
 
 docker-compose exec web rm -f tmp/pids/server.pid
-docker-compose exec web rails sunspot:solr:start
+echo "Starting solr ..."  && docker-compose exec web rails sunspot:solr:start
 docker-compose exec web bundle exec rails s -p 8000 -b '0.0.0.0'

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -2,11 +2,11 @@
 set -e
 
 function cleanup {
-  docker-compose exec web rails sunspot:solr:stop
+  echo "Stopping solr ..."  && docker-compose exec web rails sunspot:solr:stop
 }
 trap cleanup EXIT
 
-docker-compose exec web rails sunspot:solr:start
+echo "Starting solr ..."  && docker-compose exec web rails sunspot:solr:start
 docker-compose exec web yarn test
 docker-compose exec web rails test
 docker-compose exec web rails test:system


### PR DESCRIPTION
`bash docker/init.sh -f ~/database.dump`

We're getting some (repeatable) errors when loading some recent data. I'm relatively sure it's not a problem with the process, so am committing an error-swallowing workaround for the time being. We'll definitely want to remove that workaround once we diagnose and fix the issue.