### PR TITLE
Python stuff: resource prefetch, django-debug-toolbar, tests with logged-in users

### DIFF
--- a/_python/.gitignore
+++ b/_python/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.sqlite3
 .python-version
+settings.py

--- a/_python/Dockerfile
+++ b/_python/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG=C.UTF-8 \
 RUN mkdir /app
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y nano
+RUN apt-get update && apt-get install -y nano postgresql-client
 
 # nodejs
 # write a .yarnrc that will only be found inside the docker guest, and will cause

--- a/_python/config/settings/settings.py.example
+++ b/_python/config/settings/settings.py.example
@@ -1,0 +1,14 @@
+# This file is necessary only if you want to modify default settings from settings_dev.py.
+# To use, copy to settings.py:
+
+from .settings_dev import *
+
+
+STATIC_URL = '/static/'
+
+# log all SQL statements:
+# LOGGING['loggers']['django.db.backends'] = {
+#     'level': 'DEBUG',
+#     'handlers': ['console'],
+#     'propagate': False,
+# }

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -153,3 +153,28 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'GUIDE_URL',
     'BLOG_URL'
 )
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+        },
+    },
+    'formatters': {
+        'verbose': {
+            'format': '%(asctime)s %(levelname)s module=%(module)s, '
+                      'process_id=%(process)d, %(message)s'
+        }
+    },
+}

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -155,6 +155,9 @@ TEMPLATE_VISIBLE_SETTINGS = (
 )
 
 
+AUTH_USER_MODEL = 'main.User'
+
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/_python/config/settings/settings_dev.py
+++ b/_python/config/settings/settings_dev.py
@@ -22,3 +22,22 @@ RAILS_SECRET_KEY_BASE = 'd3a3c86a4791903d56cd6a4d3aa4e18fbda088c4e88655d0b0ed39e
 
 # load assets from prod for now
 STATIC_URL = 'https://opencasebook.org/'
+
+# django-debug-toolbar:
+# ddt can be useful but also be a hassle, so it only runs optionally, if you choose to `pip install django-debug-toolbar`
+# If installed, there will be a sidebar when viewing front-end pages, including useful tools such as a SQL profiler.
+import sys
+if 'pytest' not in sys.modules:  # don't run this from tests
+    try:
+        import debug_toolbar  # noqa
+        if 'debug_toolbar' not in INSTALLED_APPS:
+            INSTALLED_APPS += (
+                'debug_toolbar',
+            )
+            MIDDLEWARE.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+            INTERNAL_IPS = ['127.0.0.1']
+            DEBUG_TOOLBAR_CONFIG = {
+                'SHOW_TOOLBAR_CALLBACK': 'main.utils.show_debug_toolbar'
+            }
+    except ImportError:
+        pass

--- a/_python/config/urls.py
+++ b/_python/config/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
+from django.conf import settings
 from django.urls import path, include
 from main.admin import admin_site
 
@@ -22,3 +22,11 @@ urlpatterns = [
     path('search/', include('search.urls')),
     path('admin/', admin_site.urls),
 ]
+
+# use django-debug-toolbar if installed
+if settings.DEBUG:
+    try:
+        import debug_toolbar
+        urlpatterns += [path('__debug__/', include(debug_toolbar.urls))]
+    except ImportError:
+        pass

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -1,14 +1,13 @@
 import re
-
 import pytest
-
 import factory
-from django.test import Client
+
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.response import Response
 
-from main.models import ContentNode, User, Casebook, Section, Resource, ContentCollaborator
+from main.models import ContentNode, User, Casebook, Section, Resource, ContentCollaborator, Role, Default, TextBlock, \
+    Case, CaseCourt
 
 
 # This file defines test fixtures available to all tests.
