### PR TITLE
Publishing from a draft's "section" page

### DIFF
--- a/_python/main/templates/section_edit.html
+++ b/_python/main/templates/section_edit.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <header class="casebook-draft casebook" data-section-id="{{ section.id }}">
+  <header class="casebook-draft casebook" data-casebook-id="{{ section.casebook.id }}" data-section-id="{{ section.id }}">
     <div class="content">
       <div class="casebook-inner">
         <div class="tabs">


### PR DESCRIPTION
You can publish a draft (revision of a previously-published casebook) while viewing one of its sections. For that modal/javascript to work, it turns out that the id of the parent casebook has to be present in the html, as per this PR. 

This is interesting.... do we want to have functional tests for each action button on each page....

Ugh.