### PR TITLE
674 Move the annotator logic into single components

### DIFF
--- a/app/webpacker/components/AnnotationBase.vue
+++ b/app/webpacker/components/AnnotationBase.vue
@@ -54,6 +54,12 @@ export default {
     ...mapActions(['destroy'])
   },
   created() {
+    if(this.isHead && this.isNew && ['highlight', 'elide'].includes(this.annotation.kind)){
+      this.createAndUpdate(
+        {obj: this.annotation, vals: {}}
+      );
+    }
+
     if(!this.uiState) {
       this.$store.commit('annotations_ui/append', [
         {id: this.annotation.id,

--- a/app/webpacker/components/AnnotationBase.vue
+++ b/app/webpacker/components/AnnotationBase.vue
@@ -51,7 +51,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['destroy'])
+    ...mapActions(['destroy', 'createAndUpdate'])
   },
   created() {
     if(this.isHead && this.isNew && ['highlight', 'elide'].includes(this.annotation.kind)){

--- a/app/webpacker/components/ContextMenu.vue
+++ b/app/webpacker/components/ContextMenu.vue
@@ -76,6 +76,7 @@
 
             // When clicking away from note or link annotation during creation, destroy temporarily stored annotation in store 
             if(this.$tempId != undefined){
+              // is this still needed for highlight and elide
               let annotation = this.$store.getters['annotations/getById'](this.$tempId);
               let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
 

--- a/app/webpacker/components/ContextMenu.vue
+++ b/app/webpacker/components/ContextMenu.vue
@@ -75,14 +75,14 @@
             this.close(true);
 
             // When clicking away from note or link annotation during creation, destroy temporarily stored annotation in store 
-            // if(this.$tempId != undefined){
-            //   let annotation = this.$store.getters['annotations/getById'](this.$tempId);
-            //   let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
+            if(this.$tempId != undefined){
+              let annotation = this.$store.getters['annotations/getById'](this.$tempId);
+              let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
 
-            //   this.$store.commit('annotations/destroy', annotation);
-            //   this.$store.commit('annotations_ui/destroy', uiState);
-            //   this.$tempId = null;
-            // }
+              this.$store.commit('annotations/destroy', annotation);
+              this.$store.commit('annotations_ui/destroy', uiState);
+              this.$tempId = null;
+            }
           }
         },
         /**

--- a/app/webpacker/components/ContextMenu.vue
+++ b/app/webpacker/components/ContextMenu.vue
@@ -73,17 +73,6 @@
         if(e.relatedTarget != this.$el &&
            !this.$el.contains(e.relatedTarget)){
             this.close(true);
-
-            // When clicking away from note or link annotation during creation, destroy temporarily stored annotation in store 
-            if(this.$tempId != undefined){
-              // is this still needed for highlight and elide
-              let annotation = this.$store.getters['annotations/getById'](this.$tempId);
-              let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
-
-              this.$store.commit('annotations/destroy', annotation);
-              this.$store.commit('annotations_ui/destroy', uiState);
-              this.$tempId = null;
-            }
           }
         },
         /**

--- a/app/webpacker/components/ContextMenu.vue
+++ b/app/webpacker/components/ContextMenu.vue
@@ -75,14 +75,14 @@
             this.close(true);
 
             // When clicking away from note or link annotation during creation, destroy temporarily stored annotation in store 
-            if(this.$tempId != undefined){
-              let annotation = this.$store.getters['annotations/getById'](this.$tempId);
-              let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
+            // if(this.$tempId != undefined){
+            //   let annotation = this.$store.getters['annotations/getById'](this.$tempId);
+            //   let uiState = this.$store.getters['annotations_ui/getById'](annotation.id);
 
-              this.$store.commit('annotations/destroy', annotation);
-              this.$store.commit('annotations_ui/destroy', uiState);
-              this.$tempId = null;
-            }
+            //   this.$store.commit('annotations/destroy', annotation);
+            //   this.$store.commit('annotations_ui/destroy', uiState);
+            //   this.$tempId = null;
+            // }
           }
         },
         /**

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -19,8 +19,6 @@
     </ContextMenu>
   </template>
   <template v-if="isNew && isHead">
-    <ContextMenu data-exclude-from-offset-calcs="true"
-                 :closeOnClick="false">
     <form @submit.prevent="submit('link', content)"
           class="form link-content-wrapper"
           :id= "`${annotation.id}`"
@@ -28,7 +26,6 @@
       <LinkInput ref="linkInput"
                  v-model="content"/>
     </form>
-  </ContextMenu>
   </template>
 </span>
 </template>

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -12,20 +12,23 @@
     </AnnotationHandle>
     <ContextMenu ref="editMenu"
                  data-exclude-from-offset-calcs="true"
-                 :closeOnClick="false">
+                 :closeOnClick="false"
+                 class="edit-menu">
       <form @submit.prevent="submitUpdate">
         <LinkInput v-model="content"/>
       </form>
     </ContextMenu>
   </template>
   <template v-if="isNew && isHead">
-    <form @submit.prevent="submit('link', content)"
-          class="form link-content-wrapper"
-          :id= "`${annotation.id}`"
-          ref="linkForm">
-      <LinkInput ref="linkInput"
-                 v-model="content"/>
-    </form>
+    <div class="link-content-wrapper">
+      <form @submit.prevent="submit('link', content)"
+            class="form"
+            :id= "`${annotation.id}`"
+            ref="linkForm">
+        <LinkInput ref="linkInput"
+                   v-model="content"/>
+      </form>
+    </div>
   </template>
 </span>
 </template>
@@ -86,15 +89,28 @@ a[target="_blank"] {
   margin-right: 0.1em;
 }
 .link-content-wrapper {
+  @include sans-serif($regular, 12px, 14px);
   @include square(0);
   position: absolute;
   right: 0;
   overflow: visible;
   display: block;
-  margin-left: 10px;
 
   /* counteract styles that might come from the enclosing section */
   font-style: normal;
   text-align: left;
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid black;
+    padding: 10px 15px;
+    width: 200px;
+    background: white;
+    margin-left: 10px;
+  }
+}
+.edit-menu {
+  margin-left: 10px;
 }
 </style>

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -19,6 +19,8 @@
     </ContextMenu>
   </template>
   <template v-if="isNew && isHead">
+    <ContextMenu data-exclude-from-offset-calcs="true"
+                 :closeOnClick="false">
     <form @submit.prevent="submit('link', content)"
           class="form link-content-wrapper"
           :id= "`${annotation.id}`"
@@ -26,6 +28,7 @@
       <LinkInput ref="linkInput"
                  v-model="content"/>
     </form>
+  </ContextMenu>
   </template>
 </span>
 </template>

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -131,10 +131,6 @@ a[target="_blank"] {
     background: white;
     margin-left: 10px;
     z-index: 999;
-
-    #link-input {
-      width: 200px;
-    }
   }
 }
 .edit-menu {

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -18,7 +18,7 @@
       </form>
     </ContextMenu>
   </template>
-  <template v-if="isNew">
+  <template v-if="isNew && isHead">
     <form @submit.prevent="submit('link', content)"
           class="form link-content-wrapper"
           :id= "`${annotation.id}`"

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -20,9 +20,9 @@
   </template>
   <template v-if="isNew">
     <form @submit.prevent="submit('link', content)"
-          class="form"
-          ref="linkForm"
-          :id= "`${annotation.id}`">
+          class="form link-content-wrapper"
+          :id= "`${annotation.id}`"
+          ref="linkForm">
       <LinkInput ref="linkInput"
                  v-model="content"/>
     </form>
@@ -78,17 +78,23 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../styles/vars-and-mixins';
 a[target="_blank"] {
   background: url(../images/external-link-icon.svg) center right no-repeat;
   background-size: 0.55em 0.55em;
   padding-right: 0.7em;
   margin-right: 0.1em;
 }
-.form {
-  display: flex;
-  flex-direction: column;
-}
-.button {
-  margin-top: 1em;
+.link-content-wrapper {
+  @include square(0);
+  position: absolute;
+  right: 0;
+  overflow: visible;
+  display: block;
+  margin-left: 10px;
+
+  /* counteract styles that might come from the enclosing section */
+  font-style: normal;
+  text-align: left;
 }
 </style>

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -18,6 +18,15 @@
       </form>
     </ContextMenu>
   </template>
+  <template v-if="isNew">
+    <form @submit.prevent="submit('link', content)"
+          class="form"
+          ref="linkForm"
+          :id= "`${annotation.id}`">
+      <LinkInput ref="linkInput"
+                 v-model="content"/>
+    </form>
+  </template>
 </span>
 </template>
 
@@ -51,11 +60,19 @@ export default {
     }
   },
   methods: {
-    ...mapActions(["update"]),
+    ...mapActions(["update", "createAndUpdate"]),
     submitUpdate() {
       this.update({obj: this.annotation, vals: this.newVals});
       this.$refs.editMenu.close();
-    }
+    },
+    submit(kind, content = null){
+      let id = this.$refs.linkForm.id;
+      let annotation = this.$store.getters['annotations/getById'](parseInt(id));
+
+      this.createAndUpdate(
+        {obj: annotation, vals: {content: content}}
+      );
+    },
   }
 }
 </script>
