### PR TITLE
Remove max bounding in search function to handle impossible offsets

### DIFF
--- a/lib/differ.rb
+++ b/lib/differ.rb
@@ -60,9 +60,7 @@ module Differ
 
     def get_delta_at_offset diffs, offset
       # Reverse the list so we find the last diff that includes the offset and for which the offset isn't at the start of the diff (i.e. before the changes in that diff would have any effect)
-      diff = diffs.reverse.find { |diff|
-        diff[2].max >= offset && diff[2].min < offset
-      }
+      diff = diffs.reverse.find { |diff| diff[2].min < offset }
 
       # if the last diff is a deletion, shift the offset backward to the beginning of the deletion,
       # otherwise get the difference between the before and after ranges

--- a/test/lib/differ_test.rb
+++ b/test/lib/differ_test.rb
@@ -28,6 +28,16 @@ class DifferTest < ActiveSupport::TestCase
   end
 
   describe Differ, :get_delta_at_offset do
+    it "should return 0 when the provided offset exceeds the length of both the 'before' and 'after' strings" do
+      diffs = Differ.get_diffs "foo", "foo"
+      assert_equal 0, Differ.get_delta_at_offset(diffs, 5)
+    end
+
+    it "should return 0 when the provided offset exceeds the length of the 'before' string" do
+      diffs = Differ.get_diffs "foo", "foo bar"
+      assert_equal 0, Differ.get_delta_at_offset(diffs, 5)
+    end
+
     it "should return the difference between the original number of characters preceeding this offset and the new number of characters preceeding it" do
       diffs = Differ.get_diffs("foo ipsum", "foo bar lorum ipsum")
       assert_equal 10, Differ.get_delta_at_offset(diffs, 5)


### PR DESCRIPTION
This is meant to address the following error that was being thrown in production:

```ruby
undefined method `[]' for nil:NilClass
​
  lib/differ.rb:69:in `get_delta_at_offset
```

I believe this was caused by annotations with "impossible" offsets (i.e. greater than the length of the text). This PR causes those offsets to be left unmodified when calculating new offsets on text updated.