### PR TITLE
Python: serve Rails static assets in Django using whitenoise

### DIFF
--- a/_python/config/settings/settings.py.example
+++ b/_python/config/settings/settings.py.example
@@ -4,8 +4,6 @@
 from .settings_dev import *  # noqa
 
 
-STATIC_URL = '/static/'
-
 # log all SQL statements:
 # LOGGING['loggers']['django.db.backends'] = {
 #     'level': 'DEBUG',

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -12,13 +12,15 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 ALLOWED_HOSTS = []
 
 
 # Application definition
 
 INSTALLED_APPS = [
+    'whitenoise.runserver_nostatic',
+
     # built-in
     'main.apps.CustomAdminConfig',
     'django.contrib.auth',
@@ -37,6 +39,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 
     'django.contrib.sessions.middleware.SessionMiddleware',  # sets request.session
     'main.middleware.rails_session_middleware',  # sets request.rails_session
@@ -129,9 +132,8 @@ USE_TZ = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
-PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 RAILS_SECRET_KEY_BASE = None
 
@@ -182,3 +184,10 @@ LOGGING = {
         }
     },
 }
+
+
+# serve Rails public/ folder at the root, so urls like /robots.txt and /packs/css/main.css will work:
+WHITENOISE_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'public')
+
+# avoid the need for collectstatic in production (see http://whitenoise.evans.io/en/stable/django.html#WHITENOISE_USE_FINDERS )
+WHITENOISE_USE_FINDERS = True

--- a/_python/config/settings/settings_dev.py
+++ b/_python/config/settings/settings_dev.py
@@ -20,9 +20,6 @@ if os.environ.get('DOCKERIZED'):
 
 RAILS_SECRET_KEY_BASE = 'd3a3c86a4791903d56cd6a4d3aa4e18fbda088c4e88655d0b0ed39e540c84030b3f10982c2e1c2cbd973f550d22bca375f59d86b48034827007c9977d76b29e0'
 
-# load assets from prod for now
-STATIC_URL = 'https://opencasebook.org/'
-
 # django-debug-toolbar:
 # ddt can be useful but also be a hassle, so it only runs optionally, if you choose to `pip install django-debug-toolbar`
 # If installed, there will be a sidebar when viewing front-end pages, including useful tools such as a SQL profiler.

--- a/_python/main/templates/base.html
+++ b/_python/main/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+{% load static %}{% load rails_static %}<!DOCTYPE html>
 <html lang="en">
   <head>
     {% block prepend_to_head %}{% endblock %}
@@ -7,12 +7,12 @@
     <title>{% block page_title %}{{ page_title|default:"Open Casebooks" }}{% endblock %} | H2O</title>
     <link rel="icon" href="#" type="image/png"/>
     {% include 'includes/favicon.html' %}
-    <link rel="stylesheet" type="text/css" href="{% static "packs/css/main-ebd2321f.css" %}"/>
+    <link rel="stylesheet" type="text/css" href="{% rails_static "packs/css/main.css" %}"/>
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy"/>
     <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css"/>
     {% if include_vuejs %}
-      <script src="{% static 'packs/js/vue_app-3ed270917b4373c2fcc7.js' %}"></script>
-      <link rel="stylesheet" media="all" href="{% static 'packs/css/vue_app-48b4e940.css' %}">
+      <script src="{% rails_static 'packs/js/vue_app.js' %}"></script>
+      <link rel="stylesheet" media="all" href="{% rails_static 'packs/css/vue_app.css' %}">
     {% endif %}
   </head>
   <body class=""> <!--need parameter here for class based on view? -->
@@ -51,7 +51,7 @@
       </footer>
     </div>
     {% if include_vuejs %}</div>{% endif %}
-    <script src="{% static "packs/js/application-9a84a3f0732a1d7044d5.js"%} "></script>
+    <script src="{% rails_static "packs/js/application.js"%} "></script>
     {% include 'includes/analytics.html' %}
   </body>
 </html>