@@ -66,5 +83,12 @@ a[target="_blank"] {
   background-size: 0.55em 0.55em;
   padding-right: 0.7em;
   margin-right: 0.1em;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+}
+.button {
+  margin-top: 1em;
 }
 </style>

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -20,13 +20,23 @@
     </ContextMenu>
   </template>
   <template v-if="isNew && isHead">
-    <div class="link-content-wrapper">
+    <div class="link-content-wrapper"
+    tabindex="-1">
       <form @submit.prevent="submit('link', content)"
-            class="form"
+            class="form link-form"
             :id= "`${annotation.id}`"
-            ref="linkForm">
-        <LinkInput ref="linkInput"
-                   v-model="content"/>
+            ref="linkForm"
+            tabindex="0"
+            @focusout="focusOut"
+            >
+          <input id="link-input"
+                type="url"
+                required="true"
+                pattern="\w+://\w+.*"
+                placeholder="Url to link to..."
+                ref="linkInput"
+                v-model="content"
+                tabindex="0"/>
       </form>
     </div>
   </template>
@@ -47,8 +57,9 @@ export default {
     ContextMenu,
     LinkInput
   },
+  props: ["value"],
   data: () => ({
-    newVals: {content: null}
+    newVals: {content: null},
   }),
   computed: {
     content: {
@@ -69,14 +80,30 @@ export default {
       this.$refs.editMenu.close();
     },
     submit(kind, content = null){
-      let id = this.$refs.linkForm.id;
-      let annotation = this.$store.getters['annotations/getById'](parseInt(id));
-
       this.createAndUpdate(
-        {obj: annotation, vals: {content: content}}
+        {obj: this.annotation, vals: this.newVals}
       );
     },
-  }
+    focusOut(e){
+      console.log(e.relatedTarget);
+
+      if(Math.sign(this.annotation.id) !== -1){
+        this.$store.commit('annotations/destroy', this.annotation);
+        this.$store.commit('annotations_ui/destroy', this.uiState);
+      }
+      // debugger;
+      // if(e.currentTarget.className !== "form link-form"){
+
+      // }
+    }
+  },
+  mounted() {
+    this.$nextTick(function () {
+      if (Math.sign(this.annotation.id) == -1){
+        this.$refs.linkInput.focus();
+      }
+    })
+  },
 }
 </script>
 
