### PR TITLE
Shift annotations when underlying text is edited

### DIFF
--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -299,7 +299,7 @@ class AnnotationsAdmin(NonLoggingAdmin):
 class UnpublishedRevisionAdmin(NonLoggingAdmin):
     readonly_fields = ['created_at', 'updated_at', 'casebook', 'node', 'node_parent', 'annotation', 'field', 'value']
     list_select_related = ['casebook', 'node', 'node_parent', 'annotation']
-    list_display = ['id', 'the_draft', 'node', 'version_tree__parent','field', 'value_preview', 'annotation', 'created_at', 'updated_at']
+    list_display = ['id', 'the_draft', 'node', 'parent','field', 'value_preview', 'annotation', 'created_at', 'updated_at']
     list_filter = [CasebookIdFilter, 'field']
 
     def the_draft(self, obj):

--- a/_python/main/differ.py
+++ b/_python/main/differ.py
@@ -1,0 +1,140 @@
+from bisect import bisect_right
+from diff_match_patch import diff_match_patch
+
+from .utils import re_split_offsets
+
+
+def assert_offsets_adjusted(before_str, after_str):
+    """
+         This is a test helper for visually testing the AnnotationUpdater.adjust_offset() function. Example:
+
+         >>> assert_offsets_adjusted("f*oo b*ar b*uzz", "f*oo *b*uzz")
+
+         This models an update from "foo bar buzz" to "foo buzz", treating each * as an annotation, and ensures that the
+         stars in the first string are adjusted so that they end up in the specified place in the second string.
+    """
+    # calculate adjusted offsets
+    _, offsets, _ = re_split_offsets(r'\*', before_str)
+    updater = AnnotationUpdater(before_str.replace("*", ""), after_str.replace("*", ""))
+    adjusted_offsets = [updater.adjust_offset(i) for i in offsets]
+
+    # re-insert annotations into after_str using adjusted offsets
+    adjusted_str = after_str.replace("*", "")
+    for offset in reversed(adjusted_offsets):
+        adjusted_str = adjusted_str[:offset] + "*" + adjusted_str[offset:]
+
+    # verify correct results
+    assert adjusted_str == after_str, "%s was adjusted to %s, not %s" % (before_str, adjusted_str, after_str)
+
+
+class AbsoluteDelta(int):
+    def apply_delta(self, offset):
+        return self
+
+
+class RelativeDelta(int):
+    def apply_delta(self, offset):
+        return self + offset
+
+
+class AnnotationUpdater:
+    def __init__(self, before, after):
+        """
+            This function calculates, for each character in `before`, what delta should be applied to annotations
+            for that character so it ends up in the same location in `after`. The results are stored in self.offsets
+            and self.deltas, which are same-size lists kept separate for bisect_right lookups later.
+
+            For example, suppose we have:
+
+                before: "Kids happily eat their meals."
+                after:  "Kids eat their happy meals."
+
+            We need to apply the following deltas to each offset in `before`:
+
+                 Kids happily eat their meals.
+                 |----|-------|---------|-----
+                 +0   =5      -8        -2
+                 |----|---------......|-----
+                 Kids eat their happy meals.
+
+            Note that offsets in the preserved words need to be shifted + or -, but annotations in "happily"
+            need to be set equal to 5 because the word was deleted.
+
+            This gets stored as:
+
+            >>> a = AnnotationUpdater("Kids happily eat their meals.", "Kids eat their happy meals.")
+            >>> assert a.offsets == [0, 5, 13, 23]  # the offset beginning each range in the first string
+            >>> assert a.deltas == [RelativeDelta(0), AbsoluteDelta(5), RelativeDelta(-8), RelativeDelta(-2)]
+        """
+        if before == after:
+            raise ValueError("AnnotationUpdater requires that strings have changed.")
+
+        offset = 0
+        delta = 0
+        self.offsets = offsets = []
+        self.deltas = deltas = []
+
+        for op, text in self.get_dmp_diff(before, after):
+            if op == diff_match_patch.DIFF_EQUAL:
+                # for "equal", start a new range with a relative delta, and push the offset forward
+                offsets.append(offset)
+                deltas.append(RelativeDelta(delta))
+                offset += len(text)
+            elif op == diff_match_patch.DIFF_INSERT:
+                # for "insert", just push the delta forward
+                delta += len(text)
+            else:  # op == diff_match_patch.DIFF_DELETE
+                # for "delete", start a new range with an absolute delta. push the offset forward and delta backward.
+                offsets.append(offset)
+                deltas.append(AbsoluteDelta(offset+delta))
+                offset += len(text)
+                delta -= len(text)
+
+    @staticmethod
+    def get_dmp_diff(before, after):
+        """
+            Get diff from the diff-match-patch library:
+
+            >>> assert AnnotationUpdater.get_dmp_diff("Kids happily eat their meals.", "Kids eat their happy meals.") == [
+            ...     (diff_match_patch.DIFF_EQUAL, "Kids "),
+            ...     (diff_match_patch.DIFF_DELETE, "happily "),
+            ...     (diff_match_patch.DIFF_EQUAL, "eat their "),
+            ...     (diff_match_patch.DIFF_INSERT, "happy "),
+            ...     (diff_match_patch.DIFF_EQUAL, "meals."),
+            ... ]
+        """
+        dmp = diff_match_patch()
+        diffs = dmp.diff_main(before, after)
+        dmp.diff_cleanupSemantic(diffs)
+        return diffs
+
+    def get_first_delta_offset(self):
+        """
+            Return offset of first non-equal operation. Annotations before this point can be left as-is:
+            >>> assert AnnotationUpdater("foo bar", "foo Bar").get_first_delta_offset() == 4
+            >>> assert AnnotationUpdater("foo bar", "bar").get_first_delta_offset() == 0
+        """
+        # find the offset of either the first absolute delta, or the first relative delta with a non-0 value
+        return next((offset for offset, delta in zip(self.offsets, self.deltas) if type(delta) is AbsoluteDelta or delta != 0), -1)
+
+    def adjust_offset(self, offset):
+        """
+            Apply appropriate delta for the given offset:
+
+            >>> assert_offsets_adjusted("fo*o b*uzz", "fo*o bar b*uzz")  # adding word
+            >>> assert_offsets_adjusted("fo*o b*ar b*uzz", "fo*o *b*uzz")  # deleting word
+            >>> assert_offsets_adjusted("fo*o l*orem b*uzz", "fo*o *ipsum b*uzz")  # editing word
+            >>> assert_offsets_adjusted("*ba*r b*uzz*", "foo *ba*r b*uzz* bazz")  # prepending/appending word
+            >>> assert_offsets_adjusted("fo*o ba*r b*uzz b*azz", "*ba*r b*uzz*")  # un-prepending word
+            >>> assert_offsets_adjusted("fo*o ip*sum b*ar b*uzz", "fo*o lorem ip*sum *b*uzz")  # inserting and then deleting word
+
+            TODO: Treatment of inserts right next to annotations is pretty arbitrary,
+            because of the best-effort output of diff_cleanupSemantic to make readable diffs.
+            It would be possible to distinguish between start and end annotations, and always have inserts
+            go inside or outside if one is preferable.
+            >>> assert_offsets_adjusted("foo *bar* baz", "foo *buzz* baz")
+            >>> assert_offsets_adjusted("foo *bar* baz", "foo *lorem bar ipsum* baz")
+            >>> assert_offsets_adjusted("foo *bar* baz", "foo *bar* ipsum baz")  # ipsum is outside, unlike previous example, because of diff cleanup
+            >>> assert_offsets_adjusted("foo *bar* baz", "foo re*barbosa* baz")  # one goes inside and one outside
+        """
+        return self.deltas[bisect_right(self.offsets, offset)-1].apply_delta(offset)

