### PR TITLE
Serve the Django admin at /django-admin…

### DIFF
--- a/_python/config/urls.py
+++ b/_python/config/urls.py
@@ -20,7 +20,7 @@ from main.admin import admin_site
 urlpatterns = [
     path('', include('main.urls')),
     path('search/', include('search.urls')),
-    path('admin/', admin_site.urls),
+    path('django-admin/', admin_site.urls),
 ]
 
 # use django-debug-toolbar if installed


### PR DESCRIPTION
...so it doesn't hide the Rails admin, which is served at /admin.