@@ -95,6 +122,7 @@ a[target="_blank"] {
   right: 0;
   overflow: visible;
   display: block;
+  z-index: 999;
 
   /* counteract styles that might come from the enclosing section */
   font-style: normal;
@@ -108,6 +136,11 @@ a[target="_blank"] {
     width: 200px;
     background: white;
     margin-left: 10px;
+    z-index: 999;
+
+    #link-input {
+      width: 200px;
+    }
   }
 }
 .edit-menu {

--- a/app/webpacker/components/LinkAnnotation.vue
+++ b/app/webpacker/components/LinkAnnotation.vue
@@ -85,16 +85,10 @@ export default {
       );
     },
     focusOut(e){
-      console.log(e.relatedTarget);
-
-      if(Math.sign(this.annotation.id) !== -1){
+      if(Math.sign(this.annotation.id) === -1){
         this.$store.commit('annotations/destroy', this.annotation);
         this.$store.commit('annotations_ui/destroy', this.uiState);
       }
-      // debugger;
-      // if(e.currentTarget.className !== "form link-form"){
-
-      // }
     }
   },
   mounted() {

--- a/app/webpacker/components/LinkInput.vue
+++ b/app/webpacker/components/LinkInput.vue
@@ -4,6 +4,7 @@
        required="true"
        pattern="\w+://\w+.*"
        placeholder="Url to link to..."
+       ref="linkInput"
        :value="value"
        @input="$emit('input', $event.target.value)"/>
 </template>

--- a/app/webpacker/components/LinkInput.vue
+++ b/app/webpacker/components/LinkInput.vue
@@ -15,4 +15,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  #link-input {
+    width: 200px;
+  }
 </style>