@@ -30,12 +29,23 @@ def register_factory(cls):
         but because it's simpler it seems to work better with RelatedFactory and SubFactory.
     """
     camel_case_name = re.sub('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))', r'_\1', cls.__name__).lower()
-    globals()[camel_case_name] = pytest.fixture(lambda: cls)
-    globals()[camel_case_name.rsplit('_factory', 1)[0]] = pytest.fixture(lambda: cls())
+
+    @pytest.fixture
+    def factory_fixture(db):
+        return cls
+
+    @pytest.fixture
+    def instance_fixture(db):
+        return cls()
+
+    globals()[camel_case_name] = factory_fixture
+    globals()[camel_case_name.rsplit('_factory', 1)[0]] = instance_fixture
+
     return cls
 
 
 ### model factories ###
+
 
 @register_factory
 class UserFactory(factory.DjangoModelFactory):
@@ -59,6 +69,8 @@ class UserFactory(factory.DjangoModelFactory):
     toc_levels = ''
     print_export_format = ''
     verified_email = True
+    verified_professor = False
+    professor_verification_requested = False
 
 
 @register_factory
@@ -87,6 +99,7 @@ class SectionFactory(ContentNodeFactory):
         model = Section
 
     casebook = factory.SubFactory(CasebookFactory)
+    ordinals = [1]
 
 
 @register_factory
@@ -95,9 +108,8 @@ class ResourceFactory(ContentNodeFactory):
         model = Resource
 
     casebook = factory.SubFactory(CasebookFactory)
-    # todo:
-    resource_type = "todo"
-    resource_id = 999
+    resource_type = None
+    resource_id = None
 
 
 @register_factory
@@ -113,12 +125,66 @@ class ContentCollaboratorFactory(factory.DjangoModelFactory):
     has_attribution = True
 
 
+@register_factory
+class DefaultFactory(factory.DjangoModelFactory):
+    # actually Link
+    class Meta:
+        model = Default
+
+    name = factory.Sequence(lambda n: 'Some Link Name %s' % n)
+    description = factory.Sequence(lambda n: 'Some Link Description %s' % n)
+    url = factory.Sequence(lambda n: 'https://example.com/%s' % n)
+    public = True
+    created_via_import = False
+    user = factory.SubFactory(UserFactory)
+
+
+@register_factory
+class TextBlockFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = TextBlock
+
+    name = factory.Sequence(lambda n: 'Some TextBlock Name %s' % n)
+    description = factory.Sequence(lambda n: 'Some TextBlock Description %s' % n)
+    content = factory.Sequence(lambda n: 'Some TextBlock Content %s' % n)
+    version = 1
+    public = True
+    created_via_import = False
+    annotations_count = 0
+    user = factory.SubFactory(UserFactory)
+    enable_feedback = True
+    enable_discussions = True
+    enable_responses = True
+
+
+@register_factory
+class CaseCourtFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = CaseCourt
+
+    name_abbreviation = factory.Sequence(lambda n: 'Sm. Ct. Name Abbrev. %s' % n)
+    name = factory.Sequence(lambda n: 'Some Court Name %s' % n)
+
+
+@register_factory
+class CaseFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Case
+
+    name_abbreviation = factory.Sequence(lambda n: 'Foo%s v. Bar%s' % (n, n))
+    name = factory.Sequence(lambda n: 'Foo Foo%s vs. Bar Bar%s' % (n, n))
+    public = True
+    created_via_import = False
+    content = factory.Sequence(lambda n: 'Some Case Content %s' % n)
+    annotations_count = 0
+    case_court = factory.SubFactory(CaseCourtFactory)
+
 ### fixture functions ###
 
 # these can be injected on demand with getfixture() in doctests, or as function arguments in test files
 
 @pytest.fixture
-def content_node_tree(content_node_factory, db):
+def content_node_tree(content_node_factory):
     """
         Return a list of ContentNodes representing a tree like:
             - root
@@ -136,16 +202,37 @@ def content_node_tree(content_node_factory, db):
 
 
 @pytest.fixture
-def user_client(db, user_factory):
-    """
-        Return a test client logged in as a new user.
-    """
-    client = Client()
+def admin_user(user_factory):
     user = user_factory()
