### PR TITLE
Action buttons; refactoring; partial "edit" pages.

### DIFF
--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -245,6 +245,33 @@ def full_casebook(casebook_factory):
     ResourceFactory(casebook=casebook, ordinals=[1, 4, 3], resource_type='Default', resource_id=DefaultFactory(user=user).id)
     return casebook
 
+@pytest.fixture
+def full_private_casebook(full_casebook):
+    """
+    >>> private, published = [getfixture(f) for f in ['full_private_casebook', 'full_casebook']]
+    >>> assert published != private
+    >>> assert private.is_private
+    >>> assert all(node.is_private for node in private.contents.all())
+    """
+    casebook = full_casebook.clone()
+    return casebook
+
+@pytest.fixture
+def full_casebook_with_draft(full_casebook):
+    """
+    >>> with_draft, without_draft = [getfixture(f) for f in ['full_casebook_with_draft', 'full_casebook']]
+    >>> assert with_draft != without_draft
+    >>> assert not without_draft.has_draft
+    >>> assert with_draft.has_draft
+    >>> assert with_draft.is_public
+    >>> assert with_draft.drafts().is_private
+    >>> assert all(node.has_draft for node in with_draft.contents.all())
+    """
+    casebook = full_casebook.clone()
+    casebook.public = True
+    casebook.save()
+    casebook.make_draft()
+    return casebook
 
 @pytest.fixture
 def user_with_cloneable_casebook(casebook_factory, user_factory):

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -249,8 +249,7 @@ def full_casebook(casebook_factory):
 def full_private_casebook(full_casebook):
     """
     >>> private, published = [getfixture(f) for f in ['full_private_casebook', 'full_casebook']]
-    >>> assert published != private
-    >>> assert private.is_private
+    >>> assert private.is_private and not published.is_private
     >>> assert all(node.is_private for node in private.contents.all())
     """
     casebook = full_casebook.clone()
@@ -259,13 +258,11 @@ def full_private_casebook(full_casebook):
 @pytest.fixture
 def full_casebook_with_draft(full_casebook):
     """
-    >>> with_draft, without_draft = [getfixture(f) for f in ['full_casebook_with_draft', 'full_casebook']]
-    >>> assert with_draft != without_draft
-    >>> assert not without_draft.has_draft
-    >>> assert with_draft.has_draft
-    >>> assert with_draft.is_public
-    >>> assert with_draft.drafts().is_private
-    >>> assert all(node.has_draft for node in with_draft.contents.all())
+    >>> has_draft, draftless = [getfixture(f) for f in ['full_casebook_with_draft', 'full_casebook']]
+    >>> assert has_draft.has_draft and not draftless.has_draft
+    >>> assert all(node.has_draft for node in has_draft.contents.all())
+    >>> assert has_draft.is_public
+    >>> assert has_draft.drafts().is_private
     """
     casebook = full_casebook.clone()
     casebook.public = True

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -248,9 +248,11 @@ def full_casebook(casebook_factory):
 @pytest.fixture
 def full_private_casebook(full_casebook):
     """
-    >>> private, published = [getfixture(f) for f in ['full_private_casebook', 'full_casebook']]
-    >>> assert private.is_private and not published.is_private
-    >>> assert all(node.is_private for node in private.contents.all())
+        The same as full_casebook, except private
+
+        >>> private, published = [getfixture(f) for f in ['full_private_casebook', 'full_casebook']]
+        >>> assert private.is_private and not published.is_private
+        >>> assert all(node.is_private for node in private.contents.all())
     """
     casebook = full_casebook.clone()
     return casebook
@@ -258,11 +260,13 @@ def full_private_casebook(full_casebook):
 @pytest.fixture
 def full_casebook_with_draft(full_casebook):
     """
-    >>> has_draft, draftless = [getfixture(f) for f in ['full_casebook_with_draft', 'full_casebook']]
-    >>> assert has_draft.has_draft and not draftless.has_draft
-    >>> assert all(node.has_draft for node in has_draft.contents.all())
-    >>> assert has_draft.is_public
-    >>> assert has_draft.drafts().is_private
+        The same as full_casebook, except has an in-progress draft
+
+        >>> has_draft, draftless = [getfixture(f) for f in ['full_casebook_with_draft', 'full_casebook']]
+        >>> assert has_draft.has_draft and not draftless.has_draft
+        >>> assert all(node.has_draft for node in has_draft.contents.all())
+        >>> assert has_draft.is_public
+        >>> assert has_draft.drafts().is_private
     """
     casebook = full_casebook.clone()
     casebook.public = True

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -247,6 +247,82 @@ def full_casebook(casebook_factory):
 
 
 @pytest.fixture
+def user_with_cloneable_casebook(casebook_factory, user_factory):
+    """
+        Standard casebooks can be cloned.
+
+        >>> user = getfixture('user_with_cloneable_casebook')
+        >>> casebook = user.casebooks.first()
+        >>> assert casebook.permits_cloning
+    """
+    user = user_factory()
+    casebook = casebook_factory(contentcollaborator_set__user=user)
+    return user
+
+
+@pytest.fixture
+def user_with_uncloneable_casebook(casebook_factory, user_factory):
+    """
+        Casebooks that are drafts of already-published casebooks may not
+        be cloned.
+
+        >>> user = getfixture('user_with_uncloneable_casebook')
+        >>> casebook = user.casebooks.first()
+        >>> assert not casebook.permits_cloning
+    """
+    user = user_factory()
+    casebook = casebook_factory(
+        contentcollaborator_set__user=user,
+        draft_mode_of_published_casebook=True
+    )
+    return user
+
+
+@pytest.fixture
+def user_with_draftable_casebook(casebook_factory, user_factory):
+    """
+        Already-published casebooks may be edited via the draft mechanism.
+
+        >>> user = getfixture('user_with_draftable_casebook')
+        >>> casebook = user.casebooks.first()
+        >>> assert casebook.allows_draft_creation_by(user)
+    """
+    user = user_factory()
+    casebook = casebook_factory(
+        contentcollaborator_set__user=user,
+        public=True
+    )
+    return user
+
+
+@pytest.fixture
+def user_with_undraftable_casebooks(casebook_factory, user_factory):
+    """
+        Private casebooks may be edited directly; they may not be edited
+        via the draft mechanism.
+
+        >>> user = getfixture('user_with_undraftable_casebooks')
+        >>> casebook = user.casebooks.first()
+        >>> assert not casebook.allows_draft_creation_by(user)
+
+        Casebooks may only have one draft at a time.
+        >>> casebook = user.casebooks.last()
+        >>> assert not casebook.allows_draft_creation_by(user)
+    """
+    user = user_factory()
+    private_casebook = casebook_factory(
+        contentcollaborator_set__user=user,
+        public=False
+    )
+    casebook = casebook_factory(
+        contentcollaborator_set__user=user,
+        public=True
+    )
+    casebook.make_draft()
+    return user
+
+
+@pytest.fixture
 def capapi_mock(requests_mock):
     """
         Mock responses for queries run by CAP import functions.

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -284,7 +284,7 @@ def user_with_cloneable_casebook(casebook_factory, user_factory):
         >>> assert casebook.permits_cloning
     """
     user = user_factory()
-    casebook = casebook_factory(contentcollaborator_set__user=user)
+    casebook_factory(contentcollaborator_set__user=user)
     return user
 
 
@@ -299,7 +299,7 @@ def user_with_uncloneable_casebook(casebook_factory, user_factory):
         >>> assert not casebook.permits_cloning
     """
     user = user_factory()
-    casebook = casebook_factory(
+    casebook_factory(
         contentcollaborator_set__user=user,
         draft_mode_of_published_casebook=True
     )
@@ -316,7 +316,7 @@ def user_with_draftable_casebook(casebook_factory, user_factory):
         >>> assert casebook.allows_draft_creation_by(user)
     """
     user = user_factory()