--- a/app/webpacker/components/LinkInput.vue
+++ b/app/webpacker/components/LinkInput.vue
@@ -4,7 +4,6 @@
        required="true"
        pattern="\w+://\w+.*"
        placeholder="Url to link to..."
-       ref="linkInput"
        :value="value"
        @input="$emit('input', $event.target.value)"/>
 </template>
@@ -16,7 +15,4 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  #link-input {
-    width: 200px;
-  }
 </style>

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -33,22 +33,24 @@
          :href="`#${annotation.id}-content`"
          :id="isHead ? `${annotation.id}-head` : ''"
          @click.prevent="handleClick"><slot></slot></a>
-      <form @submit.prevent="submit('note', content)"
-            ref="noteForm"
-            class="form note-content-wrapper"
-            :id= "`${annotation.id}`">
-        <textarea ref="noteInput"
-                  id="note-textarea"
-                  required="true"
-                  placeholder="Note text..."
-                  @keydown.enter.prevent="$refs.noteSubmitButton.click"
-                  v-model="content"></textarea>
-        <input ref="noteSubmitButton"
-               type="submit"
-               value="Save"
-               id="save-note"
-               class="button">
-      </form>
+      <div class="new-note-content-wrapper">
+        <form @submit.prevent="submit('note', content)"
+              ref="noteForm"
+              class="form note-content"
+              :id= "`${annotation.id}`">
+          <textarea ref="noteInput"
+                    id="note-textarea"
+                    required="true"
+                    placeholder="Note text..."
+                    @keydown.enter.prevent="$refs.noteSubmitButton.click"
+                    v-model="content"></textarea>
+          <input ref="noteSubmitButton"
+                 type="submit"
+                 value="Save"
+                 id="save-note"
+                 class="button">
+        </form>
+      </div>
   </template>
 </span>
 </template>
