### PR TITLE
Watch for changes in css/scss when precompiling assets.

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -7,11 +7,13 @@ default: &default
   public_output_path: packs
   cache_path: tmp/cache/webpacker
   check_yarn_integrity: false
+  # if `webpack_compile_output: true`, a webpack build log will print
+  # to stdout during `assets:precompile` after successful builds
   webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['app/assets/javascripts']
+  resolved_paths: ['app/assets/javascripts', 'app/assets/stylesheets']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
This appears to do the job: without this line, locally, calls to `precompile:assets` do NOT detect changes to scss; with it, changes are detected and new packs/bundles are emitted!

I tried running locally with Guard, and with `rails s`, before and after, and the addition doesn't appear to break any of those setups.... Though again, as a newcomer to this project, I'm not sure.