-    casebook = casebook_factory(
+    casebook_factory(
         contentcollaborator_set__user=user,
         public=True
     )
@@ -338,7 +338,7 @@ def user_with_undraftable_casebooks(casebook_factory, user_factory):
         >>> assert not casebook.allows_draft_creation_by(user)
     """
     user = user_factory()
-    private_casebook = casebook_factory(
+    casebook_factory(
         contentcollaborator_set__user=user,
         public=False
     )

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -588,6 +588,12 @@ class Casebook(ContentNode):
     def get_absolute_url(self):
         return reverse('casebook', args=[self])
 
+    def get_draft_url(self):
+        draft = self.drafts()
+        if draft:
+            return reverse('edit_casebook', args=[draft])
+        raise ValueError("This casebook doesn't have a draft.")
+
     def get_title(self):
         return self.title or "Untitled casebook"
         # Proposed: I dislike the ID number here
@@ -872,6 +878,12 @@ class Section(ContentNode):
     def get_absolute_url(self):
         return reverse('section', args=[self.casebook, self])
 
+    def get_draft_url(self):
+        draft = self.casebook.drafts()
+        if draft:
+            return reverse('edit_casebook', args=[draft])
+        raise ValueError("This casebook doesn't have a draft.")
+
     def get_title(self):
         return self.title if self.title else "Untitled section"
 
@@ -893,6 +905,12 @@ class Resource(ContentNode):
 
     def get_absolute_url(self):
         return reverse('resource', args=[self.casebook, self])
+
+    def get_draft_url(self):
+        draft = self.casebook.drafts()
+        if draft:
+            return reverse('edit_casebook', args=[draft])
+        raise ValueError("This casebook doesn't have a draft.")
 
     def get_title(self):
         if self.resource_type == 'Default':

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -484,6 +484,17 @@ class ContentNode(TimestampedModel, BigPkModel):
         """
         raise NotImplementedError()
 
+    @property
+    def is_or_belongs_to_draft(self):
+        """
+        This node is, or belongs to, a Casebook that is a draft
+        of an already-published Casebook. (See allows_draft_creation_by
+        for more discussion of drafts.)
+
+        This method should be implemented by all children.
+        """
+        raise NotImplementedError()
+
     def allows_draft_creation_by(self, user):
         """
         Sometimes authors wish to alter a Casebook "in real time", so that
@@ -615,6 +626,11 @@ class SectionAndResourceMixin(models.Model):
         """See ContentNode.has_draft"""
         return self.casebook.has_draft
 
+    @property
+    def is_or_belongs_to_draft(self):
+        """See ContentNode.is_or_belongs_to_draft"""
+        return self.casebook.is_or_belongs_to_draft
+
     def allows_draft_creation_by(self, user):
         """See ContentNode.allows_draft_creation_by"""
         return self.casebook.allows_draft_creation_by(user)
@@ -700,6 +716,11 @@ class Casebook(CasebookAndSectionMixin, ContentNode):
     def has_draft(self):
         """See ContentNode.has_draft"""
         return self.clones.filter(draft_mode_of_published_casebook=True).exists()
+
+    @property
+    def is_or_belongs_to_draft(self):
+        """See ContentNode.is_or_belongs_to_draft"""
+        return self.draft_mode_of_published_casebook
 
     def allows_draft_creation_by(self, user):
         """See ContentNode.allows_draft_creation_by"""

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -421,7 +421,7 @@ class ContentNode(TimestampedModel, BigPkModel):
     def ordinal_string(self):
         return '.'.join(str(o) for o in self.ordinals)
 
-    def ordinals_with_urls(self):
+    def ordinals_with_urls(self, editing=False):
         return_value = []
         ordinals = []
         for o in self.ordinals:

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -397,8 +397,8 @@ class ContentNode(TimestampedModel, BigPkModel):
         Allow a user to make a draft-mode clone of this section's casebook.
         """
         if self.type == 'casebook':
-            return self.allows_draft_creation_by(self, user)
-        return self.casebook.allows_draft_creation_by(self, user)
+            return self.allows_draft_creation_by(user)
+        return self.casebook.allows_draft_creation_by(user)
 
     @property
     def annotatable(self):

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -389,7 +389,7 @@ class ContentNode(TimestampedModel, BigPkModel):
     @property
     def has_draft(self):
         if self.type == 'casebook':
-            return self.has_draft
+            return self.to_proxy().has_draft
         return self.casebook.has_draft
 
     def allows_draft_creation_by(self, user):
@@ -397,7 +397,7 @@ class ContentNode(TimestampedModel, BigPkModel):
         Allow a user to make a draft-mode clone of this section's casebook.
         """
         if self.type == 'casebook':
-            return self.allows_draft_creation_by(user)
+            return self.to_proxy().allows_draft_creation_by(user)
         return self.casebook.allows_draft_creation_by(user)
 
     @property

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -737,6 +737,10 @@ class Casebook(ContentNode):
 
         return cloned_casebook
 
+    def is_annotated(self):
+        # equivalent of Rails resources_have_annotations?
+        return any(node.annotations for node in self.contents.prefetch_related('annotations'))
+
 
 class SectionManager(models.Manager):
     def get_queryset(self):
@@ -766,6 +770,10 @@ class Section(ContentNode):
             "ordinals__len__gte": len(self.ordinals) + 1
         }).order_by('ordinals')
 
+    def is_annotated(self):
+        # equivalent of Rails resources_have_annotations?
+        return any(node.annotations for node in self.contents.prefetch_related('annotations'))
+
     def get_absolute_url(self):
         return reverse('section', args=[self.casebook, self])
 
@@ -783,6 +791,10 @@ class Resource(ContentNode):
         proxy = True
 
     objects = ResourceManager()
+
+    def is_annotated(self):
+        # equivalent of Rails resources_have_annotations? (for casebooks and sections)
+        return bool(self.annotations)
 
     def get_absolute_url(self):
         return reverse('resource', args=[self.casebook, self])

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -442,7 +442,8 @@ class ContentNode(TimestampedModel, BigPkModel):
 
     def editable_by(self, user):
         """
-        Allow a user to
+        Allow a user to alter a casebook.
+
         This method should be implemented by all children.
         """
         raise NotImplementedError()

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -438,7 +438,7 @@ class ContentNode(TimestampedModel, BigPkModel):
     def get_edit_or_absolute_url(self, editing=False):
         # In the Rails app, when editing a casebook/section/resource,
         # breadcrumbs and TOC entries generally point to the "edit" view...
-        # except when pointing to a resource, where they point to the annotate view.
+        # except when pointing to a resource, where they point to the "annotate" view.
         # Recreate that here.
         if editing:
             if self.annotatable:

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -372,18 +372,13 @@ class ContentNode(TimestampedModel, BigPkModel):
         ordinals = []
         for o in self.ordinals:
             ordinals.append(o)
-            node = globals()['ContentNode'].objects.get(
-                casebook_id=self.casebook_id,
-                ordinals=ordinals
-            )
-            if editing:
-                url = node.get_default_edit_url()
-            else:
-                url = node.get_absolute_url()
             return_value.append({
                 'ordinal': o,
                 'ordinals': [*ordinals],
-                'url': url
+                'url': globals()['ContentNode'].objects.get(
+                    casebook_id=self.casebook_id,
+                    ordinals=ordinals
+                ).get_edit_or_absolute_url(editing)
             })
         return return_value
 
@@ -440,14 +435,16 @@ class ContentNode(TimestampedModel, BigPkModel):
             return reverse('annotate_resource', args=[self.casebook, self])
         raise ValueError('Only Resources (Case and TextBlock) can be annotated.')
 
-    def get_default_edit_url(self):
+    def get_edit_or_absolute_url(self, editing=False):
         # In the Rails app, when editing a casebook/section/resource,
         # breadcrumbs and TOC entries generally point to the "edit" view...
         # except when pointing to a resource, where they point to the annotate view.
         # Recreate that here.
-        if self.annotatable:
-            return self.get_annotate_url()
-        return self.get_edit_url()
+        if editing:
+            if self.annotatable:
+                return self.get_annotate_url()
+            return self.get_edit_url()
+        return self.get_absolute_url
 
     def get_title(self):
         t = self.type

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -359,7 +359,7 @@ class ContentNode(TimestampedModel, BigPkModel):
 
     def viewable_by(self, user):
         """See ContentNode.editable_by"""
-        return self.public or self.editable_by(user)
+        return self.is_public or self.editable_by(user)
 
     def directly_editable_by(self, user):
         """

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -444,7 +444,7 @@ class ContentNode(TimestampedModel, BigPkModel):
             if self.annotatable:
                 return self.get_annotate_url()
             return self.get_edit_url()
-        return self.get_absolute_url
+        return self.get_absolute_url()
 
     def get_title(self):
         t = self.type

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -421,7 +421,7 @@ class ContentNode(TimestampedModel, BigPkModel):
     def ordinal_string(self):
         return '.'.join(str(o) for o in self.ordinals)
 
-    def ordinals_with_urls(self, editing=False):
+    def ordinals_with_urls(self):
         return_value = []
         ordinals = []
         for o in self.ordinals:

--- a/_python/main/serializers.py
+++ b/_python/main/serializers.py
@@ -9,7 +9,7 @@ class ContentAnnotationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.ContentAnnotation
-        fields = ('id', 'resource', 'start_offset', 'end_offset', 'kind', 'content', 'created_at', 'updated_at')
+        fields = ('id', 'resource_id', 'start_offset', 'end_offset', 'kind', 'content', 'created_at', 'updated_at')
 
 
 class CaseSerializer(serializers.ModelSerializer):

--- a/_python/main/templates/base.html
+++ b/_python/main/templates/base.html
@@ -20,7 +20,7 @@
     <div id="non-modal">
       <a href="#main" class="skip-link">Skip to main content</a>
       <a href="#footer" class="skip-link">Skip to footer</a>
-      <div class="overlay"></div>
+      <div class="modal-overlay"></div> <!--bizarrely, something is swapping out the class overlay -> modal-overlay in the Rails app... to be investigated -->
       {% block banner %}{% endblock banner %}
       <header id="main-header">
         {% include 'includes/header.html' %}

--- a/_python/main/templates/casebook.html
+++ b/_python/main/templates/casebook.html
@@ -3,11 +3,11 @@
 {% block page_title %}{{ casebook.get_title }}{% endblock %}
 
 {% block banner %}
-{% if casebook.draft_mode_of_published_casebook or not casebook.public %}
+{% if casebook.is_or_belongs_to_draft or casebook.is_private %}
   <div class="casebook-preview banner">
     {# TBD: Draft wording is proposed. #}
     <div class="banner-inner">
-      You are viewing a preview of {{ casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
+      You are viewing a preview of {{ casebook.is_or_belongs_to_draft|yesno:"your changes,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/casebook.html
+++ b/_python/main/templates/casebook.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <header class="casebook-public casebook">
+  <header class="casebook-public casebook" data-casebook-id="{{ casebook.id }}">
     <div class="content">
       <div class="casebook-inner">
           <div class="tabs">
@@ -38,6 +38,7 @@
             </div>
           </div>
       </header>
+      {% include 'includes/action_buttons.html' with content=casebook %}
       {% include 'includes/headnote.html' with content=casebook %}
       {% include 'includes/table-of-contents.html' with contents=contents %}
       </div>

--- a/_python/main/templates/casebook.html
+++ b/_python/main/templates/casebook.html
@@ -5,8 +5,9 @@
 {% block banner %}
 {% if casebook.draft_mode_of_published_casebook or not casebook.public %}
   <div class="casebook-preview banner">
+    {# TBD: Draft wording is proposed. #}
     <div class="banner-inner">
-      You are viewing a preview of a private casebook.
+      You are viewing a preview of {{ casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/casebook_edit.html
+++ b/_python/main/templates/casebook_edit.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block page_title %}Edit | {{ casebook.get_title }}{% endblock %}
+
+{% block banner %}
+<div class="casebook-draft banner">
+  <div class="banner-inner">
+    This casebook is a draft and is visible only to collaborators.
+  </div>
+</div>
+{% endblock %}
+
+{% block mainContent %}
+  <header class="casebook-draft casebook" data-casebook-id="{{ casebook.id }}">
+    <div class="content">
+      <div class="casebook-inner">
+          <div class="tabs">
+            <span class="tab active disabled">Casebook</span>
+          </div>
+      </div>
+    </div>
+  </header>
+  <section class="casebook-draft casebook">
+    <div class="content">
+      <div class="casebook-inner">
+        <div class="top-strip"></div>
+        <header class="content">
+          <h1 class="title">{{ casebook.get_title }}</h1>
+          {% if casebook.subtitle %}<h2 class="subtitle">{{ casebook.subtitle }}</h2>{% endif %}
+          <div class="authorship">
+            <div class="collaborators">
+              {% include 'includes/collaborators.html' with content=casebook%}
+            </div>
+            <div class="root-attribution">
+              {% if casebook.root_owner %}Original author: <a href="{% url 'dashboard' casebook.root_owner.id %}">{{ casebook.root_owner.display_name }}</a>{% endif %}
+            </div>
+          </div>
+      </header>
+      {% include 'includes/action_buttons.html' with content=casebook %}
+      {% include 'includes/headnote.html' with content=casebook %}
+      {% include 'includes/table-of-contents.html' with contents=contents %}
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -3,12 +3,25 @@
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}
   {% if can_add_nodes %}
-    {# This is a form on the Rails side... but its submit inputs just trigger modals via JS, so okay to be a simple button. #}
     {# TODO: actual "add resource" functionality #}
     <button class="action one-line add-resource">Add Resource</button>
     <form class="button_to" method="post" action="/casebooks/73057-zittrain-torts-playlist-rename/sections?parent=156464">
       <input class="action add-section" data-disable-with="Add Section" type="submit" value="Add Section">
-      {# TODO: csrf, accurate action url, see if disable functionality works #}
+      {% csrf_token %}
+      {# TODO: actual "add section" functionality, accurate action url, see if disable functionality works #}
+    </form>
+  {% endif %}
+  {% if can_save_nodes %}
+      {# TODO: actual save functionality, see if disable functionality works #}
+      {# TODO: consider using buttons w/ "form" attribute instead of save_details.js #}
+      <button class="action one-line save submit-{{ content.type }}-details" data-disable-with="Save">Save</a>
+      <button class="action one-line cancel cancel-{{ content.type }}-details" data-disable-with="Cancel">Cancel</a>
+  {% endif %}
+  {% if cloneable %}
+    <form class="clone_casebook" method="post" action="{% if casebook %}{% url 'clone' casebook %}{% else %}{% url 'clone' content.casebook %}{% endif %}">
+      <button class="action clone-casebook" data-disable-with="Clone" type="submit">Clone</button>
+      {% csrf_token %}
+      {# TODO: see if disable functionality works #}
     </form>
   {% endif %}
   {% if exportable %}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,4 +1,8 @@
 <aside class="casebook-actions">
+  {% if publishable %}
+    <button type="button" class="action publish one-line">Publish</button>
+    {# TODO: this opens a modal that POSTs to the casebook route. Implement that! #}
+  {% endif %}
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,4 +1,4 @@
-<aside class="casebook-actions">
+<aside class="casebook-actions" data-actions="{{ action_list }}">
   {% if publishable %}
     <button type="button" class="action publish one-line">Publish{% if content.is_or_belongs_to_draft %} Changes{% endif %}</button>
     {# TODO: this opens a modal that POSTs (PATCHs?) to the casebook route. Implement that! #}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,17 +1,17 @@
 <aside class="casebook-actions">
   {% if publishable %}
-    <button type="button" class="action publish one-line">Publish</button>
+    <button type="button" class="action publish one-line">Publish{% if content.is_or_belongs_to_draft %} Changes{% endif %}</button>
     {# TODO: this opens a modal that POSTs (PATCHs?) to the casebook route. Implement that! #}
   {% endif %}
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}
   {% if can_be_directly_edited %}
-      {# TBD: in Rails, this always points to the casebook's top-level edit page; linking straight to the section/resource to me. #}
-      <a class="action edit one-line" data-disable-with="Revise" href="{{ content.get_edit_url }}">Revise</a>
+      {# TBD: in Rails, this always points to the casebook's top-level edit page; linking straight to the section/resource makes more sense to me. #}
+      <a class="action edit one-line" data-disable-with="Revise" href="{{ content.get_edit_url }}">{% if content.is_or_belongs_to_draft %}Continue Revising{% else %}Revise{% endif %}</a>
   {% endif %}
   {% if can_view_existing_draft %}
-      {# NB: in Rails "return to draft" also refers to a link from a draft's previews to its edit pages. For clarity, the Django app is only using "return to draft" as a link from the original to the draft. #}
+      {# NB: in Rails "return to draft" also refers to a link from a draft's previews to its edit pages. For clarity, the Django app is only using "return to draft" as a link from the original to the draft, and uses "revise" or "continue revising" for links to edit pages. #}
       <a class="action edit one-line" data-disable-with="Return to Draft" href="{{ content.get_draft_url }}">Return to Draft</a>
   {% endif %}
   {% if can_create_draft %}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -2,6 +2,12 @@
   {% comment %}
     EXPORT (always)
     - the "export" button appears on all casebook, section, and resource pages, including "edit"/"layout"/"annotate" pages
+  {% endcomment %}
+
+  {# see action_button_builder.rb #}
+  <a class="action one-line export export-{{ content.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
+
+  {% comment %}
 
     CLONE (by user, casebook draft field, particular routes)
     - if you are logged in and can see a casebook, you can clone it, unless that casebook is a draft of a previously published casebook, in which case no one may clone it. If you can clone a casebook, you should see the "clone" button from all casebook pages. If the casebook is public, you should also see the "clone" button from sections' and resources' public pages. (You should not see "clone" from sections' and resources' "edit"/"layout"/"annotate" pages.)

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -7,13 +7,19 @@
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}
   {% if can_be_directly_edited %}
-      edit me
+      {# TBD: in Rails, this always points to the casebook's top-level edit page; linking straight to the section/resource to me. #}
+      <a class="action edit one-line" data-disable-with="Revise" href="{{ content.get_edit_url }}">Revise</a>
   {% endif %}
   {% if can_view_existing_draft %}
-      see my draft
+      {# NB: in Rails "return to draft" also refers to a link from a draft's previews to its edit pages. For clarity, the Django app is only using "return to draft" as a link from the original to the draft. #}
+      <a class="action edit one-line" data-disable-with="Return to Draft" href="{{ content.get_draft_url }}">Return to Draft</a>
   {% endif %}
   {% if can_create_draft %}
-      make a draft
+    <form class="button_to" method="post" action="{% if casebook %}{% url 'create_draft' casebook %}{% else %}{% url 'create_draft' content.casebook %}{% endif %}">
+      <input class="action edit one-line create-draft" data-disable-with="Revise" type="submit" value="Revise">
+      {% csrf_token %}
+    </form>
+    {# TODO: see if disable functionality works #}
   {% endif %}
   {% if can_add_nodes %}
     {# TODO: actual "add resource" functionality #}

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,7 +1,7 @@
 <aside class="casebook-actions">
   {% if publishable %}
     <button type="button" class="action publish one-line">Publish</button>
-    {# TODO: this opens a modal that POSTs to the casebook route. Implement that! #}
+    {# TODO: this opens a modal that POSTs (PATCHs?) to the casebook route. Implement that! #}
   {% endif %}
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -6,6 +6,15 @@
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}
+  {% if can_be_directly_edited %}
+      edit me
+  {% endif %}
+  {% if can_view_existing_draft %}
+      see my draft
+  {% endif %}
+  {% if can_create_draft %}
+      make a draft
+  {% endif %}
   {% if can_add_nodes %}
     {# TODO: actual "add resource" functionality #}
     <button class="action one-line add-resource">Add Resource</button>

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -14,8 +14,8 @@
   {% if can_save_nodes %}
       {# TODO: actual save functionality, see if disable functionality works #}
       {# TODO: consider using buttons w/ "form" attribute instead of save_details.js #}
-      <button class="action one-line save submit-{{ content.type }}-details" data-disable-with="Save">Save</a>
-      <button class="action one-line cancel cancel-{{ content.type }}-details" data-disable-with="Cancel">Cancel</a>
+      <button class="action one-line save submit-{{ content.type }}-details" data-disable-with="Save">Save</button>
+      <button class="action one-line cancel cancel-{{ content.type }}-details" data-disable-with="Cancel">Cancel</button>
   {% endif %}
   {% if cloneable %}
     <form class="clone_casebook" method="post" action="{% if casebook %}{% url 'clone' casebook %}{% else %}{% url 'clone' content.casebook %}{% endif %}">

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,35 +1,8 @@
 <aside class="casebook-actions">
-  {% comment %}
-    EXPORT (always)
-    - the "export" button appears on all casebook, section, and resource pages, including "edit"/"layout"/"annotate" pages
-  {% endcomment %}
-
-  {# see action_button_builder.rb #}
-  <a class="action one-line export export-{{ content.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
-
-  {% comment %}
-
-    CLONE (by user, casebook draft field, particular routes)
-    - if you are logged in and can see a casebook, you can clone it, unless that casebook is a draft of a previously published casebook, in which case no one may clone it. If you can clone a casebook, you should see the "clone" button from all casebook pages. If the casebook is public, you should also see the "clone" button from sections' and resources' public pages. (You should not see "clone" from sections' and resources' "edit"/"layout"/"annotate" pages.)
-
-    REVISE or RETURN TO DRAFT (by user, two casebook fields, particular routes)
-    - if you are a collaborator on a casebook and are viewing a public casebook or any of its resources or sections, you should always see either a "revise" or "return to draft" button. If the casebook has a draft associated with it, the button should be "return to draft"; otherwise, it should be "revise".
-
-        Related assertions:
-        - all casebooks that are drafts of previously published casebooks must be private.
-        - public casebooks, sections, and resources do not have "edit"/"layout"/"annotate" pages
-
-    PREVIEW (by user, casebook field, particular routes)
-    - if you can see a private casebook, section, or resource, you should see a "preview" button on all "edit"/"layout"/"annotate" pages. (You should not see a "preview" button on preview pages.)
-
-    PUBLISH (by casebook field, particular routes)
-    - if you are on a casebook's "edit"/"layout" page, or if you are previewing any private casebook, you should see a "publish" button. (You never see a publish button on any resource or section pages.)
-
-    SAVE/CANCEL (by particular routes)
-    - every page with a traditional webform should have a "Save" and a "Cancel" button. Therefore, if you are on a casebook's "edit"/"layout" page, a section's "edit"/"layout" page, or resource's "resource details"/"edit" page, you should see a "Save" and a "Cancel" button. (You should not see "Save" or "Cancel" anywhere else, including on a resource's "annotate" page.)
-
-    ADD SECTION and ADD RESOURCE (by particular routes)
-    - these buttons should both appear on casebooks "edit"/"layout" pages; they should appear nowhere else
-
-  {% endcomment %}
+  {% if previewable %}
+    <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
+  {% endif %}
+  {% if exportable %}
+    <a class="action one-line export export-{{ content.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
+  {% endif %}
 </aside>

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,0 +1,29 @@
+<aside class="casebook-actions">
+  {% comment %}
+    EXPORT (always)
+    - the "export" button appears on all casebook, section, and resource pages, including "edit"/"layout"/"annotate" pages
+
+    CLONE (by user, casebook draft field, particular routes)
+    - if you are logged in and can see a casebook, you can clone it, unless that casebook is a draft of a previously published casebook, in which case no one may clone it. If you can clone a casebook, you should see the "clone" button from all casebook pages. If the casebook is public, you should also see the "clone" button from sections' and resources' public pages. (You should not see "clone" from sections' and resources' "edit"/"layout"/"annotate" pages.)
+
+    REVISE or RETURN TO DRAFT (by user, two casebook fields, particular routes)
+    - if you are a collaborator on a casebook and are viewing a public casebook or any of its resources or sections, you should always see either a "revise" or "return to draft" button. If the casebook has a draft associated with it, the button should be "return to draft"; otherwise, it should be "revise".
+
+        Related assertions:
+        - all casebooks that are drafts of previously published casebooks must be private.
+        - public casebooks, sections, and resources do not have "edit"/"layout"/"annotate" pages
+
+    PREVIEW (by user, casebook field, particular routes)
+    - if you can see a private casebook, section, or resource, you should see a "preview" button on all "edit"/"layout"/"annotate" pages. (You should not see a "preview" button on preview pages.)
+
+    PUBLISH (by casebook field, particular routes)
+    - if you are on a casebook's "edit"/"layout" page, or if you are previewing any private casebook, you should see a "publish" button. (You never see a publish button on any resource or section pages.)
+
+    SAVE/CANCEL (by particular routes)
+    - every page with a traditional webform should have a "Save" and a "Cancel" button. Therefore, if you are on a casebook's "edit"/"layout" page, a section's "edit"/"layout" page, or resource's "resource details"/"edit" page, you should see a "Save" and a "Cancel" button. (You should not see "Save" or "Cancel" anywhere else, including on a resource's "annotate" page.)
+
+    ADD SECTION and ADD RESOURCE (by particular routes)
+    - these buttons should both appear on casebooks "edit"/"layout" pages; they should appear nowhere else
+
+  {% endcomment %}
+</aside>

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -2,6 +2,15 @@
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>
   {% endif %}
+  {% if can_add_nodes %}
+    {# This is a form on the Rails side... but its submit inputs just trigger modals via JS, so okay to be a simple button. #}
+    {# TODO: actual "add resource" functionality #}
+    <button class="action one-line add-resource">Add Resource</button>
+    <form class="button_to" method="post" action="/casebooks/73057-zittrain-torts-playlist-rename/sections?parent=156464">
+      <input class="action add-section" data-disable-with="Add Section" type="submit" value="Add Section">
+      {# TODO: csrf, accurate action url, see if disable functionality works #}
+    </form>
+  {% endif %}
   {% if exportable %}
     <a class="action one-line export export-{{ content.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
   {% endif %}

--- a/_python/main/templates/includes/breadcrumbs.html
+++ b/_python/main/templates/includes/breadcrumbs.html
@@ -1,8 +1,9 @@
+{% load call_method %}
 {% if content.ordinals %}
   <div class="breadcrumbs">
     {{ content.type | title }}
-    {# TODO: handle breadcrumb urls for edit/layout/annotate pages #}
-    {% for ordinal in content.ordinals_with_urls %}
+    {% call_method content 'ordinals_with_urls' editing=editing as ordinals %}
+    {% for ordinal in ordinals %}
       {% if forloop.last %}
         <span class="breadcrumb active">{{ ordinal.ordinal }}</span>
       {% else %}

--- a/_python/main/templates/includes/breadcrumbs.html
+++ b/_python/main/templates/includes/breadcrumbs.html
@@ -1,7 +1,7 @@
 {% if content.ordinals %}
   <div class="breadcrumbs">
     {{ content.type | title }}
-    {# Do we need a suffix for the urls like {% if not casebook.public %}/layout{% endif %} here? #}
+    {# TODO: handle breadcrumb urls for edit/layout/annotate pages #}
     {% for ordinal in content.ordinals_with_urls %}
       {% if forloop.last %}
         <span class="breadcrumb active">{{ ordinal.ordinal }}</span>

--- a/_python/main/templates/includes/content_browser.html
+++ b/_python/main/templates/includes/content_browser.html
@@ -12,7 +12,7 @@
           <div class="subtitle">{{ casebook.subtitle|default:"" }}</div>
         </div>
         {% if draft and user_can_edit %}
-          <a class="wrapper" href="{% url "edit_casebook" casebook.drafts %}">
+          <a class="wrapper" href="{% url "edit_casebook" draft %}">
             <div class="unpublished-changes">
              <span class="exclamation">!</span>
               <span class="description">This casebook has unpublished changes.</span>

--- a/_python/main/templates/includes/content_browser.html
+++ b/_python/main/templates/includes/content_browser.html
@@ -12,7 +12,7 @@
           <div class="subtitle">{{ casebook.subtitle|default:"" }}</div>
         </div>
         {% if draft and user_can_edit %}
-          <a class="wrapper" href="{% url "edit_casebook" casebook %}">
+          <a class="wrapper" href="{% url "edit_casebook" casebook.drafts %}">
             <div class="unpublished-changes">
              <span class="exclamation">!</span>
               <span class="description">This casebook has unpublished changes.</span>

--- a/_python/main/templates/includes/content_browser.html
+++ b/_python/main/templates/includes/content_browser.html
@@ -1,7 +1,6 @@
 {% load call_method %}
 <div class="content-browser">
-  {% for node in content %}
-    {% call_method node "to_proxy" as casebook %}
+  {% for node in content %}{% with node as casebook %}
     {% call_method casebook "editable_by" request.user as user_can_edit %}
     {% call_method casebook "drafts" as draft %}
     <a class="wrapper" href="{% if casebook.public %}{% url "casebook" casebook %}{% else %}{% url "edit_casebook" casebook %}{% endif %}">
@@ -37,5 +36,5 @@
         </div>
       </div>
     </a>
-  {% endfor %}
+  {% endwith %}{% endfor %}
 </div>

--- a/_python/main/templates/includes/content_browser.html
+++ b/_python/main/templates/includes/content_browser.html
@@ -4,7 +4,7 @@
     {% call_method node "to_proxy" as casebook %}
     {% call_method casebook "editable_by" request.user as user_can_edit %}
     {% call_method casebook "drafts" as draft %}
-    <a class="wrapper" href="{% if casebook.public %}{% url "casebook" casebook %}{% else %}{% url "layout" casebook %}{% endif %}">
+    <a class="wrapper" href="{% if casebook.public %}{% url "casebook" casebook %}{% else %}{% url "edit_casebook" casebook %}{% endif %}">
       <div class="content-page {% if casebook.public %}public{% else %}draft{% endif %}">
         <div class="casebook-info">
           <div class="state">{% if casebook.public %}Published{% else %}Draft{% endif %}</div>
@@ -12,7 +12,7 @@
           <div class="subtitle">{{ casebook.subtitle|default:"" }}</div>
         </div>
         {% if draft and user_can_edit %}
-          <a class="wrapper" href="{% url "layout" casebook %}">
+          <a class="wrapper" href="{% url "edit_casebook" casebook %}">
             <div class="unpublished-changes">
              <span class="exclamation">!</span>
               <span class="description">This casebook has unpublished changes.</span>

--- a/_python/main/templates/includes/table-of-contents.html
+++ b/_python/main/templates/includes/table-of-contents.html
@@ -1,4 +1,5 @@
-{% load include_previous_object times subtract %}
+{% load include_previous_object times subtract call_method %}
+{% if editing %}<p>This Table of Contents is not yet editable.</p>{% endif %}
 <section class="table-of-contents">
   {% if section %}<h5>Section Contents</h5>{% endif %}
   {% with contents.first.ordinals|length as initial_level %}
@@ -9,7 +10,7 @@
           {# Adjust level of nesting as appropriate: first loop if nesting deeper, second loop if unnesting #}
           {% for _ in current_level|subtract:previous_level|times %}
             <div class="section-wrapper">
-              <div class="section-contents">
+              <div class="section-contents{% if editing %} editable{% endif %}">
           {% endfor %}
           {% for _ in previous_level|subtract:current_level|times %}
               </div>
@@ -17,9 +18,10 @@
           {% endfor %}
 
           {# TOC entry #}
-          {% if content.type == 'resource'  %}
+          {% call_method content 'get_edit_or_absolute_url' editing=editing as url %}
+          {% if content.type == 'resource' %}
             <div class="listing-wrapper" data-ordinals="{{ content.ordinal_string }}">
-              <a class="listing resource" href="{{ content.get_absolute_url }}">
+              <a class="listing resource" href="{{ url }}">
                 <div class="section-number">{{ content.ordinal_string }}</div>
                   {% if content.resource_type == 'Case' %}
                     <div class="resource-container">
@@ -63,7 +65,7 @@
             </div>
           {% elif content.type == 'section' %}
             <div class="listing-wrapper" data-ordinals="{{ content.ordinal_string }}">
-              <a class="listing section" href="{{ content.get_absolute_url }}">
+              <a class="listing section" href="{{ url }}">
                 <div class="section-number">{{ content.ordinal_string }}</div>
                 <div class="section-title">{{ content.get_title }}</div>
               </a>

--- a/_python/main/templates/resource.html
+++ b/_python/main/templates/resource.html
@@ -3,10 +3,11 @@
 {% block page_title %}Resource {{ resource.ordinal_string }} | {{ resource.casebook.get_title }}{% endblock %}
 
 {% block banner %}
-{% if resource.casebook.draft_mode_of_published_casebook or not resource.casebook.public %}
+{% if resource.is_or_belongs_to_draft or resource.is_private %}
   <div class="casebook-preview banner">
+    {# TBD: Draft wording is proposed. #}
     <div class="banner-inner">
-      You are viewing a preview of {{ resource.casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
+      You are viewing a preview of {{ resource.is_or_belongs_to_draft|yesno:"your changes,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/resource.html
+++ b/_python/main/templates/resource.html
@@ -26,6 +26,7 @@
           {% include 'includes/breadcrumbs.html' with content=resource %}
           <h1 class="title">{{ resource.get_title }}</h1>
         </header>
+      {% include 'includes/action_buttons.html' with content=resource %}
       {% include 'includes/headnote.html' with content=resource %}
       <section class="resource">
         {% if resource.resource_type == 'Case' or resource.resource_type == 'TextBlock'  %}

--- a/_python/main/templates/resource.html
+++ b/_python/main/templates/resource.html
@@ -6,7 +6,7 @@
 {% if resource.casebook.draft_mode_of_published_casebook or not resource.casebook.public %}
   <div class="casebook-preview banner">
     <div class="banner-inner">
-      You are viewing a preview of a private casebook.
+      You are viewing a preview of {{ resource.casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/resource.html
+++ b/_python/main/templates/resource.html
@@ -2,6 +2,16 @@
 
 {% block page_title %}Resource {{ resource.ordinal_string }} | {{ resource.casebook.get_title }}{% endblock %}
 
+{% block banner %}
+{% if resource.casebook.draft_mode_of_published_casebook or not resource.casebook.public %}
+  <div class="casebook-preview banner">
+    <div class="banner-inner">
+      You are viewing a preview of a private casebook.
+    </div>
+  </div>
+{% endif %}
+{% endblock %}
+
 {% block mainContent %}
   <header class="casebook-public casebook" data-editable="" data-casebook-id="{{ resource.casebook.id }}" data-resource-id="{{ resource.id }}">
     <div class="content">

--- a/_python/main/templates/resource_annotate.html
+++ b/_python/main/templates/resource_annotate.html
@@ -2,18 +2,27 @@
 
 {% block page_title %}Resource {{ resource.ordinal_string }} | {{ resource.casebook.get_title }}{% endblock %}
 
+{% block banner %}
+<div class="casebook-draft banner">
+  <div class="banner-inner">
+    This casebook is a draft and is visible only to collaborators.
+  </div>
+</div>
+{% endblock %}
+
 {% block mainContent %}
-  <header class="casebook-public casebook" data-editable="" data-casebook-id="{{ resource.casebook.id }}" data-resource-id="{{ resource.id }}">
+  <header class="casebook-draft casebook" data-editable="true" data-casebook-id="{{ resource.casebook.id }}" data-resource-id="{{ resource.id }}">
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{{ resource.casebook.get_absolute_url }}">Casebook</a>
-          <span class="tab disabled active">Read</span>
+          <a class="tab" href="{% url 'layout' resource.casebook %}">Casebook</a>
+          <span class="tab disabled active">Annotate</span>
+          <a class="tab" href="{% url 'edit_resource' resource.casebook resource %}">Resource Details</a>
         </div>
       </div>
     </div>
   </header>
-  <section class="casebook-public casebook">
+  <section class="casebook-draft casebook">
     <div class="content">
       <div class="casebook-inner">
         <div class="top-strip"></div>
@@ -23,20 +32,15 @@
           </div>
         </header>
         <header class="content">
+          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=resource %}
           <h1 class="title">{{ resource.get_title }}</h1>
         </header>
         {% include 'includes/action_buttons.html' with content=resource %}
         {% include 'includes/headnote.html' with content=resource %}
         <section class="resource">
-          {% if resource.resource_type == 'Case' or resource.resource_type == 'TextBlock'  %}
-            <the-resource :editable="false" :resource="{{ resource.json }}"></the-resource>
-          {% elif resource.resource_type == 'Default' %}
-            <section class="resource link-resource">
-              Click here to view this linked resource off-site:
-              <a href="{{ resource.resource.url }}" target="_blank">{{ resource.get_title }}</a>
-            </section>
-          {% endif %}
+          <p>This isn't actually editable yet, even though it looks like it!</p>
+          <the-resource :editable="true" :resource="{{ resource.json }}"></the-resource>
         </section>
       </div>
     </div>

--- a/_python/main/templates/resource_annotate.html
+++ b/_python/main/templates/resource_annotate.html
@@ -32,7 +32,6 @@
           </div>
         </header>
         <header class="content">
-          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=resource %}
           <h1 class="title">{{ resource.get_title }}</h1>
         </header>

--- a/_python/main/templates/resource_annotate.html
+++ b/_python/main/templates/resource_annotate.html
@@ -15,7 +15,7 @@
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{% url 'layout' resource.casebook %}">Casebook</a>
+          <a class="tab" href="{% url 'edit_casebook' resource.casebook %}">Casebook</a>
           <span class="tab disabled active">Annotate</span>
           <a class="tab" href="{% url 'edit_resource' resource.casebook resource %}">Resource Details</a>
         </div>

--- a/_python/main/templates/resource_edit.html
+++ b/_python/main/templates/resource_edit.html
@@ -2,18 +2,27 @@
 
 {% block page_title %}Resource {{ resource.ordinal_string }} | {{ resource.casebook.get_title }}{% endblock %}
 
+{% block banner %}
+<div class="casebook-draft banner">
+  <div class="banner-inner">
+    This casebook is a draft and is visible only to collaborators.
+  </div>
+</div>
+{% endblock %}
+
 {% block mainContent %}
-  <header class="casebook-public casebook" data-editable="" data-casebook-id="{{ resource.casebook.id }}" data-resource-id="{{ resource.id }}">
+  <header class="casebook-draft casebook" data-editable="" data-casebook-id="{{ resource.casebook.id }}" data-resource-id="{{ resource.id }}">
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{{ resource.casebook.get_absolute_url }}">Casebook</a>
-          <span class="tab disabled active">Read</span>
+          <a class="tab" href="{% url 'layout' resource.casebook %}">Casebook</a>
+          {% if resource.resource_type == 'Case' or resource.resource_type == 'TextBlock' %}<a class="tab" href="{% url 'annotate_resource' resource.casebook resource %}">Annotate</a>{% endif %}
+          <span class="tab disabled active">Resource Details</span>
         </div>
       </div>
     </div>
   </header>
-  <section class="casebook-public casebook">
+  <section class="casebook-draft casebook">
     <div class="content">
       <div class="casebook-inner">
         <div class="top-strip"></div>
@@ -23,21 +32,13 @@
           </div>
         </header>
         <header class="content">
+          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=resource %}
           <h1 class="title">{{ resource.get_title }}</h1>
         </header>
         {% include 'includes/action_buttons.html' with content=resource %}
         {% include 'includes/headnote.html' with content=resource %}
-        <section class="resource">
-          {% if resource.resource_type == 'Case' or resource.resource_type == 'TextBlock'  %}
-            <the-resource :editable="false" :resource="{{ resource.json }}"></the-resource>
-          {% elif resource.resource_type == 'Default' %}
-            <section class="resource link-resource">
-              Click here to view this linked resource off-site:
-              <a href="{{ resource.resource.url }}" target="_blank">{{ resource.get_title }}</a>
-            </section>
-          {% endif %}
-        </section>
+        {% if resource.resource_type == 'Default' %}This should be a spot to update the URL of the Default/Link {% endif %}
       </div>
     </div>
   </section>

--- a/_python/main/templates/resource_edit.html
+++ b/_python/main/templates/resource_edit.html
@@ -32,7 +32,6 @@
           </div>
         </header>
         <header class="content">
-          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=resource %}
           <h1 class="title">{{ resource.get_title }}</h1>
         </header>

--- a/_python/main/templates/resource_edit.html
+++ b/_python/main/templates/resource_edit.html
@@ -15,7 +15,7 @@
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{% url 'layout' resource.casebook %}">Casebook</a>
+          <a class="tab" href="{% url 'edit_casebook' resource.casebook %}">Casebook</a>
           {% if resource.resource_type == 'Case' or resource.resource_type == 'TextBlock' %}<a class="tab" href="{% url 'annotate_resource' resource.casebook resource %}">Annotate</a>{% endif %}
           <span class="tab disabled active">Resource Details</span>
         </div>

--- a/_python/main/templates/section.html
+++ b/_python/main/templates/section.html
@@ -3,7 +3,7 @@
 {% block page_title %}Section {{ section.ordinal_string }} | {{ section.casebook.get_title }}{% endblock %}
 
 {% block mainContent %}
-  <header class="casebook-public casebook">
+  <header class="casebook-public casebook" data-section-id="{{ section.id }}">
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
@@ -26,6 +26,7 @@
           {% include 'includes/breadcrumbs.html' with content=section %}
           <h1 class="title">{{ section.get_title }}</h1>
         </header>
+        {% include 'includes/action_buttons.html' with content=section %}
         {% include 'includes/headnote.html' with content=section %}
         {% include 'includes/table-of-contents.html' with section=True contents=section.contents  %}
       </div>

--- a/_python/main/templates/section.html
+++ b/_python/main/templates/section.html
@@ -38,7 +38,7 @@
         </header>
         {% include 'includes/action_buttons.html' with content=section %}
         {% include 'includes/headnote.html' with content=section %}
-        {% include 'includes/table-of-contents.html' with section=True contents=contents  %}
+        {% include 'includes/table-of-contents.html' with contents=contents  %}
       </div>
     </div>
   </section>

--- a/_python/main/templates/section.html
+++ b/_python/main/templates/section.html
@@ -3,11 +3,11 @@
 {% block page_title %}Section {{ section.ordinal_string }} | {{ section.casebook.get_title }}{% endblock %}
 
 {% block banner %}
-{% if section.casebook.draft_mode_of_published_casebook or not section.casebook.public %}
+{% if section.is_or_belongs_to_draft or section.is_private %}
   <div class="casebook-preview banner">
      {# TBD: Draft wording is proposed. #}
     <div class="banner-inner">
-      You are viewing a preview of {{ section.casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
+      You are viewing a preview of {{ section.is_or_belongs_to_draft|yesno:"your changes,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/section.html
+++ b/_python/main/templates/section.html
@@ -5,8 +5,9 @@
 {% block banner %}
 {% if section.casebook.draft_mode_of_published_casebook or not section.casebook.public %}
   <div class="casebook-preview banner">
+     {# TBD: Draft wording is proposed. #}
     <div class="banner-inner">
-      You are viewing a preview of a private casebook.
+      You are viewing a preview of {{ section.casebook.draft_mode_of_published_casebook|yesno:"a draft,a private casebook"}}.
     </div>
   </div>
 {% endif %}

--- a/_python/main/templates/section_edit.html
+++ b/_python/main/templates/section_edit.html
@@ -15,7 +15,7 @@
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{% url 'layout' section.casebook %}">Casebook</a>
+          <a class="tab" href="{% url 'edit_casebook' section.casebook %}">Casebook</a>
           <span class="tab disabled active">Edit</span>
         </div>
       </div>

--- a/_python/main/templates/section_edit.html
+++ b/_python/main/templates/section_edit.html
@@ -36,8 +36,7 @@
         </header>
         {% include 'includes/action_buttons.html' with content=section %}
         {% include 'includes/headnote.html' with content=section %}
-        <p>This TOC is a placeholder. It is not yet interactive, it points to the "public" urls rather than the editable views, and, accordingly, lacks the 'editable' class that makes its indentation indicators yellow.</p>
-        {% include 'includes/table-of-contents.html' with section=True contents=section.contents  %}
+        {% include 'includes/table-of-contents.html' with contents=section.contents  %}
       </div>
     </div>
   </section>

--- a/_python/main/templates/section_edit.html
+++ b/_python/main/templates/section_edit.html
@@ -3,27 +3,25 @@
 {% block page_title %}Section {{ section.ordinal_string }} | {{ section.casebook.get_title }}{% endblock %}
 
 {% block banner %}
-{% if section.casebook.draft_mode_of_published_casebook or not section.casebook.public %}
-  <div class="casebook-preview banner">
-    <div class="banner-inner">
-      You are viewing a preview of a private casebook.
-    </div>
+<div class="casebook-draft banner">
+  <div class="banner-inner">
+    This casebook is a draft and is visible only to collaborators.
   </div>
-{% endif %}
+</div>
 {% endblock %}
 
 {% block mainContent %}
-  <header class="casebook-public casebook" data-section-id="{{ section.id }}">
+  <header class="casebook-draft casebook" data-section-id="{{ section.id }}">
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">
-          <a class="tab" href="{{ section.casebook.get_absolute_url }}">Casebook</a>
-          <span class="tab disabled active">Read</span>
+          <a class="tab" href="{% url 'layout' section.casebook %}">Casebook</a>
+          <span class="tab disabled active">Edit</span>
         </div>
       </div>
     </div>
   </header>
-  <section class="casebook-public casebook">
+  <section class="casebook-draft casebook">
     <div class="content">
       <div class="casebook-inner">
         <div class="top-strip"></div>
@@ -33,12 +31,14 @@
           </div>
         </header>
         <header class="content">
+          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=section %}
           <h1 class="title">{{ section.get_title }}</h1>
         </header>
         {% include 'includes/action_buttons.html' with content=section %}
         {% include 'includes/headnote.html' with content=section %}
-        {% include 'includes/table-of-contents.html' with section=True contents=contents  %}
+        <p>This TOC is a placeholder. It is not yet interactive, it points to the "public" urls rather than the editable views, and, accordingly, lacks the 'editable' class that makes its indentation indicators yellow.</p>
+        {% include 'includes/table-of-contents.html' with section=True contents=section.contents  %}
       </div>
     </div>
   </section>

--- a/_python/main/templates/section_edit.html
+++ b/_python/main/templates/section_edit.html
@@ -31,7 +31,6 @@
           </div>
         </header>
         <header class="content">
-          <p>These breadcrumbs don't yet point to editable views.</p>
           {% include 'includes/breadcrumbs.html' with content=section %}
           <h1 class="title">{{ section.get_title }}</h1>
         </header>

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -99,12 +99,22 @@ drf_urlpatterns = [
 urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('', views.index, name='index'),
     path('users/<int:user_id>/', views.dashboard, name='dashboard'),
+    # resources
+    path('casebooks/<idslug:casebook_param>/resources/<ordslug:ordinals_param>/layout/', RedirectView.as_view(pattern_name='resource', permanent=True)),
+    path('casebooks/<idslug:casebook_param>/resources/<ordslug:ordinals_param>/edit/', views.edit_resource, name='edit_resource'),
+    path('casebooks/<idslug:casebook_param>/resources/<ordslug:ordinals_param>/annotate/', views.annotate_resource, name='annotate_resource'),
     path('casebooks/<idslug:casebook_param>/resources/<ordslug:ordinals_param>/', views.resource, name='resource'),
+    # sections
+    path('casebooks/<idslug:casebook_param>/sections/<ordslug:ordinals_param>/layout/', views.edit_section, name='edit_section'),
+    path('casebooks/<idslug:casebook_param>/sections/<ordslug:ordinals_param>/edit/', RedirectView.as_view(pattern_name='edit_section', permanent=True)),
     path('casebooks/<idslug:casebook_param>/sections/<ordslug:ordinals_param>/', views.section, name='section'),
-    path('casebooks/<idslug:casebook_param>/layout/', views.not_implemented_yet, name='layout'),
+    # casebooks
+    path('casebooks/<idslug:casebook_param>/layout/', views.edit_casebook, name='layout'),
+    path('casebooks/<idslug:casebook_param>/edit/', RedirectView.as_view(pattern_name='layout', permanent=True)),
     path('casebooks/<idslug:casebook_param>/clone/', views.clone_casebook, name='clone'),
     path('casebooks/<idslug:casebook_param>/create_draft/', views.create_draft, name='create_draft'),
     path('casebooks/<idslug:casebook_param>/', views.casebook, name='casebook'),
+    # cases
     path('cases/from_capapi', views.from_capapi, name='from_capapi'),
     path('cases/<int:case_id>/', views.case, name='case'),
     # canonical paths for static pages

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -109,8 +109,8 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('casebooks/<idslug:casebook_param>/sections/<ordslug:ordinals_param>/edit/', RedirectView.as_view(pattern_name='edit_section', permanent=True)),
     path('casebooks/<idslug:casebook_param>/sections/<ordslug:ordinals_param>/', views.section, name='section'),
     # casebooks
-    path('casebooks/<idslug:casebook_param>/layout/', views.edit_casebook, name='layout'),
-    path('casebooks/<idslug:casebook_param>/edit/', RedirectView.as_view(pattern_name='layout', permanent=True)),
+    path('casebooks/<idslug:casebook_param>/layout/', views.edit_casebook, name='edit_casebook'),
+    path('casebooks/<idslug:casebook_param>/edit/', RedirectView.as_view(pattern_name='edit_casebook', permanent=True)),
     path('casebooks/<idslug:casebook_param>/clone/', views.clone_casebook, name='clone'),
     path('casebooks/<idslug:casebook_param>/create_draft/', views.create_draft, name='create_draft'),
     path('casebooks/<idslug:casebook_param>/', views.casebook, name='casebook'),

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -294,6 +294,11 @@ def create_draft(request, casebook_param):
         When draft creation is permitted, create one, and redirect to it:
         >>> check_response(client.post(reverse('create_draft', args=[casebook.pk]), as_user=owner_of_draftable_casebook), status_code=302)
     """
+    # NB: in the Rails app, drafts are created via GET rather than POST
+    # Started GET "/casebooks/128853-constitutional-law/resources/1.2.1-marbury-v-madison/create_draft" for 172.18.0.1 at 2019-10-22 18:00:49 +0000
+    # Processing by Content::ResourcesController#create_draft as HTML
+    # Let's not recreate that.
+    # TODO: figure out if this complicates our roll out strategy.
     casebook = get_object_or_404(Casebook, id=casebook_param['id'])
     if casebook.allows_draft_creation_by(request.user):
         clone = casebook.make_draft()

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -245,7 +245,8 @@ def edit_section(request, casebook_param, ordinals_param):
     contents = section.contents.prefetch_resources().order_by('ordinals')
     return render(request, 'section_edit.html', {
         'section': section,
-        'contents': contents
+        'contents': contents,
+        'editing': True
     })
 
 
@@ -268,7 +269,7 @@ def resource(request, casebook_param, ordinals_param):
 
     return render(request, 'resource.html', {
         'resource': resource,
-        'include_vuejs': resource.resource_type in ['Case', 'TextBlock']
+        'include_vuejs': resource.annotatable
     })
 
 
@@ -280,6 +281,7 @@ def edit_resource(request, casebook_param, ordinals_param):
     resource = get_object_or_404(Resource.objects.select_related('casebook'), casebook=casebook_param['id'], ordinals=ordinals_param['ordinals'])
     return render(request, 'resource_edit.html', {
         'resource': resource,
+        'editing': True
     })
 
 
@@ -301,7 +303,8 @@ def annotate_resource(request, casebook_param, ordinals_param):
 
     return render(request, 'resource_annotate.html', {
         'resource': resource,
-        'include_vuejs': resource.resource_type in ['Case', 'TextBlock']
+        'include_vuejs': resource.resource_type in ['Case', 'TextBlock'],
+        'editing': True
     })
 
 

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -59,10 +59,9 @@ def action_buttons(request, context):
             published casebooks must be private. - public casebooks, sections,
             and resources do not have "edit"/"layout"/"annotate" pages
 
-        PREVIEW (by user, casebook field, particular routes) - if you can see
-        a private casebook, section, or resource, you should see a "preview"
-        button on all "edit"/"layout"/"annotate" pages. (You should not see a
-        "preview" button on preview pages.)
+        PREVIEW (by user, casebook field, particular routes) - you should see a
+        "preview" button on all "edit"/"layout"/"annotate" pages. (You should
+        not see a "preview" button on preview pages.)
 
         PUBLISH (by casebook field, particular routes) - if you are on a
         casebook's "edit"/"layout" page, or if you are previewing any private
@@ -77,12 +76,14 @@ def action_buttons(request, context):
         anywhere else, including on a resource's "annotate" page.)
 
         ADD SECTION and ADD RESOURCE (by particular routes) - these buttons
-        should both appear on casebooks "edit"/"layout" pages; they should
+        should both appear on casebooks and sections "edit"/"layout" pages; they should
         appear nowhere else
     """
+    view = request.resolver_match.view_name
     return {
         'previewable': context.get('editing', False),
-        'exportable': True
+        'exportable': True,
+        'can_add_nodes': view in ['layout', 'edit_section']
     }
 
 def render_with_actions(request, template_name, context=None, content_type=None, status=None, using=None):

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -183,7 +183,7 @@ def actions(request, context):
     return actions
 
 def render_with_actions(request, template_name, context=None, content_type=None, status=None, using=None):
-    if 'context' is None:
+    if context is None:
         context = {}
 
     return render(request, template_name, {

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -268,6 +268,7 @@ def create_draft(request, casebook_param):
 @login_required
 def edit_casebook(request, casebook_param):
     # TODO: This should check that the user is a collaborator on the casebook.
+    # TODO: This should 403 or redirect if the casebook is already published.
     # NB: The Rails app does NOT redirect here to a canonical URL; it silently accepts any slug.
     # Duplicating that here.
     casebook = get_object_or_404(Casebook, id=casebook_param['id'])
@@ -301,6 +302,7 @@ def section(request, casebook_param, ordinals_param):
 @login_required
 def edit_section(request, casebook_param, ordinals_param):
     # TODO: This should check that the user is a collaborator on the casebook.
+    # TODO: This should 403 or redirect if the casebook is already published.
     # NB: The Rails app does NOT redirect here to a canonical URL; it silently accepts any slug.
     # Duplicating that here.
     section = get_object_or_404(Section.objects.select_related('casebook'), casebook=casebook_param['id'], ordinals=ordinals_param['ordinals'])
@@ -338,6 +340,7 @@ def resource(request, casebook_param, ordinals_param):
 @login_required
 def edit_resource(request, casebook_param, ordinals_param):
     # TODO: This should check that the user is a collaborator on the casebook.
+    # TODO: This should 403 or redirect if the casebook is already published.
     # NB: The Rails app does NOT redirect here to a canonical URL; it silently accepts any slug.
     # Duplicating that here.
     resource = get_object_or_404(Resource.objects.select_related('casebook'), casebook=casebook_param['id'], ordinals=ordinals_param['ordinals'])
@@ -350,6 +353,7 @@ def edit_resource(request, casebook_param, ordinals_param):
 @login_required
 def annotate_resource(request, casebook_param, ordinals_param):
     # TODO: This should check that the user is a collaborator on the casebook.
+    # TODO: This should 403 or redirect if the casebook is already published.
     # NB: The Rails app does NOT redirect here to a canonical URL; it silently accepts any slug.
     # Duplicating that here.
     resource = get_object_or_404(Resource.objects.select_related('casebook'), casebook=casebook_param['id'], ordinals=ordinals_param['ordinals'])

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -1,9 +1,8 @@
-import requests
-from django.views.decorators.http import require_POST
+import json
 from pyquery import PyQuery
+import requests
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -11,6 +10,8 @@ from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponseBadRequest, JsonResponse, Http404
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
+from django.views.decorators.http import require_POST
+
 
 from test_helpers import check_response
 from .utils import parse_cap_decision_date

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -38,42 +38,55 @@ def action_buttons(request, context):
     """
         See node_decorate.rb, action_button_builder.rb, and _actions.html.erb
 
-        EXPORT - the "export" button appears on all casebook, section, and
-        resource pages, including "edit"/"layout"/"annotate" pages
+        Casebooks
+        # Published casebook, anonymous
+        # - exportable
+        # Published casebook without draft, collaborator
+        # - exportable, cloneable, can_create_draft
+        # Published casebook with draft, collaborator
+        # - exportable, cloneable,  can_view_existing_draft
+        # Never-published casebook
+        # - exportable, cloneable, can_be_directly_edited, publishable
+        # Never-published casebook, edit page
+        # - exportable, cloneable, previewable, publishable
+        # Draft casebook
+        # - exportable, publishable
+        # Draft casebook, edit page
+        # - exportable, previewable, publishable
 
-        CLONE - If you are logged in and if a casebook permits cloning, you
-        should see the "clone" button from the casebook, section, and resource
-        views, and, from the edit_casebook page. (Evidently, you should not
-        be able to clone from the edit_section or edit_resource pages, though.)
+        Sections
+        # In published casebook, anonymous
+        # - exportable
+        # In published casebook without draft, collaborator
+        # - exportable, cloneable , can_create_draft
+        # In published casebook with draft, collaborator
+        # - exportable, cloneable, can_view_existing_draft
+        # In never-published casebook
+        # - exportable, cloneable, can_be_directly_edited
+        # In never-published casebook, edit page
+        # - exportable, previewable
+        # In draft casebook
+        # - exportable, publishable
+        # In draft casebook, edit page
+        # - exportable, previewable, publishable
 
-        REVISE or RETURN TO DRAFT - if you are a collaborator on a casebook and
-        are viewing a public casebook or any of its resources or sections, you
-        should always see either a "revise" or "return to draft" button. If the
-        casebook has a draft associated with it, the button should be "return
-        to draft"; otherwise, it should be "revise". In this case, the "revise"
-        button should create a draft.
-
-        If you are viewing a private book..... it should say "revise" on all
-        preview pages. In this case, "revise" should be a link to the edit view.
-
-        PREVIEW - you should see a "preview" button on all
-        "edit"/"layout"/"annotate" pages. (You should not see a "preview"
-        button on preview pages.)
-
-        PUBLISH - if you are on a casebook's "edit"/"layout" page, or if you
-        are previewing any private casebook, you should see a "publish" button.
-        (You never see a publish button on any resource or section pages.)
-
-        SAVE/CANCEL - every page with a traditional webform should have a
-        "Save" and a "Cancel" button. Therefore, if you are on a casebook's
-        "edit"/"layout" page, a section's "edit"/"layout" page, or resource's
-        "resource details"/"edit" page, you should see a "Save" and a "Cancel"
-        button. (You should not see "Save" or "Cancel" anywhere else, including
-        on a resource's "annotate" page.)
-
-        ADD SECTION and ADD RESOURCE - these buttons should both appear on
-        casebooks and sections "edit"/"layout" pages; they should appear
-        nowhere else
+        Resources
+        # In published casebook, anonymous
+        # - exportable
+        # In published casebook without draft, collaborator
+        # - exportable, cloneable, can_create_draft
+        # In published casebook with draft, collaborator
+        # - exportable, cloneable, can_view_existing_draft
+        # In never-published casebook
+        # - exportable, cloneable, can_be_directly_edited
+        # In never-published casebook, edit page
+        # - exportable, previewable
+        # In draft casebook
+        # - exportable, publishable
+        # In draft casebook, edit page
+        # - exportable, previewable, publishable
+        # In draft casebook, annotate page
+        # - exportable, previewable, publishable
     """
     view = request.resolver_match.view_name
     node = context.get('casebook') or context.get('section') or context.get('resource')
@@ -86,7 +99,7 @@ def action_buttons(request, context):
         'exportable': True,
         'cloneable': cloneable,
         'previewable': context.get('editing', False),
-        'publishable': view == 'edit_casebook' or (view == 'casebook' and node.is_private),
+        'publishable': view == 'edit_casebook' or node.is_private and view in ['casebook', 'section', 'resource'],
         'can_save_nodes': view in ['edit_casebook', 'edit_section', 'edit_resource'],
         'can_add_nodes': view in ['edit_casebook', 'edit_section'],
         'can_be_directly_edited': view in ['casebook', 'resource', 'section'] and node.directly_editable_by(request.user),

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -57,14 +57,13 @@ def action_buttons(request, context):
             published casebooks must be private. - public casebooks, sections,
             and resources do not have "edit"/"layout"/"annotate" pages
 
-        PREVIEW (by user, casebook field, particular routes) - you should see a
-        "preview" button on all "edit"/"layout"/"annotate" pages. (You should
-        not see a "preview" button on preview pages.)
+        PREVIEW - you should see a "preview" button on all
+        "edit"/"layout"/"annotate" pages. (You should not see a "preview"
+        button on preview pages.)
 
-        PUBLISH (by casebook field, particular routes) - if you are on a
-        casebook's "edit"/"layout" page, or if you are previewing any private
-        casebook, you should see a "publish" button. (You never see a publish
-        button on any resource or section pages.)
+        PUBLISH - if you are on a casebook's "edit"/"layout" page, or if you
+        are previewing any private casebook, you should see a "publish" button.
+        (You never see a publish button on any resource or section pages.)
 
         SAVE/CANCEL - every page with a traditional webform should have a
         "Save" and a "Cancel" button. Therefore, if you are on a casebook's
@@ -95,6 +94,7 @@ def action_buttons(request, context):
         'exportable': True,
         'cloneable': cloneable,
         'previewable': context.get('editing', False),
+        'publishable': view == 'edit_casebook' or (view == 'casebook' and not context.get('casebook').public),
         'can_save_nodes': view in ['edit_casebook', 'edit_section', 'edit_resource'],
         'can_add_nodes': view in ['edit_casebook', 'edit_section'],
     }
@@ -182,6 +182,13 @@ def casebook(request, casebook_param):
 
         TODO: test with editors, not only owners.
         TODO: build, then test, action buttons :-)
+        TODO: slashes.
+        > RuntimeError: You called this URL via POST, but the URL
+        > doesn't end in a slash and you have APPEND_SLASH set. Django
+        > can't redirect to the slash URL while maintaining POST data.
+        > Change your form to point to localhost:8001/casebooks/157662/
+        > (note the trailing slash), or set APPEND_SLASH=False in your
+        > Django settings.
 
         Given:
         >>> casebook, casebook_factory, client, admin_user, user_factory = [getfixture(f) for f in ['casebook', 'casebook_factory', 'client', 'admin_user', 'user_factory']]

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -20,6 +20,13 @@ from .models import Casebook, Resource, Section, Case, User, CaseCourt
 
 def login_required_response(request):
     if request.user.is_authenticated:
+        # In the Rails application, this usually (always?) forwards
+        # a user to their own dashboard and flashes a message about
+        # insufficient permissions instead. Per discussion, we've
+        # decided not to implement that for now: the experience
+        # should be rare, and it's not obvious that the redirection
+        # provides a superior user experience. We can readdress if
+        # this turns out to matter to users.
         return HttpResponseForbidden()
     else:
         return redirect_to_login(request.build_absolute_uri())

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -35,18 +35,16 @@ def login_required_response(request):
 
 def action_buttons(request, context):
     """
-        EXPORT (always)
-        - the "export" button appears on all casebook, section, and resource
-          pages, including "edit"/"layout"/"annotate" pages
+        See node_decorate.rb, action_button_builder.rb, and _actions.html.erb
 
-        CLONE (by user, casebook draft field, particular routes) - if you are
-        logged in and can see a casebook, you can clone it, unless that
-        casebook is a draft of a previously published casebook, in which case
-        no one may clone it. If you can clone a casebook, you should see the
-        "clone" button from all casebook pages. If the casebook is public, you
-        should also see the "clone" button from sections' and resources'
-        public pages. (You should not see "clone" from sections' and
-        resources' "edit"/"layout"/"annotate" pages.)
+        EXPORT - the "export" button appears on all casebook, section, and
+        resource pages, including "edit"/"layout"/"annotate" pages
+
+        CLONE - If you are logged in and if a casebook permits cloning, you
+        should see the "clone" button from all casebook pages. If, in addition,
+        the casebook is public, or if you are a collaborator, you should see
+        the "clone" button from sections' and resources' public pages (but not
+        their "edit", "layout", or "annotate" pages.);
 
         REVISE or RETURN TO DRAFT (by user, two casebook fields, particular
         routes) - if you are a collaborator on a casebook and are viewing a
@@ -68,16 +66,16 @@ def action_buttons(request, context):
         casebook, you should see a "publish" button. (You never see a publish
         button on any resource or section pages.)
 
-        SAVE/CANCEL (by particular routes) - every page with a traditional
-        webform should have a "Save" and a "Cancel" button. Therefore, if you
-        are on a casebook's "edit"/"layout" page, a section's "edit"/"layout"
-        page, or resource's "resource details"/"edit" page, you should see a
-        "Save" and a "Cancel" button. (You should not see "Save" or "Cancel"
-        anywhere else, including on a resource's "annotate" page.)
+        SAVE/CANCEL - every page with a traditional webform should have a
+        "Save" and a "Cancel" button. Therefore, if you are on a casebook's
+        "edit"/"layout" page, a section's "edit"/"layout" page, or resource's
+        "resource details"/"edit" page, you should see a "Save" and a "Cancel"
+        button. (You should not see "Save" or "Cancel" anywhere else, including
+        on a resource's "annotate" page.)
 
-        ADD SECTION and ADD RESOURCE (by particular routes) - these buttons
-        should both appear on casebooks and sections "edit"/"layout" pages; they should
-        appear nowhere else
+        ADD SECTION and ADD RESOURCE - these buttons should both appear on
+        casebooks and sections "edit"/"layout" pages; they should appear
+        nowhere else
     """
     view = request.resolver_match.view_name
     return {

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -83,7 +83,7 @@ def action_buttons(request, context):
     return {
         'previewable': context.get('editing', False),
         'exportable': True,
-        'can_add_nodes': view in ['layout', 'edit_section']
+        'can_add_nodes': view in ['edit_casebook', 'edit_section']
     }
 
 def render_with_actions(request, template_name, context=None, content_type=None, status=None, using=None):
@@ -243,7 +243,7 @@ def clone_casebook(request, casebook_param):
     """
     casebook = get_object_or_404(Casebook, id=casebook_param['id'])
     clone = casebook.clone(request.user)
-    return HttpResponseRedirect(reverse('layout', args=[clone.pk]))
+    return HttpResponseRedirect(reverse('edit_casebook', args=[clone.pk]))
 
 
 @login_required

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -212,7 +212,8 @@ def edit_casebook(request, casebook_param):
     contents = casebook.contents.prefetch_resources().order_by('ordinals')
     return render(request, 'casebook_edit.html', {
         'casebook': casebook,
-        'contents': contents
+        'contents': contents,
+        'editing': True
     })
 
 

--- a/app/assets/javascripts/lib/ui/content/save_details.js
+++ b/app/assets/javascripts/lib/ui/content/save_details.js
@@ -3,7 +3,7 @@ import delegate from 'delegate';
 delegate(document, '.submit-resource-details', 'click', submitEditDetailsForm);
 delegate(document, '.cancel-resource-details', 'click', cancelDetailsForm);
 delegate(document, '.submit-section-details', 'click', submitSectionDetailsForm);
-delegate(document, '.cancel-section-defailts', 'click', cancelDetailsForm);
+delegate(document, '.cancel-section-details', 'click', cancelDetailsForm);
 delegate(document, '.submit-casebook-details', 'click', submitCasebookDetailsForm);
 delegate(document, '.cancel-casebook-details', 'click', cancelDetailsForm);
 

--- a/app/services/action_button_builder.rb
+++ b/app/services/action_button_builder.rb
@@ -72,7 +72,7 @@ class ActionButtonBuilder
   end
 
   def cancel_section
-    { link_to: true, text: I18n.t("content.actions.cancel"), path: "#", class: "action one-line cancel cancel-section-defailts" }
+    { link_to: true, text: I18n.t("content.actions.cancel"), path: "#", class: "action one-line cancel cancel-section-details" }
   end
 
   ############

--- a/app/views/layouts/_favicon.html.erb
+++ b/app/views/layouts/_favicon.html.erb
@@ -1,9 +1,1 @@
 <link href="<%= asset_path('favicon.ico') %>" rel="shortcut icon" type="image/vnd.microsoft.icon"></link>
-
-<% # TODO: mobile icons: %>
-<% if false %>
-	<link href="<%= asset_path('favicon.57x57.png') %>" rel="apple-touch-icon" type="image/png"></link>
-	<link href="<%= asset_path('favicon.72x72.png') %>" rel="apple-touch-icon" sizes="72x72" type="image/png"></link>
-	<link href="<%= asset_path('favicon.114x114.png') %>" rel="apple-touch-icon" sizes="114x114" type="image/png"></link>
-	<link href="<%= asset_path('favicon.114x114.png') %>" rel="icon" type="image/png"></link>
-<% end %>


### PR DESCRIPTION
The goal of this PR was to port over the logic for which "action buttons" (e.g. Save, Publish, Clone, Export, etc.) to display on which pages.

This proved a very useful approach for starting to build out the rest of the app: action buttons appear on virtually every page. So, this PR includes a number of partially-implemented views, and, by way of the buttons, exposes much as-yet-unported functionality. For instance, you can click the "publish" button... but it doesn't publish yet! There are no form fields on the pages that should have forms. Etc. I would have preferred not to merge in these half-finished pages... But, I think that's probably impossible short of finishing the port in one go :-) I believe it is unambiguous what has been built and what hasn't. I've included lots of TODOs and topics for discussion. A PR to come soon will address some of the TODOs, and will convert the rest of them to use the better "todo" utility functions.

Working on action buttons also proved a useful project for exposing opportunities for better abstractions in the code base. THANKS @jcushman for the ContentNode db method that arranges for ContentNode querysets to contain Casebook, Section, and Resource instead of ContentNodes. That turns out to make a lot of things cleaner.... We're also starting to tease out the similarities and differences between Casebooks, Sections, and Resources, in anticipation of eventually re-imagining this data model, using less polymorphism and more consistent tree handling. So, there's a lot of refactoring in models.py. I'm trying to make it easy to see at a glance which methods are common to all node types, which methods are implemented by all node types but with differing logic, and which methods are unique to specific node types. We'll see how it holds up.

I've included tests for the action buttons specifically, and a few other tests here and there.... I plan to continue filling in tests, as I fill in more TODOs.