### PR TITLE
Add cloneable field to casebook

### DIFF
--- a/app/decorators/content/node_decorator.rb
+++ b/app/decorators/content/node_decorator.rb
@@ -36,10 +36,10 @@ class Content::NodeDecorator < Draper::Decorator
         else
           return [:create_draft] << clone_and_export
         end
+      elsif ! casebook.cloneable? || anonymous?
+        return [:export]
       elsif current_user.present?
         return clone_and_export
-      elsif anonymous?
-        return [:export]
       end
     elsif preview_mode
       if casebook.draft_mode_of_published_casebook?
@@ -70,10 +70,10 @@ class Content::NodeDecorator < Draper::Decorator
         else
           return [:create_section_draft] << clone_and_export
         end
+      elsif ! casebook.cloneable? || anonymous?
+        return [:export]
       elsif current_user.present?
         return clone_and_export
-      elsif anonymous?
-        return [:export]
       end
     elsif preview_mode
       if casebook.draft_mode_of_published_casebook?
@@ -100,10 +100,10 @@ class Content::NodeDecorator < Draper::Decorator
         else
           return [:create_resource_draft] << clone_and_export
         end
+      elsif ! casebook.cloneable? || anonymous?
+        return [:export]
       elsif current_user.present?
         return clone_and_export
-      elsif anonymous?
-        return [:export]
       end
     elsif preview_mode
       if casebook.draft_mode_of_published_casebook?

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -266,6 +266,7 @@ RailsAdmin.config do |config|
       field :subtitle
       field :headnote, :ck_editor
       field :public
+      field :cloneable
       field :ancestry do
         read_only true
       end

--- a/db/migrate/20190411201647_add_cloneable_to_casebooks.rb
+++ b/db/migrate/20190411201647_add_cloneable_to_casebooks.rb
@@ -1,0 +1,9 @@
+class AddCloneableToCasebooks < ActiveRecord::Migration[5.2]
+  def up
+    add_column :content_nodes, :cloneable, :boolean, default: true, null: false
+  end
+
+  def down
+    remove_column :content_nodes, :cloneable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_07_221258) do
+ActiveRecord::Schema.define(version: 2019_04_11_201647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2018_12_07_221258) do
     t.bigint "playlist_id"
     t.bigint "root_user_id"
     t.boolean "draft_mode_of_published_casebook"
+    t.boolean "cloneable", default: true, null: false
     t.index ["ancestry"], name: "index_content_nodes_on_ancestry"
     t.index ["casebook_id", "ordinals"], name: "index_content_nodes_on_casebook_id_and_ordinals", using: :gin
     t.index ["casebook_id"], name: "index_content_nodes_on_casebook_id"


### PR DESCRIPTION
Admin can uncheck cloneable field ( all casebooks are able to be cloned by default ) to hide clone button from unauthorized users ( casebook collaborator or an admin user ) 