--- a/_python/main/templates/includes/favicon.html
+++ b/_python/main/templates/includes/favicon.html
@@ -1,2 +1,2 @@
-{% load static %}
-<link href="{% static "assets/favicon.ico" %}" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+{% load rails_static %}
+<link href="{% rails_static "assets/favicon.ico" %}" rel="shortcut icon" type="image/vnd.microsoft.icon" />

--- a/_python/main/templates/index.html
+++ b/_python/main/templates/index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load rails_static %}
 
 {% block mainContent %}
 <section class="hero">
@@ -30,7 +31,7 @@
             </section>
       </div>
       <div class="screenshot">
-        <div class="image-wrapper"><img src="{% static "assets/landing-demo.png" %}" alt="a screenshot of an example case" />
+        <div class="image-wrapper"><img src="{% rails_static "assets/landing-demo.png" %}" alt="a screenshot of an example case" />
         </div>
       </div>
     </div>
@@ -41,38 +42,38 @@
     <h1>Featured Faculty Authors</h1>
     <div class="layout">
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/zittrain.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/zittrain.png" %}"/></div>
           <div class="name">Professor Jonathan Zittrain</div>
           <div class="institution">Harvard Law School</div>
           <div class="link"><a href="{% url 'casebook' 30206 %}">Torts</a>
           </div>
         </div>
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/suk-gersen.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/suk-gersen.png" %}"/></div>
           <div class="name">Professor Jeannie Suk Gersen</div>
           <div class="institution">Harvard Law School</div>
           <div class="link"><a href="{% url 'casebook' 28024 %}">Criminal Law</a></div>
         </div>
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/quinn.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/quinn.png" %}"/></div>
           <div class="name">Professor Brian Quinn</div>
           <div class="institution">Boston College Law School</div>
           <div class="link"><a href="{% url 'casebook' 28884 %}">An Introduction to the Law of Corporations</a></div>
         </div>
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/fried2.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/fried2.png" %}"/></div>
           <div class="name">Professor Charles Fried</div>
           <div class="institution">Harvard Law School</div>
           <div class="link"><a href="{% url 'casebook' 75344 %}">Contracts Law</a></div>
         </div>
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/cohen.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/cohen.png" %}"/></div>
           <div class="name">Professor I. Glenn Cohen</div>
           <div class="institution">Harvard Law School</div>
           <div class="link"><a href="{% url 'casebook' 29269 %}">Civil Procedure</a></div>
         </div>
         <div class="endorser">
-          <div class="photo"><img src="{% static "assets/endorsers/modirzadeh.png" %}"/></div>
+          <div class="photo"><img src="{% rails_static "assets/endorsers/modirzadeh.png" %}"/></div>
           <div class="name">Professor Naz Modirzadeh</div>
           <div class="institution">Harvard Law School</div>
           <div class="link"><a href="{% url 'casebook' 45698 %}">International Humanitarian Law / Laws of War</a></div>
@@ -85,7 +86,7 @@
   </div>
 </section>
 <section class="stinger">
-    <img src="{% static "assets/logo.png" %}" title="H2O"/>
+    <img src="{% rails_static "assets/logo.png" %}" title="H2O"/>
     <h1>"Build coursebooks better, faster and smarter — today."</h1>
     <a class="call-to-action" href="{{ SIGNUP_URL }}">Get started</a>
 </section>

