### PR TITLE
Update scrypt for OS X Mojave compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scrypt (3.0.5)
+    scrypt (3.0.6)
       ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.3)
       thor (~> 0.14)


### PR DESCRIPTION
The particular commit that this needs to pull in is https://github.com/pbhogan/scrypt/commit/8f94ec5ba7c3b59844d12fc4480430c2b7889dc7 , which targets x86_64 instead of i386 arch. 