### PR TITLE
Sanitize or escape user-supplied values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
 cache:
   bundler: true
   yarn: true
+jdk:
+  - openjdk8
 rvm:
   - 2.4.1
 before_install:

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -6,25 +6,21 @@ class PasswordResetsController < ApplicationController
     @user = {email_address: params.fetch(:email_address, '')}
   end
 
-  def html_safe x
-    x.html_safe
-  end
-
   def create
     account_email = params.fetch(:user, {}).fetch(:email_address, nil)
     if account_email.blank?
-      flash[:error] = I18n.t('users.reset-password.blank.html', sent_to: account_email, sign_up_path: new_user_path(email_address: account_email)).html_safe
+      flash[:error] = I18n.t('users.reset-password.blank.html').html_safe
       return redirect_to new_password_reset_path
     end
 
     @user = User.where(email_address: account_email).first
     if @user.nil?
-      flash[:error] = I18n.t('users.reset-password.not-found.html', sent_to: account_email, sign_up_path: new_user_path(user: {email_address: account_email})).html_safe
+      flash[:error] = I18n.t('users.reset-password.not-found.html', sent_to: html_escape(account_email), sign_up_path: html_escape(new_user_path(user: {email_address: account_email}))).html_safe
       return redirect_to new_password_reset_path(email_address: account_email)
     end
 
     @user.deliver_password_reset_instructions!
-    flash[:success] = I18n.t('users.reset-password.success.html', sent_to: @user.email_address).html_safe
+    flash[:success] = I18n.t('users.reset-password.success.html', sent_to: html_escape(@user.email_address)).html_safe
     redirect_to new_user_session_path(email_address: @user.email_address)
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -112,7 +112,7 @@ class Case < ApplicationRecord
     resources = Content::Resource.where(resource_type: self.class.name, resource_id: self.id)
     resources.each do |resource|
       casebook = resource.casebook
-      links += "<div><a href=#{resource_path(casebook, resource)}>#{casebook.title} [#{casebook.created_at.year}] - #{casebook.owner}</a></div>".html_safe
+      links += "<div><a href=#{resource_path(casebook, resource)}>#{html_escape(casebook.title)} [#{casebook.created_at.year}] - #{html_escape(casebook.owner)}</a></div>".html_safe
     end
     links.html_safe
   end

--- a/app/models/default.rb
+++ b/app/models/default.rb
@@ -62,7 +62,7 @@ class Default < ApplicationRecord
     resources = Content::Resource.where(resource_type: self.class.name, resource_id: self.id)
     resources.each do |resource|
       casebook = resource.casebook
-      links += "<div><a href=#{resource_path(casebook, resource)}>#{casebook.title} [#{casebook.created_at.year}] - #{casebook.owner}</a></div>".html_safe
+      links += "<div><a href=#{resource_path(casebook, resource)}>#{html_escape(casebook.title)} [#{casebook.created_at.year}] - #{html_escape(casebook.owner)}</a></div>".html_safe
     end
     links.html_safe
   end

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -76,6 +76,12 @@ class TextBlock < ApplicationRecord
     self.content.gsub!(/\p{Cc}/, "")
   end
 
+  def sanitized_to_json
+    # wrap built-in method, to include a sanitation step
+    self.content = ActionController::Base.helpers.sanitize(self.content)
+    self.to_json
+  end
+
   def associated_resources
     links = ""
     resources = Content::Resource.where(resource_type: self.class.name, resource_id: self.id)

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -81,7 +81,7 @@ class TextBlock < ApplicationRecord
     resources = Content::Resource.where(resource_type: self.class.name, resource_id: self.id)
     resources.each do |resource|
       casebook = resource.casebook
-      links += "<div><a href=#{resource_path(casebook, resource)}>#{html_esccape(casebook.title)} [#{casebook.created_at.year}] - #{html_escape(casebook.owner)}</a></div>".html_safe
+      links += "<div><a href=#{resource_path(casebook, resource)}>#{html_escape(casebook.title)} [#{casebook.created_at.year}] - #{html_escape(casebook.owner)}</a></div>".html_safe
     end
     links.html_safe
   end

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -81,7 +81,7 @@ class TextBlock < ApplicationRecord
     resources = Content::Resource.where(resource_type: self.class.name, resource_id: self.id)
     resources.each do |resource|
       casebook = resource.casebook
-      links += "<div><a href=#{resource_path(casebook, resource)}>#{casebook.title} [#{casebook.created_at.year}] - #{casebook.owner}</a></div>".html_safe
+      links += "<div><a href=#{resource_path(casebook, resource)}>#{html_esccape(casebook.title)} [#{casebook.created_at.year}] - #{html_escape(casebook.owner)}</a></div>".html_safe
     end
     links.html_safe
   end

--- a/app/views/content/resources/_embed.erb
+++ b/app/views/content/resources/_embed.erb
@@ -1,5 +1,5 @@
 <% if resource.resource.is_a?(Case) || resource.resource.is_a?(TextBlock) %>
-<the-resource-body :resource="<%= resource.resource.to_json %>"
+<the-resource-body :resource="<%= resource.resource.try('sanitized_to_json') || resource.resource.to_json %>"
                    :editable="<%= editable || false %>"></the-resource-body>
 <% elsif resource.resource.is_a? Default %>
 <section class="resource link-resource">

--- a/app/views/content/resources/show.html.erb
+++ b/app/views/content/resources/show.html.erb
@@ -49,7 +49,7 @@
       </h3>
     <% end %>
     <p>
-      <%= @content.formatted_headnote %>
+      <%= sanitize @content.formatted_headnote %>
     </p>
   </section>
 <% else %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -65,7 +65,7 @@
       </h3>
     <% end %>
     <p>
-      <%= @content.formatted_headnote %>
+      <%= sanitize @content.formatted_headnote %>
     </p>
   </section>
 <% else %>


### PR DESCRIPTION
Subsequent to the recent discussion about user-supplied `<img src="">`, Jack was wondering how we handle other user-supplied values throughout the app. Investigation proved we could benefit from more careful handling of headnotes, and more careful handing of titles, usernames, and email addresses in a handful of spots. 

This PR runs headnotes through [Rail's sanitizer](https://github.com/rails/rails-html-sanitizer/blob/master/lib/rails/html/sanitizer.rb#L61) before rendering, and adds html-escaping in other places where user-supplied text is subsequently marked as `html_safe`. 

Experimentation suggests that Vuejs is stripping `script` tags from cases and textblocks before rendering. It would be good to get another set of eyes on this, especially from a dev more experienced with Vue to verify that we're okay. I'll plan to do more reading soon, to see if we can pin down its behavior.

Going forward, we should think about running headnotes, textblocks, and cases through `sanitize` on save. (We can't now, without shifting annotations, but once 812 lands....)