### PR TITLE
Add basic server side rendering of resources via Vue SSR

### DIFF
--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -64,7 +64,8 @@ export default {
     },
 
     resourceId() {
-      return document.querySelector("header.casebook").dataset.resourceId;
+      const header = document.querySelector("header.casebook");
+      return header ? header.dataset.resourceId : null;
     }
   },
   methods: {

--- a/lib/vue/ssr.js
+++ b/lib/vue/ssr.js
@@ -1,0 +1,30 @@
+import { createRenderer } from "vue-server-renderer";
+import Vue from "vue/dist/vue.esm";
+import store from "store/index";
+import TheResourceBody from "components/TheResourceBody";
+
+process.stdin.setEncoding('utf8');
+
+let data = '';
+process.stdin.on('readable', () => {
+  let chunk;
+  while ((chunk = process.stdin.read()) !== null) {
+    data += chunk;
+  }
+});
+
+process.stdin.on('end', () => {
+  const json = JSON.parse(data);
+  store.commit('annotations/append', json.annotations);
+
+  const app = new Vue({
+    store,
+    render: h => h(TheResourceBody, {props: {resource: {content: json.content}}})
+  });
+
+  const renderer = createRenderer();
+  renderer.renderToString(app, (err, html) => {
+    if (err) throw err;
+    process.stdout.write(html);
+  });
+});

--- a/lib/vue/ssr.rb
+++ b/lib/vue/ssr.rb
@@ -1,0 +1,28 @@
+require 'tempfile'
+
+module Vue
+  module SSR
+    def self.compile
+      file = Tempfile.new('vue_ssr.js')
+      begin
+        `NODE_ENV=production bin/webpack --entry #{Rails.root.join('lib','vue','ssr.js')} --output #{file.path} --config #{Rails.root.join('config','webpack','test.js')} --target node --mode production`
+        yield file.path
+      ensure
+        file.close
+        file.unlink
+      end
+    end
+
+    def self.render content, annotations = []
+      self.compile do |script|
+        node_cmd = "node -r #{Rails.root.join('test','javascript','mocha_setup.js')} #{script}"
+        IO.popen(node_cmd, 'r+') do |io|
+          io.write({content: content,
+                    annotations: annotations}.to_json)
+          io.close_write
+          io.read
+        end
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.29",
     "sinon": "^7.3.2",
+    "vue-server-renderer": "^2.6.10",
     "webpack-dev-server": "^3.3.1",
     "xhr-mock": "^2.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4438,7 +4438,7 @@ lodash.tail@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
-lodash.template@^4.2.4:
+lodash.template@^4.2.4, lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
   integrity sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=
@@ -6715,6 +6715,13 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.2.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  dependencies:
+    path-parse "^1.0.6"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -6866,7 +6873,7 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-serialize-javascript@^1.4.0:
+serialize-javascript@^1.3.0, serialize-javascript@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
   integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
@@ -7071,6 +7078,11 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
 
 source-map@^0.4.2:
   version "0.4.4"
@@ -7837,6 +7849,20 @@ vue-scrollto@^2.13.0:
   integrity sha512-FmJncIrXvsqvyVAN55Trc2CQWVDyxuMgdQQp1Q9I9bhoEi7XXpvXXQonhbFBktzNggJf1rpfHpVqa8KLhPeePQ==
   dependencies:
     bezier-easing "2.1.0"
+
+vue-server-renderer@^2.6.10:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.6.10.tgz#cb2558842ead360ae2ec1f3719b75564a805b375"
+  integrity sha512-UYoCEutBpKzL2fKCwx8zlRtRtwxbPZXKTqbl2iIF4yRZUNO/ovrHyDAJDljft0kd+K0tZhN53XRHkgvCZoIhug==
+  dependencies:
+    chalk "^1.1.3"
+    hash-sum "^1.0.2"
+    he "^1.1.0"
+    lodash.template "^4.4.0"
+    lodash.uniq "^4.5.0"
+    resolve "^1.2.0"
+    serialize-javascript "^1.3.0"
+    source-map "0.5.6"
 
 vue-style-loader@^4.1.0:
   version "4.1.2"


### PR DESCRIPTION
#677 

Usage via Ruby:

```ruby
resource = Content::Resource.last # grab a Resource with a Case
Vue::SSR.render(resource.resource.content, resource.annotations) # => html string
```

This currently uses webpack to build the ssr.js file on each
invocation, which is inefficient but good for dev. Given that we're
going to be pairing this with PANDOC work, it would make sense to
optimize this with a proper deploy-time build of ssr.js at that point.