### PR TITLE
Possible? A more efficient TOC?

### DIFF
--- a/_python/main/templates/includes/table-of-contents.html
+++ b/_python/main/templates/includes/table-of-contents.html
@@ -27,8 +27,8 @@
                         {{ content.get_title }}
                       </div>
                       <div class="case-metadata-container">
-                        <div class="resource-case">{{ content.resource.citations.0.cite }}</div>
-                        <div class="resource-date">{{ content.resource.date_year }}</div>
+                        <div class="resource-case">{{ content.citations.0.cite }}</div>
+                        <div class="resource-date">{{ content.date_year }}</div>
                       </div>
                     </div>
                     <div class="resource-type-container">


### PR DESCRIPTION
Building a casebook's TOC feels a little sluggish, I think because of all the calls to the DB to pull up metadata on related resources. We can't presently do a `prefetch_related`, because `ContentNode`s are related to `Link`, `Text` AND `Case` objects through a single `resource_id` key.

I think these annotations are ALMOST everything we need.... except for calls to `get_name`, which happen with each type of related resource. That can be replicated too, with more subqueries, and calls to `Coalesce`... but this is starting to feel ridiculous. We could maybe do some slick SQL, like with search.... but that also feels ridiculous. 

It's not THAT sluggish... Maybe fine as is. Maybe we can, in the future, simplify the logic for things names, so that we can simply query a single field in the normal way (e.g., merge columns, and add a default value to the model).