### PR TITLE
Publishing casebooks

### DIFF
--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'main.middleware.generated_by_header_middleware',
+    'main.middleware.method_override_middleware',
 
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -205,3 +205,6 @@ NOT_ON_PRODUCTION = False
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 CRISPY_FAIL_SILENTLY = False
+
+# Temporary: this is the name of the CSRF header used by the Rails app's AJAX requests
+CSRF_HEADER_NAME = 'HTTP_X_CSRF_TOKEN'

--- a/_python/main/middleware.py
+++ b/_python/main/middleware.py
@@ -100,3 +100,22 @@ def generated_by_header_middleware(get_response):
         response['X-Generated-By'] = 'python'
         return response
     return middleware
+
+
+### http-header-based method overriding ###
+
+METHOD_OVERRIDE_HEADER = 'HTTP_X_HTTP_METHOD_OVERRIDE'
+
+def method_override_middleware(get_response):
+    """
+        Temporary middleware during migration to implement Rails-style HTTP method overriding,
+        so that AJAX requests that are REALLY "POST", but include headers like
+        "X-HTTP-Method-Override: PATCH" are treated as PATCH, PUT, DELETE, etc.
+        https://www.django-rest-framework.org/topics/browser-enhancements/#http-header-based-method-overriding
+    """
+    def middleware(request):
+        if request.method == 'POST' and METHOD_OVERRIDE_HEADER in request.META:
+            request.method = request.META[METHOD_OVERRIDE_HEADER].upper()
+        return get_response(request)
+    return middleware
+

--- a/_python/main/templates/includes/action_buttons.html
+++ b/_python/main/templates/includes/action_buttons.html
@@ -1,7 +1,7 @@
 <aside class="casebook-actions" data-actions="{{ action_list }}">
   {% if publishable %}
     <button type="button" class="action publish one-line">Publish{% if content.is_or_belongs_to_draft %} Changes{% endif %}</button>
