### PR TITLE
Handle unmet peer dependencies.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    image: h2o:0.2
+    image: h2o:0.3
     tty: true
     command: bash
     environment:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap-sass": "3.4.1",
     "ckeditor": "4.11.0",
     "classlist-polyfill": "^1.2.0",
+    "css-loader": "*",
     "debounce": "^1.0.2",
     "delegate": "^3.1.2",
     "drag-mock": "^1.4.0",
@@ -25,15 +26,18 @@
     "path-complete-extname": "^0.1.0",
     "query-string": "^4.3.4",
     "rails-erb-loader": "^5.5.0",
+    "typescript": "*",
     "vue": "^2.6.6",
     "vue-contenteditable-directive": "^1.2.0",
     "vue-loader": "^15.6.2",
     "vue-scrollto": "^2.13.0",
     "vue-template-compiler": "^2.6.6",
-    "vuex": "^3.1.0"
+    "vuex": "^3.1.0",
+    "webpack": "^4.29.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.29",
+    "@babel/core": "^7.2.2",
     "babel-jest": "^24.1.0",
     "jest": "^24.1.0",
     "jest-serializer-vue": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,7 +2155,7 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-loader@^2.1.0:
+css-loader@*, css-loader@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.0.tgz#42952ac22bca5d076978638e9813abce49b8f0cc"
   integrity sha512-MoOu+CStsGrSt5K2OeZ89q3Snf+IkxRfAIt9aAKg4piioTrhtP1iEFPu+OVn3Ohz24FO6L+rw9UJxBILiSBw5Q==
@@ -8062,6 +8062,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@*:
+  version "3.3.4000"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
  yarn install into a clean `node_modules` folder consistently reports:
  > [3/4] Linking dependencies...
  > warning "vue-jest > @babel/plugin-transform-modules-commonjs@7.2.0" has unmet peer dependency "@babel/core@^7.0.0-0".
  > warning "@rails/webpacker > pnp-webpack-plugin > ts-pnp@1.0.0" has unmet peer dependency "typescript@*".
  > warning " > rails-erb-loader@5.5.0" has unmet peer dependency "webpack@^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0".
  > warning " > vue-loader@15.6.2" has unmet peer dependency "css-loader@*".
  > warning " > vue-loader@15.6.2" has unmet peer dependency "webpack@^4.1.0 || ^5.0.0-0".
  > warning " > babel-jest@24.1.0" has unmet peer dependency "@babel/core@^7.0.0".
  > warning " > vue-jest@4.0.0-beta.2" has unmet peer dependency "@babel/core@7.x".
  > warning "vue-jest > ts-jest@23.10.5" has incorrect peer dependency "jest@>=22 <24".
  > warning " > webpack-dev-server@3.1.14" has unmet peer dependency "webpack@^4.0.0".
  > warning "webpack-dev-server > webpack-dev-middleware@3.4.0" has unmet peer dependency "webpack@^4.0.0".

This PR fixes all the "unmet peer dependency" warnings. 