@@ -100,6 +102,33 @@ a:active {
   color: inherit;
   /* Bootstrap's normalize uses !important so we must too */
   text-decoration: $light-blue underline !important;
+}
+
+.new-note-content-wrapper {
+  @include square(0);
+  position: absolute;
+  right: 0;
+  overflow: visible;
+  display: block;
+
+  /* counteract styles that might come from the enclosing section */
+  font-style: normal;
+  text-align: left;
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid black;
+    padding: 10px 15px;
+  }
+
+  .button {
+    margin-top: 1em;
+  }
+
+  .note-content {
+    width: fit-content;
+  }
 }
 
 .note-content-wrapper {

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -55,7 +55,6 @@
 
 <script>
 import AnnotationBase from './AnnotationBase';
-import ContextMenu from "./ContextMenu";
 import { createNamespacedHelpers } from 'vuex';
 const { mapGetters } = createNamespacedHelpers('annotations_ui');
 const { mapActions } = createNamespacedHelpers("annotations");

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -110,6 +110,7 @@ a:active {
   right: 0;
   overflow: visible;
   display: block;
+  margin-left: 10px;
 
   /* counteract styles that might come from the enclosing section */
   font-style: normal;
@@ -120,14 +121,11 @@ a:active {
     flex-direction: column;
     border: 1px solid black;
     padding: 10px 15px;
+    width: fit-content;
   }
 
   .button {
     margin-top: 1em;
-  }
-
-  .note-content {
-    width: fit-content;
   }
 }
 

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -29,7 +29,10 @@
     </span>
   </template>
   <template v-if="isNew && isHead">
-    <ContextMenu>
+      <a class="selected-text"
+         :href="`#${annotation.id}-content`"
+         :id="isHead ? `${annotation.id}-head` : ''"
+         @click.prevent="handleClick"><slot></slot></a>
       <form @submit.prevent="submit('note', content)"
             ref="noteForm"
             class="form note-content-wrapper"
@@ -46,7 +49,6 @@
                id="save-note"
                class="button">
       </form>
-    </ContextMenu>
   </template>
 </span>
 </template>

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -28,7 +28,7 @@
       </span>
     </span>
   </template>
-  <template v-if="isNew">
+  <template v-if="isNew && isHead">
     <form @submit.prevent="submit('note', content)"
           ref="noteForm"
           class="form note-content-wrapper"

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -29,7 +29,7 @@
     </span>
   </template>
   <template v-if="isNew">
-    <form @submit.prevent="submitNoteAndHighlight('note', content)"
+    <form @submit.prevent="submit('note', content)"
           ref="noteForm"
           class="form note-content-wrapper"
           :id= "`${annotation.id}`">
@@ -72,17 +72,13 @@ export default {
       document.getElementById(e.currentTarget.getAttribute("href").slice(1)).focus({preventScroll: true});
       this.toggleExpansion(this.uiState);
     },
-    submitNoteAndHighlight(kind, content = null){
+    submit(kind, content = null){
       let id = this.$refs.noteForm.id;
-      let annotation = this.$store.getters['annotations/getById'](id);
+      let annotation = this.$store.getters['annotations/getById'](parseInt(id));
 
-      debugger;
       this.createAndUpdate(
         {obj: annotation, vals: {content: content}}
       );
-
-      this.$refs.noteForm = null;
-      this.close();
     },
   }
 }

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -29,28 +29,31 @@
     </span>
   </template>
   <template v-if="isNew && isHead">
-    <form @submit.prevent="submit('note', content)"
-          ref="noteForm"
-          class="form note-content-wrapper"
-          :id= "`${annotation.id}`">
-      <textarea ref="noteInput"
-                id="note-textarea"
-                required="true"
-                placeholder="Note text..."
-                @keydown.enter.prevent="$refs.noteSubmitButton.click"
-                v-model="content"></textarea>
-      <input ref="noteSubmitButton"
-             type="submit"
-             value="Save"
-             id="save-note"
-             class="button">
-    </form>
+    <ContextMenu>
+      <form @submit.prevent="submit('note', content)"
+            ref="noteForm"
+            class="form note-content-wrapper"
+            :id= "`${annotation.id}`">
+        <textarea ref="noteInput"
+                  id="note-textarea"
+                  required="true"
+                  placeholder="Note text..."
+                  @keydown.enter.prevent="$refs.noteSubmitButton.click"
+                  v-model="content"></textarea>
+        <input ref="noteSubmitButton"
+               type="submit"
+               value="Save"
+               id="save-note"
+               class="button">
+      </form>
+    </ContextMenu>
   </template>
 </span>
 </template>
 
 <script>
 import AnnotationBase from './AnnotationBase';
+import ContextMenu from "./ContextMenu";
 import { createNamespacedHelpers } from 'vuex';
 const { mapGetters } = createNamespacedHelpers('annotations_ui');
 const { mapActions } = createNamespacedHelpers("annotations");

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -88,8 +88,7 @@ export default {
       );
     },
     focusOut(e){
-      if(e.relatedTarget == null || ["save-note", "note-textarea"].includes(e.relatedTarget.id) == false ){
-
+      if (Math.sign(this.annotation.id) === -1 && e.relatedTarget == null || e.relatedTarget !== null && ["save-note", "note-textarea"].includes(e.relatedTarget.id) == false){     
         this.$store.commit('annotations/destroy', this.annotation);
         this.$store.commit('annotations_ui/destroy', this.uiState);
       }

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -86,7 +86,14 @@ export default {
         {obj: annotation, vals: {content: content}}
       );
     },
-  }
+  },
+  mounted() {
+    this.$nextTick(function () {
+      if (Math.sign(this.annotation.id) == -1){
+        this.$refs.noteInput.focus()
+      }
+    })
+  },
 }
 </script>
 