-    {# TODO: this opens a modal that POSTs (PATCHs?) to the casebook route. Implement that! #}
+    {% csrf_token %}
   {% endif %}
   {% if previewable %}
     <a class="action one-line preview" href="{{ content.get_absolute_url }}">Preview</a>

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -113,7 +113,9 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('casebooks/<idslug:casebook_param>/edit/', RedirectView.as_view(pattern_name='edit_casebook', permanent=True)),
     path('casebooks/<idslug:casebook_param>/clone/', views.clone_casebook, name='clone'),
     path('casebooks/<idslug:casebook_param>/create_draft/', views.create_draft, name='create_draft'),
+    # TODO: we temporarily need to list with and without trailing slash, to handle POSTs without slashes
     path('casebooks/<idslug:casebook_param>/', views.casebook, name='casebook'),
+    path('casebooks/<idslug:casebook_param>', views.casebook, name='casebook'),
     # cases
     path('cases/from_capapi', views.from_capapi, name='from_capapi'),
     path('cases/<int:case_id>/', views.case, name='case'),

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -114,8 +114,8 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('casebooks/<idslug:casebook_param>/clone/', views.clone_casebook, name='clone'),
     path('casebooks/<idslug:casebook_param>/create_draft/', views.create_draft, name='create_draft'),
     # TODO: we temporarily need to list with and without trailing slash, to handle POSTs without slashes
-    path('casebooks/<idslug:casebook_param>/', views.casebook, name='casebook'),
-    path('casebooks/<idslug:casebook_param>', views.casebook, name='casebook'),
+    path('casebooks/<idslug:casebook_param>/', views.CasebookView.as_view(), name='casebook'),
+    path('casebooks/<idslug:casebook_param>', views.CasebookView.as_view(), name='casebook'),
     # cases
     path('cases/from_capapi', views.from_capapi, name='from_capapi'),
     path('cases/<int:case_id>/', views.case, name='case'),

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -329,8 +329,10 @@ class CasebookView(View):
         casebook = get_object_or_404(Casebook, id=casebook_param['id'])
 
         # check permissions
-        if not casebook.viewable_by(request.user):
+        if not casebook.editable_by(request.user):
             raise PermissionDenied
+        if casebook.is_public:
+            raise PermissionDenied("Only private casebooks may be published.")
 
         if casebook.draft_mode_of_published_casebook:
             casebook = casebook.merge_draft()

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -340,18 +340,18 @@ def clone_casebook(request, casebook_param):
 
         If the casebook can be cloned, do so, then redirect to new clone:
         >>> casebook = owner_of_cloneable_casebook.casebooks.first()
-        >>> check_response(client.post(reverse('clone', args=[casebook.pk]), as_user=user), status_code=302)
-        >>> check_response(client.post(reverse('clone', args=[casebook.pk]), as_user=owner_of_cloneable_casebook), status_code=302)
+        >>> check_response(client.post(reverse('clone', args=[casebook]), as_user=user), status_code=302)
+        >>> check_response(client.post(reverse('clone', args=[casebook]), as_user=owner_of_cloneable_casebook), status_code=302)
 
         Otherwise, return Permission Denied:
         >>> casebook = owner_of_uncloneable_casebook.casebooks.first()
-        >>> check_response(client.post(reverse('clone', args=[casebook.pk]), as_user=user), status_code=403)
-        >>> check_response(client.post(reverse('clone', args=[casebook.pk]), as_user=owner_of_uncloneable_casebook), status_code=403)
+        >>> check_response(client.post(reverse('clone', args=[casebook]), as_user=user), status_code=403)
+        >>> check_response(client.post(reverse('clone', args=[casebook]), as_user=owner_of_uncloneable_casebook), status_code=403)
     """
     casebook = get_object_or_404(Casebook, id=casebook_param['id'])
     if casebook.permits_cloning:
         clone = casebook.clone(request.user)
-        return HttpResponseRedirect(reverse('edit_casebook', args=[clone.pk]))
+        return HttpResponseRedirect(reverse('edit_casebook', args=[clone]))
     raise PermissionDenied
 
 
@@ -368,14 +368,14 @@ def create_draft(request, casebook_param):
 
         Only some casebooks can be edited via this draft mechanism.
         >>> for casebook in owner_of_undraftable_casebooks.casebooks.all():
-        ...     check_response(client.post(reverse('create_draft', args=[casebook.pk]), as_user=owner_of_undraftable_casebooks), status_code=403)
+        ...     check_response(client.post(reverse('create_draft', args=[casebook]), as_user=owner_of_undraftable_casebooks), status_code=403)
 
         And, drafts can only be created by authorized users.
         >>> casebook = owner_of_draftable_casebook.casebooks.first()
-        >>> check_response(client.post(reverse('create_draft', args=[casebook.pk]), as_user=user), status_code=403)
+        >>> check_response(client.post(reverse('create_draft', args=[casebook]), as_user=user), status_code=403)
 
         When draft creation is permitted, create one, and redirect to it:
-        >>> check_response(client.post(reverse('create_draft', args=[casebook.pk]), as_user=owner_of_draftable_casebook), status_code=302)
+        >>> check_response(client.post(reverse('create_draft', args=[casebook]), as_user=owner_of_draftable_casebook), status_code=302)
     """
     # NB: in the Rails app, drafts are created via GET rather than POST
     # Started GET "/casebooks/128853-constitutional-law/resources/1.2.1-marbury-v-madison/create_draft" for 172.18.0.1 at 2019-10-22 18:00:49 +0000
@@ -385,7 +385,7 @@ def create_draft(request, casebook_param):
     casebook = get_object_or_404(Casebook, id=casebook_param['id'])
     if casebook.allows_draft_creation_by(request.user):
         clone = casebook.make_draft()
-        return HttpResponseRedirect(reverse('edit_casebook', args=[clone.pk]))
+        return HttpResponseRedirect(reverse('edit_casebook', args=[clone]))
     raise PermissionDenied
 
 

--- a/app/assets/javascripts/lib/requests.js
+++ b/app/assets/javascripts/lib/requests.js
@@ -1,8 +1,17 @@
 import Axios from 'axios';
 
 export function request (url, method, data = {}, options = {scroll: true}) {
-  const csrf_el = document.querySelector('meta[name=csrf-token]');
-  let headers = csrf_el ? {'X-CSRF-Token': csrf_el.getAttribute('content')} : {};
+
+  // For now, separate handling of csrf in the Rails and Django apps.
+  const rails_csrf_el = document.querySelector('meta[name=csrf-token]');
+  const django_csrf_el = document.querySelector('[name=csrfmiddlewaretoken]');
+  let csrf_token = undefined;
+  if (rails_csrf_el){
+    csrf_token = rails_csrf_el.getAttribute('content');
+  } else if (django_csrf_el){
+    csrf_token = django_csrf_el.value;
+  }
+  let headers = csrf_token ? {'X-CSRF-Token': csrf_token} : {};
   headers['X-HTTP-Method-Override'] = method;
 
   let promise = Axios.post(url, data, {headers: headers});

--- a/app/assets/javascripts/lib/requests.js
+++ b/app/assets/javascripts/lib/requests.js
@@ -1,5 +1,12 @@
 import Axios from 'axios';
 
+function destroy_modal(modal) {
+  if(modal){
+    modal.el.dataset.processing = "false";
+    modal.destroy();
+  }
+}
+
 export function request (url, method, data = {}, options = {scroll: true}) {
 
   // For now, separate handling of csrf in the Rails and Django apps.
@@ -21,6 +28,28 @@ export function request (url, method, data = {}, options = {scroll: true}) {
       throw e;
     })
     .then(response => {
+
+      // Throw in some quick error handling.
+      if (response.status != 200) {
+        // The user should be notified here; we don't have a mechanism
+        // for doing that yet, and I don't want to use alert();
+        console.error(`AJAX request failed with ${response.status}.`)
+
+        destroy_modal(options["modal"])
+        return
+      }
+
+      // This code actually expects successful AJAX requests to receive
+      // a redirect as a response. Axios follows the redirect, performing
+      // a GET of the page we want the browser to display next. Here, we
+      // examine the URL of we just retrieved, and compare it to the URL
+      // of the page we are presently on. If we are already on that page,
+      // we perform a refresh. Otherwise, we direct the browser there.
+      // In all cases, this performs a duplicate GET.
+      //
+      // Let's have a think on how we might redesign this in the future.
+      // Probably a mix of more Vue, and switching from AJAX to standard
+      // form submissions.
       let html = response.data;
       let location = response.request.responseURL;
 
@@ -36,9 +65,8 @@ export function request (url, method, data = {}, options = {scroll: true}) {
         window.location.replace(location);
       }
 
-      if (options["modal"]){
-        options["modal"].destroy();
-      }
+      // Is this code reachable? I don't see how; keeping it for now.
+      destroy_modal(options["modal"])
 
     })
     .done(); 

--- a/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
+++ b/app/assets/javascripts/lib/ui/content/publish_modal.js.erb
@@ -13,12 +13,15 @@ function casebook_path(resourceId, format = 'pdf') {
 }
 
 function showPublishModal (e) {
-  new PublishModal('publish-modal', e.target, {
+  let modal = new PublishModal('publish-modal', e.target, {
     'click .confirm': (e) => {
       showSpinner();
       e.currentTarget.dataset.processing = "true" // override the component destroy events
       let casebookId = document.querySelector('main > header').dataset.casebookId;
-      patch(casebook_path(casebookId), {content_casebook: {public: true}});
+      // TODO: I think this wants to be a standard POST form submission.
+      // It doesn't even need to be AJAX, since publishing should never fail,
+      // and we need to re-render the whole page or redirecting to another page after success.
+      patch(casebook_path(casebookId), {content_casebook: {public: true}}, {modal: modal});
     },
   });
 }

--- a/app/webpacker/config/axios.js
+++ b/app/webpacker/config/axios.js
@@ -3,8 +3,16 @@ import AxiosConfig from "axios";
 
 let headers = {"Content-Type": "application/json",
                "Accept": "application/json"};
-const csrf_el = document.querySelector("meta[name=csrf-token]");
-if(csrf_el) headers["X-CSRF-Token"] = csrf_el.getAttribute("content");
+// For now, separate handling of csrf in the Rails and Django apps.
+const rails_csrf_el = document.querySelector('meta[name=csrf-token]');
+const django_csrf_el = document.querySelector('[name=csrfmiddlewaretoken]');
+let csrf_token = undefined;
+if (rails_csrf_el){
+  csrf_token = rails_csrf_el.getAttribute('content');
+} else if (django_csrf_el){
+  csrf_token = django_csrf_el.value;
+}
+if(csrf_token) headers["X-CSRF-Token"] = csrf_token;
 
 const Axios = AxiosConfig.create({headers: headers});
 

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,4 +2,15 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 
+// These changes make development easier during this in-between
+// time where we are running in Rails and Django simultaneously:
+// the Django setup wants assets on disk, not in memory, and wants
+// them to have reliable names.
+
+// Write assets to disk, don't store in memory
+environment.config.merge({devServer: {writeToDisk: true}});
+// Don't use hashes in development
+environment.config.merge({output: {filename: 'js/[name].js'}});
+environment.plugins.get('MiniCssExtract').options.filename = 'css/[name].css';
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
This PR adds the ability to publish a private casebook, both a) a newly-composed casebook that has never been published, and b) a draft of an already-published casebook, whose publication == "merging" the draft into the parent.

It's pretty simple, but includes some extras:
- some JS that pulls Django's CSRF token out of the page for use in AJAX requests
- some middleware that re-creates Rails' strategy of listening for a "X-CSRF-TOKEN" in requests, and if present, using it's value ("PATCH", "PUT", "DELETE", etc.) in place of the truly received HTTP verb (POST) when routing requests.
- a temporary duplication of the `casebooks` route in `urls.py` to work around a regrettable situation with trailing slashes.....
- a tweaking of the Webpack dev server, to smooth things while we need functional Rails and Django setups.