--- a/_python/main/templatetags/rails_static.py
+++ b/_python/main/templatetags/rails_static.py
@@ -1,0 +1,61 @@
+import re
+from functools import lru_cache
+from pathlib import Path
+
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@lru_cache(None)
+def path_lookup():
+    """
+        This function caches every path in the Rails public/ directory (settings.WHITENOISE_ROOT) and returns a
+        dictionary mapping the relative paths to the URLs that should be included in templates, stripping out
+        hexadecimal hashes from the paths if necessary. This allows the rails_static tag to use
+        {% rails_static "packs/css/main.css" %} in the template to include "/packs/css/main-a4a68e68.css" in the HTML.
+
+        Given this set of files in public/ :
+
+        >>> monkeypatch = getfixture('monkeypatch')
+        >>> monkeypatch.setattr(Path, 'glob', lambda *args, **kwargs: [
+        ...     settings.WHITENOISE_ROOT+'/css/main-a4a68e68.css',
+        ...     settings.WHITENOISE_ROOT+'/main.css',
+        ...     settings.WHITENOISE_ROOT+'/main-cafe0001.css',
+        ... ])
+
+        Return this lookup table:
+
+        >>> assert path_lookup() == {
+        ...     'css/main-a4a68e68.css': '/css/main-a4a68e68.css',
+        ...     'css/main.css': '/css/main-a4a68e68.css',
+        ...     'main.css': '/main.css',
+        ...     'main-cafe0001.css': '/main-cafe0001.css',
+        ... }
+
+        Note that in the usual case css/main.css can be looked up with or without a hash, but we also make sure that
+        main-cafe0001.css does not shadow main.css in the edge case where one file looks like a hashed version of another.
+    """
+    # get all paths
+    paths = Path(settings.WHITENOISE_ROOT).glob('**/*')
+    out = {}
+    exact_paths = []
+
+    # add all paths with hashes stripped
+    for path in paths:
+        path = str(path).split(settings.WHITENOISE_ROOT, 1)[1].lstrip('/')
+        path_without_hash = re.sub(r'-[a-f0-9]+(\.\w+)$', r'\1', path)
+        out[path_without_hash] = '/' + path
+        exact_paths.append(path)
+
+    # add paths without hashes stripped
+    for path in exact_paths:
+        out[path] = '/' + path
+
+    return out
+
+
+@register.simple_tag
+def rails_static(path):
+    return path_lookup().get(path, '')

--- a/_python/requirements.in
+++ b/_python/requirements.in
@@ -3,6 +3,9 @@ pip-tools
 django
 django-extensions
 djangorestframework
+whitenoise          # static file serving
+
+# database
 psycopg2            # postgres connector
 
 bleach              # html sanitization
@@ -14,5 +17,4 @@ pytest
 pytest-django
 pytest-cov
 factory-boy        # create django model fixtures on demand
-
 flake8

--- a/_python/requirements.txt
+++ b/_python/requirements.txt
@@ -225,6 +225,9 @@ webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923 \
     # via bleach
+whitenoise==4.1.4 \
+    --hash=sha256:22f79cf8f1f509639330f93886acaece8ec5ac5e9600c3b981d33c34e8a42dfd \
+    --hash=sha256:6dfea214b7c12efd689007abf9afa87a426586e9dbc051873ad2c8e535e2a1ac
 zipp==0.5.2 \
     --hash=sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a \
     --hash=sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec \

--- a/_python/static/README.txt
+++ b/_python/static/README.txt
@@ -1,0 +1,3 @@
+Location for Django static assets.
+
+This file is a placeholder so git keeps the folder here until we add actual assets.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: ./_python/Dockerfile
-    image: h2o-python:0.3
+    image: h2o-python:0.4
     tty: true
     command: bash
     environment:


### PR DESCRIPTION
This avoids the temporary hack we had of loading static assets from production URLs. Django will now use `whitenoise` to serve static assets, serving the Django assets under `/static/` and also anything in the Rails public/ folder under `/`. So Rails files will now be available as `http://h2o-dev.local:8001/robots.txt`, `http://h2o-dev.local:8001/packs/css/main-1a2b3c4d.css` etc, and Django assets for the admin and django-debug-toolbar and anything else will also work.

This opens up the ability to gradually migrate any assets to `/static/` if they are only referenced from the Django side.

Rails assets have hashes in the filenames that might change and shouldn't be included in our templates. So this also includes a `rails_static` templatetag that looks up hashed filenames, inserting "/packs/css/main-a4a68e68.css" for `{% rails_static "packs/css/main.css" %}`.