### PR TITLE
Tweak css to test build process

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -24,4 +24,7 @@
       margin-bottom: 10px;
     }
   }
+  a {
+    text-decoration: underline !important;
+  }
 }


### PR DESCRIPTION
This underlines links on about, terms-of-service, etc. `!important` because some other code is using `!important` to remove the underlines....

We can reverse this if we want, it's just to test the build.... Though I'd argue that most links should be underlined 😉 