--- a/_python/main/utils.py
+++ b/_python/main/utils.py
@@ -82,3 +82,21 @@ def fix_before_deploy(message):
 def fix_after_rails(message):
     """ Use this to document actions that should be taken after the migration to Python is complete. """
     pass
+
+
+def re_split_offsets(pattern, s):
+    """
+        Split a string by regular expression, and return the substrings, the offsets for each separator, and the text
+        of each separator. This is useful for setting up annotation test templates. Example:
+
+        >>> assert re_split_offsets(r'[A-Z]', "AaaBbbCccDdd") == (
+        ...     ["", "aa", "bb", "cc", "dd"],
+        ...     [0, 2, 4, 6],
+        ...     ["A", "B", "C", "D"],
+        ... )
+    """
+    parts = re.split(r'(%s)' % pattern, s)
+    strs = [parts[i] for i in range(0, len(parts), 2)]
+    split_strs = [parts[i] for i in range(1, len(parts), 2)]
+    split_offsets = [sum(len(s) for s in strs[:i+1]) for i in range(len(strs)-1)]
+    return strs, split_offsets, split_strs

--- a/_python/requirements.in
+++ b/_python/requirements.in
@@ -12,6 +12,7 @@ psycopg2            # postgres connector
 bleach              # html sanitization
 rubymarshal         # read ruby session cookies
 cryptography        # read ruby session cookies
