### PR TITLE
Handle repeated deletions of annotations in drafts

### DIFF
--- a/app/services/merge_draft_into_published_casebook.rb
+++ b/app/services/merge_draft_into_published_casebook.rb
@@ -88,8 +88,8 @@ class MergeDraftIntoPublishedCasebook
 
   def deleted_annotations
     revisions.where(field: "deleted_annotation").each do |revision|
-      ancestor_annotation = Content::Annotation.find(revision.value.to_i)
-      if ancestor_annotation.present?
+      ancestor_annotation = Content::Annotation.find_by(:id => revision.value.to_i)
+      if ancestor_annotation
         ancestor_annotation.destroy!
       end
       revision.destroy!


### PR DESCRIPTION
When you want to edit an already-published casebook, you first make a draft, which is in actuality a complete copy of the whole textbook. If you delete one of the draft's annotations, there is code that matches the draft annotation with the original annotation, and makes a note in the table UnpublishedRevisions, "be sure to delete the original annotation, when publishing the draft!" If there is an annotation on characters 10-20, and make a draft, delete that annotation, then create another annotation in exactly the same spot, and then delete THAT one, it will make TWO notes in UnpublishedRevisions: one for each deletion. During publication/merging, this loop errors on the second attempt to delete the original annotation: `find` errors if no record is present; `find_by` does not.