### PR TITLE
Modify differ to handle negative offsets

### DIFF
--- a/lib/differ.rb
+++ b/lib/differ.rb
@@ -58,9 +58,18 @@ module Differ
       }
     end
 
+    # test whether the offset is negative or greater than the text from which the diffs were generated
+    def offset_out_of_bounds? diffs, offset
+      offset < 0 || diffs.last[2].max < offset
+    end
+
     def get_delta_at_offset diffs, offset
+      return 0 if offset_out_of_bounds?(diffs, offset)
+
       # Reverse the list so we find the last diff that includes the offset and for which the offset isn't at the start of the diff (i.e. before the changes in that diff would have any effect)
-      diff = diffs.reverse.find { |diff| diff[2].min < offset }
+      diff = diffs.reverse.find { |diff|
+        diff[2].max >= offset && diff[2].min < offset
+      }
 
       # if the last diff is a deletion, shift the offset backward to the beginning of the deletion,
       # otherwise get the difference between the before and after ranges

--- a/test/lib/differ_test.rb
+++ b/test/lib/differ_test.rb
@@ -38,6 +38,11 @@ class DifferTest < ActiveSupport::TestCase
       assert_equal 0, Differ.get_delta_at_offset(diffs, 5)
     end
 
+    it "should return 0 when the provided offset is less than 0" do
+      diffs = Differ.get_diffs "foo", "foo bar"
+      assert_equal 0, Differ.get_delta_at_offset(diffs, -1)
+    end
+
     it "should return the difference between the original number of characters preceeding this offset and the new number of characters preceeding it" do
       diffs = Differ.get_diffs("foo ipsum", "foo bar lorum ipsum")
       assert_equal 10, Differ.get_delta_at_offset(diffs, 5)


### PR DESCRIPTION
Annotations may have negative offsets as a result of the text beneath
them being deleted.