### PR TITLE
Tweaks suggested by node debugging process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ rvm:
   - 2.4.1
 before_install:
   - nvm install 6
-  - npm install yarn -g && yarn install
+  - npm install yarn -g && yarn install --frozen-lockfile --check-files
 before_script:
   - bundle exec bin/rails sunspot:solr:start
   - bundle exec bin/rails db:setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 before_script:
   - bundle exec bin/rails sunspot:solr:start
   - bundle exec bin/rails db:setup
-  - bundle exec bin/rails assets:precompile
+  - bundle exec bin/rails assets:precompile DISABLE_SPRING=1
   - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 script:
   - bundle exec bin/rails test

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Auto-deploy of the latest master. If the build is green, it's up-to-date.
 1. [Installation of yarn](https://yarnpkg.com/lang/en/docs/install/) is platform-specific. On a Mac: if you already have node installed, `brew install yarn --without-node`, or `brew install yarn` to simultaneously install node.
 2. `yarn install`
 
+Heads up: `yarn install` might get re-run for you behind the scenes under a number of circumstances. For instance,
+- [Guard is configured to re-run yarn install](https://github.com/harvard-lil/h2o/blob/master/Guardfile#L10) when package.json changes
+- Rails includes a `yarn:install` task that may be called from other Rails/Rake tasks, including `assets:precompile`
+- Webpacker also runs `yarn:install` under certain circumstances
+
+[We disabled some of the magic](https://github.com/harvard-lil/h2o/blob/master/Rakefile) to give us more control. You might want to keep an eye on your console, in case you are expecting `yarn install` to run automatically some place we've disabled it, or in case it runs some time when you aren't expecting it!
+
 ### Set up the Postgres database
 
 1. Install postgres ~9.6 (if missing). Note: `brew install postgres` now installs postgres 10+. To install 9.6.5 via Homebrew, install postgres using the specific version formula (`brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d014fa223f77bee4b4097c5e80faa0954e28182f/Formula/postgresql.rb`) and then run `brew switch postgres 9.6.5`

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ H2o::Application.load_tasks
 
 Rake::Task['yarn:install'].clear
 namespace :yarn do
-  desc "Override yarn:install. Don't do anything!"
+  desc "Overridden yarn:install. Don't do anything!"
   task :install => [:environment] do
     puts "Skipping yarn:install"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,19 @@
 require File.expand_path('../config/application', __FILE__)
 
 H2o::Application.load_tasks
+
+Rake::Task['yarn:install'].clear
+namespace :yarn do
+  desc "Override yarn:install. Don't do anything!"
+  task :install => [:environment] do
+    puts "Skipping yarn:install"
+  end
+end
+
+Rake::Task['webpacker:yarn_install'].clear
+namespace :webpacker do
+  desc "Overridden webpacker:yarn_install. Don't do anything!"
+  task :yarn_install => [:environment] do
+    puts "Skipping webpacker:yarn_install"
+  end
+end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -4,3 +4,7 @@
   tmp/restart.txt
   tmp/caching-dev.txt
 ).each { |path| Spring.watch(path) }
+
+# Uncomment to suppress output from Spring.
+# See https://github.com/harvard-lil/h2o/issues/743
+# Spring.quiet = true

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -27,6 +27,10 @@ environment.plugins.append('Provide', new webpack.ProvidePlugin({
   jQuery: 'jquery'
 }));
 
+// Uncomment to suppress output except on error.
+// See https://github.com/harvard-lil/h2o/issues/743
+//environment.config.stats = 'errors-only'
+
 environment.loaders.append('vue', vue);
 environment.plugins.append('vue-loader', new VueLoaderPlugin());
 module.exports = environment;


### PR DESCRIPTION
This PR has a few tweaks suggested by the explorations in https://github.com/harvard-lil/h2o/issues/744 and https://github.com/harvard-lil/h2o/issues/743.

1) It suppresses some of the automatic calls to `yarn install`.

If merged, stage/prod deployments should be altered to include an explicit call to `yarn install --frozen-lockfile --check-files`. This command defaults to `NODE_ENV=development`; if you want only production requirements installed, set `NODE_ENV=production`.

2) It sets Travis to compile assets without the assistance of Spring, to prevent unwanted output and prevent spurious reports that asset compilation has failed. 

3) It adds, in comments, another option for suppressing unwanted output locally. If stage/prod calls to `precompile:assets`, which do not (should not!) use Spring, are spuriously reporting failed compilation, we can consider uncommenting one or both lines.

Both the above issues are still pending; I'll keep my eye on them.