--- a/app/webpacker/components/NoteAnnotation.vue
+++ b/app/webpacker/components/NoteAnnotation.vue
@@ -37,7 +37,8 @@
         <form @submit.prevent="submit('note', content)"
               ref="noteForm"
               class="form note-content"
-              :id= "`${annotation.id}`">
+              :id= "`${annotation.id}`"
+              @focusout="focusOut">
           <textarea ref="noteInput"
                     id="note-textarea"
                     required="true"
@@ -86,6 +87,13 @@ export default {
         {obj: annotation, vals: {content: content}}
       );
     },
+    focusOut(e){
+      if(e.relatedTarget == null || ["save-note", "note-textarea"].includes(e.relatedTarget.id) == false ){
+
+        this.$store.commit('annotations/destroy', this.annotation);
+        this.$store.commit('annotations_ui/destroy', this.uiState);
+      }
+    }
   },
   mounted() {
     this.$nextTick(function () {

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -5,15 +5,15 @@
             :style="{top: offset}">
     <li>
       <a id="create-highlight"
-         @click="submit('highlight')">Highlight</a>
+         @click="input($event, 'highlight')">Highlight</a>
     </li>
     <li>
       <a id="create-elision"
-         @click="submit('elide')">Elide</a>
+         @click="input($event, 'elide')">Elide</a>
     </li>
     <li>
       <a id="create-replacement"
-         @click="insertReplacementPlaceholder">Replace</a></li>
+         @click="input($event, 'replace')">Replace</a></li>
     <li>
       <a id="create-link"
          @click="input($event, 'link')">Add link</a>
@@ -57,7 +57,7 @@ export default {
   },
   data: () => ({
     ranges: null,
-    content: "",
+    content: null,
     showModal: false,
   }),
   watch: {
@@ -108,53 +108,18 @@ export default {
       this.$refs.noteMenu.close();
     },
 
-    submit(kind, content = null) {
-      this.create({
-        kind: kind,
-        content: content,
-        resource_id: this.resourceId,
-        ...this.offsets
-      }).catch(e => {
-        this.showModal = true;
-      });
-
-      this.close();
-    },
-
-    submitNoteAndHighlight(kind, content = null){
-      let id = this.$refs[`${kind}Menu`].$tempId;
-      let annotation = this.$store.getters['annotations/getById'](id);
-
-      this.createAndUpdate(
-        {obj: annotation, vals: {content: content}}
-      );
-
-      this.$refs[`${kind}Menu`].$tempId = null;
-      this.close();
-    },
-
-    insertReplacementPlaceholder() {
-      this.$store.commit('annotations/append', [{
-        id: this.tempId(),
-        content: "",
-        kind: "replace",
-        resource_id: this.resourceId,
-        ...this.offsets
-      }]);
-
-      this.close();
-    },
-
     input(e, kind) {
       let id = this.tempId();
 
       this.$store.commit('annotations/append', [{
         id: id,
-        content: "",
+        content: this.content,
         kind: kind,
         resource_id: this.resourceId,
         ...this.offsets
       }]);
+
+      this.close();
     },
   }
 }

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -119,7 +119,7 @@ export default {
         ...this.offsets
       }]);
 
-      this.close();
+      // this.close();
     },
   }
 }

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -32,11 +32,6 @@
     </form>
   </ContextMenu>
 
-<!--   <ContextMenu ref="noteMenu"
-                v-model="tempId"
-               :closeOnClick="false">
-  </ContextMenu> -->
-
   <Modal v-if="showModal"
             @close="showModal = false">
     <template slot="title">Error</template>
@@ -168,15 +163,6 @@ export default {
         resource_id: this.resourceId,
         ...this.offsets
       }]);
