### PR TITLE
Hide note-content-wrapper unless annotation is not new.

### DIFF
--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -10,7 +10,7 @@
       <a @click="destroy(annotation)">Remove note</a>
     </li>
   </AnnotationHandle>
-  <template v-if="isHead">
+  <template v-if="isHead && !isNew">
     <span v-show="uiState.expanded"
           class="note-content-wrapper"
           data-exclude-from-offset-calcs="true">


### PR DESCRIPTION
#673 

<img width="373" alt="Screen Shot 2019-03-25 at 1 47 44 PM" src="https://user-images.githubusercontent.com/14900328/54945473-43f76780-4f0c-11e9-860b-f14efc7cc6ac.png">
