### PR TITLE
Can move nodes in the content tree

### DIFF
--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -299,7 +299,7 @@ class AnnotationsAdmin(NonLoggingAdmin):
 class UnpublishedRevisionAdmin(NonLoggingAdmin):
     readonly_fields = ['created_at', 'updated_at', 'casebook', 'node', 'node_parent', 'annotation', 'field', 'value']
     list_select_related = ['casebook', 'node', 'node_parent', 'annotation']
-    list_display = ['id', 'the_draft', 'node', 'parent','field', 'value_preview', 'annotation', 'created_at', 'updated_at']
+    list_display = ['id', 'the_draft', 'node', 'version_tree__parent','field', 'value_preview', 'annotation', 'created_at', 'updated_at']
     list_filter = [CasebookIdFilter, 'field']
 
     def the_draft(self, obj):

--- a/_python/test_helpers.py
+++ b/_python/test_helpers.py
@@ -45,7 +45,8 @@ def dump_casebook_outline(casebook):
         ...     '   ContentNode<8> -> Case<2>: Foo Foo1 vs. Bar Bar1',
         ...     '    ContentAnnotation<3>: note 0-10',
         ...     '    ContentAnnotation<4>: replace 0-10',
-        ...     '   ContentNode<9> -> Default<2>: Some Link Name 1'
+        ...     '   ContentNode<9> -> Default<2>: Some Link Name 1',
+        ...     ' Section<10>: Some Section 9',
         ... ]
     """
     out = []
@@ -61,3 +62,16 @@ def dump_casebook_outline(casebook):
             for annotation in node.annotations.all():
                 out.append("%s ContentAnnotation<%s>: %s %s-%s" % (indent, annotation.id, annotation.kind, annotation.global_start_offset, annotation.global_end_offset))
     return out
+
+
+def dump_content_tree(node):
+    """
+        Return a nested list of the content_tree__children for this node, where each child is represented as
+        [<child>, <child.content_tree__parent>, dump_content_tree(child)]
+    """
+    node.content_tree__load()
+    return _dump_content_tree(node)
+
+
+def _dump_content_tree(node):
+    return [[child, child.content_tree__parent, _dump_content_tree(child)] for child in node.content_tree__children]


### PR DESCRIPTION
- Add the `ContentNode.content_tree__move_to` method, as well as a bunch of supporting methods
- Refactor some ancestry methods to start with `version_tree__` (I don't think I hit all of the methods that could use this new naming scheme though)
- Add `-v -v` option for `assert_num_queries`