+diff-match-patch    # update annotations when underlying text changes
 
 # Testing
 pytest

--- a/_python/requirements.txt
+++ b/_python/requirements.txt
@@ -116,6 +116,8 @@ cssselect==1.1.0 \
     --hash=sha256:f612ee47b749c877ebae5bb77035d8f4202c6ad0f0fc1271b3c18ad6c4468ecf \
     --hash=sha256:f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc \
     # via pyquery
+diff-match-patch==20181111 \
+    --hash=sha256:a809a996d0f09b9bbd59e9bbd0b71eed8c807922512910e05cbd3f9480712ddb
 django-crispy-forms==1.8.0 \
     --hash=sha256:0320b303420fec9ce94e045321dfd180ca0e31e0336211c5d30ad0bda5ebbb5d \
     --hash=sha256:22b6634e3a6316623e4eb062527fe5be5f97ea8b83020c65bcd8fac4747807b5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: ./_python/Dockerfile
-    image: h2o-python:0.7
+    image: h2o-python:0.8
     tty: true
     command: bash
     environment:


### PR DESCRIPTION
This ports over the code from differ.rb and adds code to update annotations when Case or TextBlock content is modified.

There are two new sources of error introduced during the port (in addition to the usual may-not-have-done-it-right source):

(1) lxml may extract text from html differently from the Ruby html parser
(2) I modified the internal data structure from differ.rb so it looks like:

```
offsets = [0, 5, 13, 23]  # the offset beginning each range in the first string
deltas = [RelativeDelta(0), AbsoluteDelta(5), RelativeDelta(-8), RelativeDelta(-2)]  # how to adjust offsets within each range 
```

This basically precalculates the delta to apply for every given offset. The `diffs` data structure in the current ruby instead looks like this:

```
[(0, 'Kids ', Range(min=0, max=5), Range(min=0, max=5)),
 (-1, 'happily ', Range(min=5, max=13), Range(min=5, max=13)),
 (0, 'eat their ', Range(min=13, max=23), Range(min=5, max=15)),
 (1, 'happy ', Range(min=23, max=29), Range(min=15, max=21)),
 (0, 'meals.', Range(min=23, max=29), Range(min=21, max=27))]
```

... which I find a little less intuitive as far as knowing how to adjust a given offset.

So, given the various things that can break here, we'll definitely want to do some checking of this one on real data! To make things a little easier, I added some test helpers that take readable text input and output, so it's easy to collect edge case examples.

---

A major question I'm not clear on, but you might be, is what to do with annotations for text that is deleted. The current ruby code sets the start and stop offsets to -1, so this does too. I think that implies deleting them. So:

(a) how and when should annotations with -1 offsets be filtered out or removed?
(b) is that actually correct? like it makes sense to remove a "highlight" or "delete" annotation, but what about a note?

---

Also in this PR:

- revert a find-replace mistake from the version_tree PR
- Add an `EditTrackedModel` model that represents my newest swing at tracking edited fields on Django models