-
-      // this.$refs[`${kind}Menu`].open(e);
-      // this.$refs[`${kind}Menu`].$tempId = id;
-
-      // this.$nextTick(
-      //   () =>
-      //     (this.$refs[`${kind}Input`].$el ||
-      //      this.$refs[`${kind}Input`]).focus()
-      // );
     },
   }
 }

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -104,8 +104,6 @@ export default {
     close() {
       document.getSelection().empty();
       this.ranges = null;
-      this.$refs.linkMenu.close();
-      this.$refs.noteMenu.close();
     },
 
     input(e, kind) {
@@ -118,6 +116,8 @@ export default {
         resource_id: this.resourceId,
         ...this.offsets
       }]);
+
+      this.close();
     },
   }
 }

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -118,8 +118,6 @@ export default {
         resource_id: this.resourceId,
         ...this.offsets
       }]);
-
-      // this.close();
     },
   }
 }

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -23,14 +23,6 @@
          @click="input($event, 'note')">Add note</a>
     </li>
   </SideMenu>
- <ContextMenu ref="linkMenu"
-               :closeOnClick="false">
-    <form @submit.prevent="submitNoteAndHighlight('link', content)"
-          class="form">
-      <LinkInput ref="linkInput"
-                 v-model="content"/>
-    </form>
-  </ContextMenu>
 
   <Modal v-if="showModal"
             @close="showModal = false">

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -82,7 +82,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions(["create", "createAndUpdate"]),
+    ...mapActions(["create"]),
 
     tempId() {
       return Math.floor(Math.random() * Math.floor(10000000)) * -1;

--- a/app/webpacker/components/TheAnnotator.vue
+++ b/app/webpacker/components/TheAnnotator.vue
@@ -23,8 +23,7 @@
          @click="input($event, 'note')">Add note</a>
     </li>
   </SideMenu>
-
-  <ContextMenu ref="linkMenu"
+ <ContextMenu ref="linkMenu"
                :closeOnClick="false">
     <form @submit.prevent="submitNoteAndHighlight('link', content)"
           class="form">
@@ -33,24 +32,10 @@
     </form>
   </ContextMenu>
 
-  <ContextMenu ref="noteMenu"
+<!--   <ContextMenu ref="noteMenu"
+                v-model="tempId"
                :closeOnClick="false">
-    <form @submit.prevent="submitNoteAndHighlight('note', content)"
-          class="form"
-          id="note-form">
-      <textarea ref="noteInput"
-                id="note-textarea"
-                required="true"
-                placeholder="Note text..."
-                @keydown.enter.prevent="$refs.noteSubmitButton.click"
-                v-model="content"></textarea>
-      <input ref="noteSubmitButton"
-             type="submit"
-             value="Save"
-             id="save-note"
-             class="button">
-    </form>
-  </ContextMenu>
+  </ContextMenu> -->
 
   <Modal v-if="showModal"
             @close="showModal = false">
@@ -184,14 +169,14 @@ export default {
         ...this.offsets
       }]);
 
-      this.$refs[`${kind}Menu`].open(e);
-      this.$refs[`${kind}Menu`].$tempId = id;
+      // this.$refs[`${kind}Menu`].open(e);
+      // this.$refs[`${kind}Menu`].$tempId = id;
 
-      this.$nextTick(
-        () =>
-          (this.$refs[`${kind}Input`].$el ||
-           this.$refs[`${kind}Input`]).focus()
-      );
+      // this.$nextTick(
+      //   () =>
+      //     (this.$refs[`${kind}Input`].$el ||
+      //      this.$refs[`${kind}Input`]).focus()
+      // );
     },
   }
 }


### PR DESCRIPTION
#674 

**Testing plan**
There are no noticeable changes for users, but a lot of the functionality under the hood has changed. So compare annotating to production and make sure that everything is still fully functional

- [ ] can create, edit and delete all forms of annotations correctly
- [ ] All menus ( main annotation menu, note, link, replace ) look the same
- [ ] when making a note or link annotation, click away makes the annotation disappear. Including the underscored text that was to be annotated and the text input box 

