### PR TITLE
Pin version of Chrome and Chromedriver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 addons:
   apt:
     packages:
-      - google-chrome-stable
+      - google-chrome-stable=74.0.3729.131-1
       - wdiff
   postgresql: "9.4"
   artifacts:
@@ -22,7 +22,7 @@ rvm:
 before_install:
   - nvm install 6
   - npm install yarn -g && yarn install --frozen-lockfile --check-files
-  - wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - mv chromedriver ~/bin/chromedriver
   - chmod +x ~/bin/chromedriver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    image: h2o:0.4
+    image: h2o:0.5
     tty: true
     command: bash
     environment:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
-    && apt-get -y install google-chrome-stable \
-    && wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip \
+    && apt-get -y install google-chrome-stable=74.0.3729.131-1 \
+    && wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip \
     && apt-get -y install unzip \
     && unzip chromedriver_linux64.zip \
     && mv chromedriver /usr/bin/chromedriver \


### PR DESCRIPTION
I cannot imagine how I landed on version 2.41 of Chromedriver in my initial installation.... this pins Chrome to the version being distributed today via `http://dl.google.com/linux/chrome/deb/ stable main` and the matching version of Chromedriver. Works in Docker; syntax may be incorrect for Travis.

We're not positive this is precisely correct for the long run; I'll definitely readdress if this technique proves to be brittle.