### PR TITLE
First pass at whitelisting Django routes

### DIFF
--- a/_python/config/settings/settings_dev.py
+++ b/_python/config/settings/settings_dev.py
@@ -1,6 +1,6 @@
 from .settings_base import *  # noqa
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', '.local', 'backend']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', '.local', 'backend', 'django']
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - ./docker/h2o.conf:/etc/nginx/conf.d/default.conf
     ports:
       - 8002:80
+      - 8003:81
     depends_on:
       - web
       - python

--- a/docker/h2o.conf
+++ b/docker/h2o.conf
@@ -31,7 +31,7 @@ map $request_uri $dest {
     /privacy-policy/                          django;
     ~^/resources/[0-9]+/annotations$          django;
     ~^/resources/[0-9]+/annotations\.[^/]+/$  django;
-    ~^/search/.*$                             django;
+    ~^/search/?.*$                            django;
     /terms-of-service/                        django;
     ~^/users/[0-9]+/$                         django;
     ~^/.*$                                    rails;

--- a/docker/h2o.conf
+++ b/docker/h2o.conf
@@ -31,7 +31,7 @@ map $request_uri $dest {
     /privacy-policy/                          django;
     ~^/resources/[0-9]+/annotations$          django;
     ~^/resources/[0-9]+/annotations\.[^/]+/$  django;
-    /search/                                  django;
+    ~^/search/.*$                             django;
     /terms-of-service/                        django;
     ~^/users/[0-9]+/$                         django;
     ~^/.*$                                    rails;

--- a/docker/h2o.conf
+++ b/docker/h2o.conf
@@ -12,3 +12,46 @@ server {
         proxy_next_upstream error timeout http_404 http_500 http_502 http_503 http_504 non_idempotent;
     }
 }
+
+upstream rails { server web:8000; }
+upstream django { server python:8000; }
+
+map $request_uri $dest {
+    /                                         django;
+    /about/                                   django;
+    ~^/casebooks/[^/]+/$                      django;
+    ~^/casebooks/[^/]+/resources/[^/]+/$      django;
+    ~^/casebooks/[^/]+/sections/[^/]+/$       django;
+    ~^/cases/[0-9]+/                          django;
+    /faq/                                     django;
+    /pages/about/                             django;
+    /pages/faq/                               django;
+    /pages/privacy-policy/                    django;
+    /pages/terms-of-service/                  django;
+    /privacy-policy/                          django;
+    ~^/resources/[0-9]+/annotations$          django;
+    ~^/resources/[0-9]+/annotations\.[^/]+/$  django;
+    /search/                                  django;
+    /terms-of-service/                        django;
+    ~^/users/[0-9]+/$                         django;
+    ~^/.*$                                    rails;
+}
+
+server {
+    listen 81;
+    listen [::]:81;
+    location / {
+         if ($request_method = POST ) {
+            proxy_pass http://rails;
+        }
+        if ($request_method = PATCH ) {
+            proxy_pass http://rails;
+        }
+        if ($request_method = PUT ) {
+            proxy_pass http://rails;
+        }
+        if ($request_method = GET ) {
+            proxy_pass http://$dest;
+        }
+    }
+}


### PR DESCRIPTION
This exposes the application locally at port 8003, manually whitelisting routes we want to send to Django in `docker/h2o.conf`. To try it, run, in three separate terminals,
```
docker-compose up
bash docker/run.sh
docker-compose exec python ./manage.py runrver 0.0.0.0:8000
```