### PR TITLE
Merge draft casebooks

### DIFF
--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -196,3 +196,8 @@ WHITENOISE_USE_FINDERS = True
 
 CAPAPI_BASE_URL = 'https://api.case.law/v1/'
 CAPAPI_API_KEY = ''
+
+
+# Set this to true to affirmatively assert that it is OK to execute code that includes fix_before_deploy() lines.
+# This can safely be set to True everywhere except on production.
+NOT_ON_PRODUCTION = False

--- a/_python/config/settings/settings_dev.py
+++ b/_python/config/settings/settings_dev.py
@@ -6,6 +6,7 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', '.local', 'backend', 'django
 SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'
 
 DEBUG = True
+NOT_ON_PRODUCTION = True
 
 # don't check password quality locally, since it's annoying
 AUTH_PASSWORD_VALIDATORS = []

--- a/_python/main/utils.py
+++ b/_python/main/utils.py
@@ -71,3 +71,14 @@ def clone_model_instance(instance):
     clone = deepcopy(instance)
     clone.id = clone.pk = clone.created_at = None
     return clone
+
+
+def fix_before_deploy(message):
+    """ Use this to document questions that should be answered before a given line of code is allowed to run on production. """
+    if not settings.NOT_ON_PRODUCTION:
+        raise ValueError(message)
+
+
+def fix_after_rails(message):
+    """ Use this to document actions that should be taken after the migration to Python is complete. """
+    pass


### PR DESCRIPTION
- Add a casebook.merge_draft function, not yet exposed through views (though I do have some WIP locally on the view to go along with this). This uses the strategy Becky and I discussed where casebook attributes are copied over, old casebook assets are deleted, and draft content nodes are pointed to the published casebook. I'm sure I missed something!

- Coming along for the ride: `fix_after_rails("some todo message")` and `fix_before_deploy("some todo message")`, to use in place of our current `# TODO` comments. `fix_before_deploy` asserts that `settings.NOT_ON_PRODUCTION` has been set to true, so it will make a fuss if we whitelist a route we shouldn't. `fix_after_rails` is just a no-op, but making it a function ensures that we're consistently using the same string and can find them all later.