### PR TITLE
Add pytest integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ package-lock.json
 *.dump
 .byebug_history
 .tmp
+
+# IntelliJ IDEA
+*.iml

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -1,0 +1,177 @@
+import re
+
+import pytest
+
+import factory
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.response import Response
+
+from main.models import ContentNode, User, Casebook, Section, Resource, ContentCollaborator
+
+
+# This file defines test fixtures available to all tests.
+# To see available fixtures run pytest --fixtures
+
+
+### helpers ###
+
+def register_factory(cls):
+    """
+        Decorator to take a factory class and inject test fixtures. For example,
+
+            @register_factory
+            class UserFactory
+
+        will inject the fixtures "user_factory" (equivalent to UserFactory) and "user" (equivalent to UserFactory()).
+
+        This is basically the same as the @register decorator provided by the pytest_factoryboy package,
+        but because it's simpler it seems to work better with RelatedFactory and SubFactory.
+    """
+    camel_case_name = re.sub('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))', r'_\1', cls.__name__).lower()
+    globals()[camel_case_name] = pytest.fixture(lambda: cls)
+    globals()[camel_case_name.rsplit('_factory', 1)[0]] = pytest.fixture(lambda: cls())
+    return cls
+
+
+### model factories ###
+
+@register_factory
+class UserFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = User
+
+    persistence_token = ''
+    login_count = 0
+    attribution = "some name"
+    print_titles = True
+    print_dates_details = True
+    print_paragraph_numbers = True
+    print_annotations = True
+    print_highlights = ''
+    print_font_face = ''
+    print_font_size = ''
+    default_show_comments = True
+    default_show_paragraph_numbers = True
+    hidden_text_display = True
+    print_links = True
+    toc_levels = ''
+    print_export_format = ''
+    verified_email = True
+
+
+@register_factory
+class ContentNodeFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = ContentNode
+
+    public = True
+    cloneable = True
+    created_at = timezone.now()
+    ordinals=[]
+
+
+@register_factory
+class CasebookFactory(ContentNodeFactory):
+    class Meta:
+        model = Casebook
+
+    contentcollaborator_set = factory.RelatedFactory('conftest.ContentCollaboratorFactory', 'content')
+    title = factory.Sequence(lambda n: 'Some Title %s' % n)
+
+
+@register_factory
+class SectionFactory(ContentNodeFactory):
+    class Meta:
+        model = Section
+
+    casebook = factory.SubFactory(CasebookFactory)
+
+
+@register_factory
+class ResourceFactory(ContentNodeFactory):
+    class Meta:
+        model = Resource
+
+    casebook = factory.SubFactory(CasebookFactory)
+    # todo:
+    resource_type = "todo"
+    resource_id = 999
+
+
+@register_factory
+class ContentCollaboratorFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = ContentCollaborator
+
+    user = factory.SubFactory(UserFactory)
+    content = factory.SubFactory(CasebookFactory)
+    role = 'owner'
+    created_at = timezone.now()
+    updated_at = timezone.now()
+    has_attribution = True
+
+
+### fixture functions ###
+
+# these can be injected on demand with getfixture() in doctests, or as function arguments in test files
+
+@pytest.fixture
+def content_node_tree(content_node_factory, db):
+    """
+        Return a list of ContentNodes representing a tree like:
+            - root
+                - c_1
+                    - c_1_1
+                    - c_1_2
+                - c_2
+    """
+    root = content_node_factory()
+    c_1 = content_node_factory(ancestry=str(root.id))
+    c_2 = content_node_factory(ancestry=str(root.id))
+    c_1_1 = content_node_factory(ancestry="%s/%s" % (c_1.ancestry, c_1.id))
+    c_1_2 = content_node_factory(ancestry="%s/%s" % (c_1.ancestry, c_1.id))
+    return [root, c_1, c_2, c_1_1, c_1_2]
+
+
+@pytest.fixture
+def user_client(db, user_factory):
+    """
+        Return a test client logged in as a new user.
+    """
+    client = Client()
+    user = user_factory()
+    # TODO: force_login uses Django auth system; need to patch
+    # client.force_login(user=user)
+    client.user = user  # make user available to tests
+    return client
+
+
+### global functions ###
+
+# these are injected into the namespace for all doctests by inject_helpers
+
+def check_response(response, status_code=200, content_type=None, content_includes=None, content_excludes=None):
+    assert response.status_code == status_code
+
+    # check content-type if not a redirect
+    if response['content-type']:
+        # For rest framework response, expect json; else expect html.
+        if not content_type:
+            if type(response) == Response:
+                content_type = "application/json"
+            else:
+                content_type = "text/html"
+        assert response['content-type'].split(';')[0] == content_type
+
+    if content_includes:
+        assert content_includes in response.content.decode()
+    if content_excludes:
+        assert content_excludes not in response.content.decode()
+
+
+@pytest.fixture(autouse=True)
+def inject_helpers(doctest_namespace):
+    doctest_namespace["check_response"] = check_response
+    doctest_namespace["reverse"] = reverse

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -34,14 +34,14 @@ class ArInternalMetadata(TimestampedModel):
     value = models.CharField(max_length=255, blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'ar_internal_metadata'
 
 class SchemaMigration(models.Model):
     version = models.CharField(primary_key=True, max_length=255)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'schema_migrations'
 
 
@@ -49,7 +49,7 @@ class Session(TimestampedModel):
     data = models.TextField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'sessions'
 
 
@@ -61,7 +61,7 @@ class CaseCourt(TimestampedModel):
     capapi_id = models.IntegerField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'case_courts'
 
 
@@ -84,7 +84,7 @@ class Case(TimestampedModel):
     case_court = models.ForeignKey('CaseCourt', models.PROTECT, related_name='cases')
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'cases'
 
     def get_name(self):
@@ -110,7 +110,7 @@ class ContentAnnotation(TimestampedModel):
     resource = models.ForeignKey('ContentNode', models.PROTECT, related_name='annotations')
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'content_annotations'
 
 
@@ -125,7 +125,7 @@ class ContentCollaborator(TimestampedModel):
     content = models.ForeignKey('ContentNode', models.CASCADE)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'content_collaborators'
         unique_together = (('user', 'content'),)
 
@@ -158,7 +158,7 @@ class ContentNode(TimestampedModel):
     playlist_id = models.BigIntegerField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'content_nodes'
 
     @property
@@ -264,16 +264,29 @@ class ContentNode(TimestampedModel):
     # see https://github.com/stefankroes/ancestry/blob/master/lib/ancestry/materialized_path.rb
     ###
 
-    def child_ancestry(self):
-        """ Return ancestry value for children of this node. """
-        return "%s/%s" % (self.ancestry, self.pk) if self.ancestry else str(self.pk)
-
     def descendants(self):
-        """ Return all descendants of this node. """
-        return type(self).objects.filter(Q(ancestry=self.child_ancestry()) | Q(ancestry__startswith=self.child_ancestry()+"/"))
+        """
+            Return all descendants of this node.
+
+            >>> getfixture('db')  # allow db access
+            >>> root, c_1, c_2, c_1_1, c_1_2 = getfixture('content_node_tree')
+            >>> assert set(root.descendants()) == {c_1, c_2, c_1_1, c_1_2}
+            >>> assert set(c_1.descendants()) == {c_1_1, c_1_2}
+            >>> assert set(c_2.descendants()) == set()
+        """
+        child_ancestry = "%s/%s" % (self.ancestry, self.pk) if self.ancestry else str(self.pk)
+        return type(self).objects.filter(Q(ancestry=child_ancestry) | Q(ancestry__startswith=child_ancestry+"/"))
 
     def root(self):
-        """ Return root node for this node, or None if no ancestors. """
+        """
+            Return root node for this node, or None if no ancestors.
+
+            >>> getfixture('db')  # allow db access
+            >>> root, c_1, c_2, c_1_1, c_1_2 = getfixture('content_node_tree')
+            >>> assert root.root() is None
+            >>> assert c_1.root() == root
+            >>> assert c_1_1.root() == root
+        """
         if not self.ancestry:
             return None
         return type(self).objects.get(pk=self.ancestry.split("/")[0])
@@ -409,7 +422,7 @@ class Default(TimestampedModel):
     user = models.ForeignKey('User', on_delete=models.PROTECT, related_name='defaults')
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'defaults'
 
     def related_resources(self):
@@ -423,7 +436,7 @@ class RawContent(TimestampedModel):
     source_id = models.BigIntegerField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'raw_contents'
         unique_together = (('source_type', 'source_id'),)
 
@@ -437,7 +450,7 @@ class Role(TimestampedModel):
     authorizable_id = models.IntegerField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'roles'
 
     def __str__(self):
@@ -454,7 +467,7 @@ class RolesUser(TimestampedModel):
     role = models.ForeignKey(Role, blank=True, null=True, on_delete=models.CASCADE)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'roles_users'
 
 
@@ -477,7 +490,7 @@ class TextBlock(TimestampedModel):
     enable_responses = models.BooleanField()
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'text_blocks'
 
     def related_resources(self):
@@ -496,7 +509,7 @@ class UnpublishedRevision(TimestampedModel):
     annotation = models.ForeignKey('ContentAnnotation', blank=True, null=True, on_delete=models.CASCADE)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'unpublished_revisions'
 
 
@@ -555,7 +568,7 @@ class User(TimestampedModel):
     image_updated_at = models.DateTimeField(blank=True, null=True)
 
     class Meta:
-        managed = False
+        # managed = False
         db_table = 'users'
 
     @property

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -1,12 +1,13 @@
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
+from django.urls import reverse
 from django.views.generic import TemplateView
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 import json
 
+from conftest import check_response
 from .serializers import ContentAnnotationSerializer, CaseSerializer, TextBlockSerializer
 from .models import Casebook, Resource, Section, Case, User
 
@@ -57,6 +58,34 @@ def index(request):
 
 
 def dashboard(request, user_id):
+    """
+        Show given user's casebooks.
+
+        Given:
+
+        >>> db, casebook, client = [getfixture(f) for f in ['db', 'casebook', 'client']]
+        >>> user = casebook.collaborators.first()
+
+        All users can see public casebooks:
+
+        >>> response = client.get(reverse('dashboard', args=[user.id]))
+        >>> check_response(response, content_includes=casebook.title)
+
+        Other users cannot see non-public casebooks:
+
+        >>> casebook.public = False
+        >>> casebook.save()
+        >>> response = client.get(reverse('dashboard', args=[user.id]))
+        >>> check_response(response, content_excludes=casebook.title)
+
+        Users can see their own non-public casebooks:
+
+        # TODO: test auth
+
+        Admins can see a user's non-public casebooks:
+
+        # TODO: test auth
+    """
     user = get_object_or_404(User, pk=user_id)
     return render(request, 'dashboard.html', {'user': user})
 

--- a/_python/requirements.in
+++ b/_python/requirements.in
@@ -13,4 +13,5 @@ cryptography        # read ruby session cookies
 pytest
 pytest-django
 pytest-cov
+factory-boy        # create django model fixtures on demand
 

--- a/_python/requirements.txt
+++ b/_python/requirements.txt
@@ -113,6 +113,13 @@ django==2.2.4 \
 djangorestframework==3.10.2 \
     --hash=sha256:42979bd5441bb4d8fd69d0f385024a114c3cae7df0f110600b718751250f6929 \
     --hash=sha256:aedb48010ebfab9651aaab1df5fd3b4848eb4182afc909852a2110c24f89a359
+factory-boy==2.12.0 \
+    --hash=sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee \
+    --hash=sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370
+faker==2.0.2 \
+    --hash=sha256:45cc9cca3de8beba5a2da3bd82a6e5544f53da1a702645c8485f682366c15026 \
+    --hash=sha256:a6459ff518d1fc6ee2238a7209e6c899517872c7e1115510279033ffe6fe8ef3 \
+    # via factory-boy
 importlib-metadata==0.19 \
     --hash=sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8 \
     --hash=sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3 \
@@ -168,6 +175,10 @@ pytest-django==3.5.1 \
 pytest==5.0.1 \
     --hash=sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d \
     --hash=sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77
+python-dateutil==2.8.0 \
+    --hash=sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb \
+    --hash=sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e \
+    # via faker
 pytz==2019.2 \
     --hash=sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32 \
     --hash=sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7 \
@@ -178,11 +189,15 @@ rubymarshal==1.2.6 \
 six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
-    # via bleach, cryptography, django-extensions, packaging, pathlib2, pip-tools
+    # via bleach, cryptography, django-extensions, faker, packaging, pathlib2, pip-tools, python-dateutil
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873 \
     # via django
+text-unidecode==1.3 \
+    --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
+    --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93 \
+    # via faker
 wcwidth==0.1.7 \
     --hash=sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e \
     --hash=sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c \

--- a/_python/setup.cfg
+++ b/_python/setup.cfg
@@ -1,0 +1,7 @@
+## http://pytest.org/latest/customize.html#adding-default-options
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+addopts = --doctest-modules --nomigrations
+# these options can be used for faster test discovery if necessary:
+# testpaths = main/tests
+# norecursedirs = node_modules test_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: ./_python/Dockerfile
-    image: h2o-python:0.1
+    image: h2o-python:0.2
     tty: true
     command: bash
     environment:


### PR DESCRIPTION
First pass at adding a testing framework. Tests can be run with `$ pytest` in the _python directory, from the python docker container.

I didn't write a ton of tests, but (for purposes of discussion) included docstring tests for a couple of model functions and a view function as examples of how we could do those. The other place tests can live of course is in files like `main/tests/test_views.py`, which may be better for some things, but I wanted to see what the doctest version looked like.

I always end up hating test fixtures, so this is yet another reinvention of that! All the fixtures live in conftest.py. The file includes three sections:

- Factories, which use a lot of subfactories and relatedfactories so you can e.g. create a casebook and it comes along with a new user who owns it. (Or if you already have a user, you can override the default with like `casebook_factory(contentcollaborator_set__user=user)`.) Each factory has a factory fixture and an instance fixture that are registered automatically.
- Fixtures: functions you can import on demand in a test (because they imply some setup and teardown that shouldn't be done for every test)
- Globals: helper functions that are injected into the namespace for every doctest

It's all so shiny and new! Let's talk about how all this works because it will very quickly become old and tangled.