-    # TODO: force_login uses Django auth system; need to patch
-    # client.force_login(user=user)
-    client.user = user  # make user available to tests
-    return client
+    role, created = Role.objects.get_or_create(name='superadmin')
+    user.roles.add(role)
+    return user
+
+
+@pytest.fixture
+def full_casebook(casebook_factory):
+    """
+        Create:
+            - owner
+            - casebook
+                - section
+                    - resource -> textblock
+                    - resource -> case
+                    - resource -> link
+                    - resource -> textblock
+                    - resource -> case
+                    - resource -> link
+    """
+    user = UserFactory()
+    casebook = casebook_factory(contentcollaborator_set__user=user)
+    section = SectionFactory(casebook=casebook)
+    ResourceFactory(casebook=casebook, ordinals=[1, 1], resource_type='TextBlock', resource_id=TextBlockFactory(user=user).id)
+    ResourceFactory(casebook=casebook, ordinals=[1, 2], resource_type='Case', resource_id=CaseFactory().id)
+    ResourceFactory(casebook=casebook, ordinals=[1, 3], resource_type='Default', resource_id=DefaultFactory(user=user).id)
+    ResourceFactory(casebook=casebook, ordinals=[1, 4], resource_type='TextBlock', resource_id=TextBlockFactory(user=user).id)
+    ResourceFactory(casebook=casebook, ordinals=[1, 5], resource_type='Case', resource_id=CaseFactory().id)
+    ResourceFactory(casebook=casebook, ordinals=[1, 6], resource_type='Default', resource_id=DefaultFactory(user=user).id)
+    return casebook
 
 
 ### global functions ###

--- a/_python/main/middleware.py
+++ b/_python/main/middleware.py
@@ -58,6 +58,11 @@ def get_rails_user(request):
     """
         Implement what we need from https://github.com/binarylogic/authlogic
     """
+    # special case -- tests can inject a User object into the environ under 'as_user'
+    # this is necessary only because our rails hack doesn't allow us to use `client.force_login(user)` in tests
+    if 'as_user' in request.environ and type(request.environ['as_user']) == User:
+        return request.environ['as_user']
+
     # fetch user, if exists, from request.rails_session['user_credentials_id']
     if not 'user_credentials_id' in request.rails_session:
         return AnonymousUser()

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -638,6 +638,10 @@ class User(TimestampedModel):
     image_file_size = models.IntegerField(blank=True, null=True)
     image_updated_at = models.DateTimeField(blank=True, null=True)
 
+    EMAIL_FIELD = 'email_address'
+    USERNAME_FIELD = 'login'
+    REQUIRED_FIELDS = []  # used by createsuperuser
+
     class Meta:
         # managed = False
         db_table = 'users'

--- a/_python/main/templates/includes/table-of-contents.html
+++ b/_python/main/templates/includes/table-of-contents.html
@@ -27,8 +27,8 @@
                         {{ content.get_title }}
                       </div>
                       <div class="case-metadata-container">
-                        <div class="resource-case">{{ content.resource.citations.0.cite }}</div>
-                        <div class="resource-date">{{ content.resource.decision_date | date:"Y" }}</div>
+                        <div class="resource-case">{{ content.citations.0.cite }}</div>
+                        <div class="resource-date">{{ content.decision_date | date:"Y" }}</div>
                       </div>
                     </div>
                     <div class="resource-type-container">

--- a/_python/main/utils.py
+++ b/_python/main/utils.py
@@ -1,5 +1,5 @@
 import bleach
-import django.core.paginator
+from django.conf import settings
 
 
 def sanitize(html):
@@ -9,8 +9,8 @@ def sanitize(html):
     return bleach.clean(html, tags=['p', 'br', *bleach.sanitizer.ALLOWED_TAGS])
 
 
-class Paginator(django.core.paginator.Paginator):
-    @property
-    def short_page_range(self):
-        return (i for i in self.page_range if i <= 2 or i >= self.num_pages-1 or abs(i-self.num_pages))
-        page_range = self.page_range
+def show_debug_toolbar(request):
+    """
+        Whether to show the Django debug toolbar.
+    """
+    return bool(settings.DEBUG)


### PR DESCRIPTION
Misc work from yesterday:

- sql profiling helpers:
  - postgresql-client auto-installed in python docker env
  - django-debug-toolbar will be used if installed via `pip install django-debug-toolbar`
  - add logging config and example logger in `settings.py.example` to log all sql queries
- expanded test fixtures, including `full_casebook` with a section and 6 resources (this might not be right yet!) and an `admin_user`
- hack our auth middleware so test client can make authorized requests like `client.get(url, as_user=admin_user)`; use to expand tests on the dashboard page
- add `ContentNode.objects.prefetch_resources()` so each fetched content_node will come with `.resource` prepopulated without a separate sql query; use to speed up the TOC page
- replace `blank=True, null=True` in `resource_type` and `resource_id`
- tweak User model so `AUTH_USER_MODEL = 'main.User'` works in settings (this may cause problems when setting up new databases, until the main/migrations are in! not sure)