### PR TITLE
Add mandatory @perms_test decorator for views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ package-lock.json
 
 # IntelliJ IDEA
 *.iml
+.vscode

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -142,6 +142,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 RAILS_SECRET_KEY_BASE = None
 
+LOGIN_URL = '/user_sessions/new'
 GUIDE_URL = 'https://about.opencasebook.org/'
 BLOG_URL = 'https://about.opencasebook.org/blog/'
 CAPAPI_CASE_URL_FSTRING = 'https://api.case.law/v1/cases/{}/'

--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     # third party
     'django_extensions',
     'crispy_forms',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [
@@ -205,3 +206,9 @@ CRISPY_FAIL_SILENTLY = False
 
 # Temporary: this is the name of the CSRF header used by the Rails app's AJAX requests
 CSRF_HEADER_NAME = 'HTTP_X_CSRF_TOKEN'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',  # authenticate with Django login
+    ),
+}

--- a/_python/config/settings/settings_pytest.py
+++ b/_python/config/settings/settings_pytest.py
@@ -1,0 +1,13 @@
+# Django settings used by pytest
+
+# WARNING: this imports from .settings_dev instead of config.settings, meaning it chooses to IGNORE any settings in
+# config/settings/settings.py. This is potentially better (in that it doesn't return different results locally than
+# it will on CI), but also potentially worse (in that you can't try out settings tweaks in settings.py and run tests
+# against them).
+
+from .settings_dev import *
+
+# Don't use whitenoise for tests. Including whitenoise causes it to rescan static during each test, which greatly
+# increases test time.
+MIDDLEWARE.remove('whitenoise.middleware.WhiteNoiseMiddleware')
+

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -343,80 +343,11 @@ def full_casebook_with_draft(full_casebook):
     casebook.make_draft()
     return casebook
 
-@pytest.fixture
-def user_with_cloneable_casebook(casebook_factory, user_factory):
-    """
-        Standard casebooks can be cloned.
-
-        >>> user = getfixture('user_with_cloneable_casebook')
-        >>> casebook = user.casebooks.first()
-        >>> assert casebook.permits_cloning
-    """
-    user = user_factory()
-    casebook_factory(contentcollaborator_set__user=user)
-    return user
-
 
 @pytest.fixture
-def user_with_uncloneable_casebook(casebook_factory, user_factory):
-    """
-        Casebooks that are drafts of already-published casebooks may not
-        be cloned.
-
-        >>> user = getfixture('user_with_uncloneable_casebook')
-        >>> casebook = user.casebooks.first()
-        >>> assert not casebook.permits_cloning
-    """
-    user = user_factory()
-    casebook_factory(
-        contentcollaborator_set__user=user,
-        draft_mode_of_published_casebook=True
-    )
-    return user
-
-
-@pytest.fixture
-def user_with_draftable_casebook(casebook_factory, user_factory):
-    """
-        Already-published casebooks may be edited via the draft mechanism.
-
-        >>> user = getfixture('user_with_draftable_casebook')
-        >>> casebook = user.casebooks.first()
-        >>> assert casebook.allows_draft_creation_by(user)
-    """
-    user = user_factory()
-    casebook_factory(
-        contentcollaborator_set__user=user,
-        public=True
-    )
-    return user
-
-
-@pytest.fixture
-def user_with_undraftable_casebooks(casebook_factory, user_factory):
-    """
-        Private casebooks may be edited directly; they may not be edited
-        via the draft mechanism.
-
-        >>> user = getfixture('user_with_undraftable_casebooks')
-        >>> casebook = user.casebooks.first()
-        >>> assert not casebook.allows_draft_creation_by(user)
-
-        Casebooks may only have one draft at a time.
-        >>> casebook = user.casebooks.last()
-        >>> assert not casebook.allows_draft_creation_by(user)
-    """
-    user = user_factory()
-    casebook_factory(
-        contentcollaborator_set__user=user,
-        public=False
-    )
-    casebook = casebook_factory(
-        contentcollaborator_set__user=user,
-        public=True
-    )
-    casebook.make_draft()
-    return user
+def other_user(user_factory):
+    """ A user who has no relationship to a given casebook. """
+    return user_factory()
 
 
 @pytest.fixture

--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -64,8 +64,9 @@ class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
 
-    attribution = factory.Sequence(lambda n: 'Attribution %s' % n)
+    attribution = factory.Sequence(lambda n: 'Some User %s' % n)
     affiliation = factory.Sequence(lambda n: 'Affiliation %s' % n)
+    verified_email = True
 
 
 @register_factory
@@ -86,6 +87,19 @@ class CasebookFactory(ContentNodeFactory):
 
     contentcollaborator_set = factory.RelatedFactory('conftest.ContentCollaboratorFactory', 'content')
     title = factory.Sequence(lambda n: 'Some Title %s' % n)
+    public = True
+
+
+@register_factory
+class PrivateCasebookFactory(CasebookFactory):
+    public = False
+
+
+@register_factory
+class DraftCasebookFactory(CasebookFactory):
+    public = False
+    draft_mode_of_published_casebook=True
+    copy_of = factory.SubFactory(CasebookFactory)
 
 
 @register_factory
@@ -104,8 +118,8 @@ class ResourceFactory(ContentNodeFactory):
         model = Resource
 
     casebook = factory.SubFactory(CasebookFactory)
-    resource_type = None
-    resource_id = None
+    resource_type = 'Case'
+    resource_id = factory.LazyFunction(lambda: CaseFactory().id)
 
 
 @register_factory
@@ -177,6 +191,11 @@ class CaseFactory(factory.DjangoModelFactory):
 
 
 @register_factory
+class PrivateCaseFactory(CaseFactory):
+    public = False
+
+
+@register_factory
 class ContentAnnotationFactory(factory.DjangoModelFactory):
     class Meta:
         model = ContentAnnotation
@@ -213,7 +232,7 @@ def casebook_tree(casebook_factory):
 
 @pytest.fixture
 def admin_user(user_factory):
-    user = user_factory()
+    user = user_factory(attribution='Admin')
     role, created = Role.objects.get_or_create(name='superadmin')
     user.roles.add(role)
     return user

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -1163,6 +1163,14 @@ class Casebook(CasebookAndSectionMixin, ContentNode):
 
     objects = CasebookManager()
 
+    @property
+    def sections(self):
+        return Section.objects.filter(casebook=self)
+
+    @property
+    def resources(self):
+        return Resource.objects.filter(casebook=self)
+
     def get_absolute_url(self):
         """See ContentNode.get_absolute_url"""
         return reverse('casebook', args=[self])

--- a/_python/main/test/test_permissions.py
+++ b/_python/main/test/test_permissions.py
@@ -1,0 +1,105 @@
+import pytest
+
+from django.template import Variable
+from django.urls import reverse
+
+from ..urls import urlpatterns
+from test_helpers import check_response
+
+
+"""
+    This file applies the tests that are attached to each view via the @perms_test decorator.
+    A particular test looks like this:
+    
+        @perms_test({'method': 'post', 'args': ['casebook'], 'results': {302: ['casebook.owner', 'admin_user'], 403: ['other_user'], 'login': [None]}})
+        def some_view(request, casebook): ...
+    
+    This means the test should POST to `reverse(some_view, args=[casebook])`, and that casebook.owner and admin_user
+    should receive a 302 response; other_user should receive a 403; and non-auth requests should redirect to the login
+    form. 
+"""
+
+
+def get_permissions_tests():
+    """
+        This function runs during test collection time. It inspects each route in main.urls, and generates parameters
+        for the test_permissions() test below.
+    """
+    for path in urlpatterns:
+        view_func = path.callback
+
+        # don't run tests on built-in views:
+        if view_func.__name__ in ['RedirectView', 'TemplateView']:
+            continue
+
+        # retrieve the test config for this view, which will have been attached as view_func.perms_test by the
+        # @perms_test decorator
+        if not hasattr(view_func, 'perms_test') and hasattr(view_func, 'view_class'):
+            # for class-based views, inspect each request method separately:
+            view_class = path.callback.view_class
+            to_test = [(m.lower(), getattr(getattr(view_class, m.lower()), 'perms_test', None)) for m in view_class()._allowed_methods() if m != 'OPTIONS']
+        else:
+            # just one test config for regular function-based views:
+            to_test = [('get', getattr(view_func, 'perms_test', None))]
+
+        # yield test_permissions parameters for each test config detected:
+        for default_request_method, test_config in to_test:
+            if test_config is None:
+                yield path, False, None, None, None, None, None
+                continue
+            for test in test_config:
+                request_method = test.get('method', default_request_method)
+                url_args = test.get('args', [])
+                for status_code, users in test['results'].items():
+                    for user_string in users:
+                        yield path, True, view_func, url_args, request_method, status_code, user_string
+
+
+@pytest.mark.parametrize("path, has_tests, view_func, url_args, request_method, status_code, user_string", get_permissions_tests())
+def test_permissions(
+        # regular test fixtures
+        client, request,
+        # parameters from get_permissions_tests()
+        path, has_tests, view_func, url_args, request_method, status_code, user_string
+):
+    """
+        This test function runs a single request on behalf of a single user. The example at the top of this file would
+        run this function four separate times.
+    """
+    # all routes are required to have tests
+    if not has_tests:
+        raise Exception(
+            "View function or method for path %s is missing a @perms_test decorator. "
+            "Use @no_perms_test if you are sure your view doesn't need tests." % path)
+
+    # Helper method to fetch and return a particular fixture, like 'casebook' or 'casebook.owner'.
+    # Values are also stored in the `context` dictionary so they can be reused instead of recreated.
+    # The part of `path` before the first period is treated as a pytest fixture, and the remainder is
+    # resolved using the Django template language (so lookups like 'casebook.resources.1.some_func'
+    # will work).
+    def hydrate(context, path):
+        if path not in context:
+            fixture_name = path.split('.', 1)[0]
+            if fixture_name not in context:
+                context[fixture_name] = request.getfixturevalue(fixture_name)
+            if fixture_name != path:
+                context[path] = Variable(path).resolve(context)
+        return context[path]
+
+    # Special handling for status code 'login' -- expect a 302, but also check that we redirect to
+    # the login page. This lets us differentiate from pages that redirect on success.
+    should_redirect_to_login = False
+    if status_code == 'login':
+        status_code = 302
+        should_redirect_to_login = True
+
+    # run request
+    context = {}
+    url = reverse(view_func, args=[hydrate(context, arg) for arg in url_args])
+    user = hydrate(context, user_string) if user_string else None
+    response = getattr(client, request_method)(url, as_user=user)
+
+    # check response
+    check_response(response, status_code=status_code)
+    if should_redirect_to_login:
+        assert response.url.startswith('/user_sessions/new'), "View failed to redirect to login page"

--- a/_python/main/test/test_permissions_helpers.py
+++ b/_python/main/test/test_permissions_helpers.py
@@ -1,0 +1,50 @@
+"""
+    This file contains helpers for the permissions tests in test_permissions.py. These can't go in test_permissions.py
+    without causing a circular import, as they need to be imported from views.py and urls.py and that file needs to
+    inspect urls.py during test setup.
+"""
+
+# test configs for use in @perms_test
+viewable_section = [
+    {'args': ['full_casebook', 'full_casebook.sections.first'], 'results': {200: [None, 'other_user', 'full_casebook.owner']}},
+    {'args': ['full_private_casebook', 'full_private_casebook.sections.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.sections.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+]
+directly_editable_section = [
+    {'args': ['full_casebook', 'full_casebook.sections.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
+    {'args': ['full_private_casebook', 'full_private_casebook.sections.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.sections.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+]
+viewable_resource = [
+    {'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {200: [None, 'other_user', 'full_casebook.owner']}},
+    {'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+]
+directly_editable_resource = [
+    {'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
+    {'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+]
+patch_directly_editable_resource = [
+    {'method': 'patch', 'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
+    {'method': 'patch', 'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {400: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
+    {'method': 'patch', 'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {400: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+]
+
+
+def perms_test(*config):
+    """
+        View decorator that attaches a test config to the view for later use by test_permissions.
+    """
+    def decorator(func):
+        func.perms_test = config[0] if type(config[0]) is list else config
+        return func
+    return decorator
+
+
+def no_perms_test(func):
+    """
+        View decorator that attaches an empty test config.
+    """
+    func.perms_test = []
+    return func

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, re_path, register_converter
 from django.views.generic import RedirectView, TemplateView
 from rest_framework.urlpatterns import format_suffix_patterns
 
+from .test.test_permissions_helpers import no_perms_test
 from .utils import fix_after_rails
 from .models import Casebook, Section
 from . import views
@@ -123,7 +124,7 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('casebooks/<idslug:casebook_param>/create_draft/', views.create_draft, name='create_draft'),
     # TODO: we temporarily need to list with and without trailing slash, to handle POSTs without slashes
     path('casebooks/<idslug:casebook_param>/', views.CasebookView.as_view(), name='casebook'),
-    path('casebooks/<idslug:casebook_param>', views.CasebookView.as_view(), name='casebook'),
+    path('casebooks/<idslug:casebook_param>', no_perms_test(views.CasebookView.as_view())),
     # cases
     path('cases/from_capapi', views.from_capapi, name='from_capapi'),
     path('cases/<int:case_id>/', views.case, name='case'),

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -106,15 +106,15 @@ def actions(request, context):
 
         Given:
         >>> published, private, with_draft, client = [getfixture(f) for f in ['full_casebook', 'full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> published_section = published.contents.all()[0]
-        >>> published_resource = published.contents.all()[1]
-        >>> private_section = private.contents.all()[0]
-        >>> private_resource = private.contents.all()[1]
-        >>> with_draft_section = with_draft.contents.all()[0]
-        >>> with_draft_resource = with_draft.contents.all()[1]
+        >>> published_section = published.sections.first()
+        >>> published_resource = published.resources.first()
+        >>> private_section = private.sections.first()
+        >>> private_resource = private.resources.first()
+        >>> with_draft_section = with_draft.sections.first()
+        >>> with_draft_resource = with_draft.resources.first()
         >>> draft = with_draft.drafts()
-        >>> draft_section = draft.contents.all()[0]
-        >>> draft_resource = draft.contents.all()[1]
+        >>> draft_section = draft.sections.first()
+        >>> draft_resource = draft.resources.first()
 
         ##
         # These pages allow the same actions regardless of node types
@@ -545,9 +545,9 @@ def section(request, casebook, section):
 
         Given:
         >>> published, private, with_draft, client = [getfixture(f) for f in ['full_casebook', 'full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> published_section = published.contents.all()[0]
-        >>> private_section = private.contents.all()[0]
-        >>> draft_section = with_draft.drafts().contents.all()[0]
+        >>> published_section = published.sections.first()
+        >>> private_section = private.sections.first()
+        >>> draft_section = with_draft.drafts().sections.first()
 
         All users can see sections in public casebooks:
         >>> check_response(client.get(published_section.get_absolute_url(), content_includes=published_section.title))
@@ -582,8 +582,8 @@ def edit_section(request, casebook, section):
 
         Given:
         >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> private_section = private.contents.all()[0]
-        >>> draft_section = with_draft.drafts().contents.all()[0]
+        >>> private_section = private.sections.first()
+        >>> draft_section = with_draft.drafts().sections.first()
 
         Users can edit sections in their unpublished and draft casebooks:
         >>> for section in [private_section, draft_section]:
@@ -620,9 +620,9 @@ def resource(request, casebook, resource):
 
         Given:
         >>> published, private, with_draft, client = [getfixture(f) for f in ['full_casebook', 'full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> published_resource = published.contents.all()[1]
-        >>> private_resource = private.contents.all()[1]
-        >>> draft_resource = with_draft.drafts().contents.all()[1]
+        >>> published_resource = published.resources.first()
+        >>> private_resource = private.resources.first()
+        >>> draft_resource = with_draft.drafts().resources.first()
 
         All users can see resources in public casebooks:
         >>> check_response(client.get(published_resource.get_absolute_url(), content_includes=published_resource.title))
@@ -827,6 +827,7 @@ def case(request, case_id):
     })
 
 
+@require_POST
 @login_required
 def from_capapi(request):
     """
@@ -853,7 +854,7 @@ def from_capapi(request):
         data = json.loads(request.body.decode("utf-8"))
         cap_id = int(data['id'])
     except Exception:
-        raise HttpResponseBadRequest
+        return HttpResponseBadRequest("Request body should match {'id': <int>}")
 
     # try to fetch existing case:
     case = Case.objects.filter(capapi_id=cap_id, public=True).first()

--- a/_python/search/models.py
+++ b/_python/search/models.py
@@ -61,9 +61,9 @@ class SearchIndex(models.Model):
         Get all casebooks:
         >>> assert dump_search_results(SearchIndex().search('casebook')) == (
         ...     [
-        ...         {'affiliation': 'Affiliation 0', 'created_at': '...', 'title': 'Some Title 0', 'attribution': 'Attribution 0'},
-        ...         {'affiliation': 'Affiliation 1', 'created_at': '...', 'title': 'Some Title 1', 'attribution': 'Attribution 1'},
-        ...         {'affiliation': 'Affiliation 2', 'created_at': '...', 'title': 'Some Title 2', 'attribution': 'Attribution 2'}
+        ...         {'affiliation': 'Affiliation 0', 'created_at': '...', 'title': 'Some Title 0', 'attribution': 'Some User 0'},
+        ...         {'affiliation': 'Affiliation 1', 'created_at': '...', 'title': 'Some Title 1', 'attribution': 'Some User 1'},
+        ...         {'affiliation': 'Affiliation 2', 'created_at': '...', 'title': 'Some Title 2', 'attribution': 'Some User 2'}
         ...     ],
         ...     {'user': 3, 'case': 3, 'casebook': 3},
         ...     {}
@@ -71,20 +71,20 @@ class SearchIndex(models.Model):
 
         Get casebooks by query string:
         >>> assert dump_search_results(SearchIndex().search('casebook', 'Some Title 0'))[0] == [
-        ...     {'affiliation': 'Affiliation 0', 'created_at': '...', 'title': 'Some Title 0', 'attribution': 'Attribution 0'},
+        ...     {'affiliation': 'Affiliation 0', 'created_at': '...', 'title': 'Some Title 0', 'attribution': 'Some User 0'},
         ... ]
 
         Get casebooks by filter field:
-        >>> assert dump_search_results(SearchIndex().search('casebook', filters={'attribution': 'Attribution 1'}))[0] == [
-        ...     {'affiliation': 'Affiliation 1', 'created_at': '...', 'title': 'Some Title 1', 'attribution': 'Attribution 1'},
+        >>> assert dump_search_results(SearchIndex().search('casebook', filters={'attribution': 'Some User 1'}))[0] == [
+        ...     {'affiliation': 'Affiliation 1', 'created_at': '...', 'title': 'Some Title 1', 'attribution': 'Some User 1'},
         ... ]
 
         Get all users:
         >>> assert dump_search_results(SearchIndex().search('user')) == (
         ...     [
-        ...         {'casebook_count': 1, 'attribution': 'Attribution 0', 'affiliation': 'Affiliation 0'},
-        ...         {'casebook_count': 1, 'attribution': 'Attribution 1', 'affiliation': 'Affiliation 1'},
-        ...         {'casebook_count': 1, 'attribution': 'Attribution 2', 'affiliation': 'Affiliation 2'},
+        ...         {'casebook_count': 1, 'attribution': 'Some User 0', 'affiliation': 'Affiliation 0'},
+        ...         {'casebook_count': 1, 'attribution': 'Some User 1', 'affiliation': 'Affiliation 1'},
+        ...         {'casebook_count': 1, 'attribution': 'Some User 2', 'affiliation': 'Affiliation 2'},
         ...     ],
         ...     {'casebook': 3, 'case': 3, 'user': 3},
         ...     {},

--- a/_python/setup.cfg
+++ b/_python/setup.cfg
@@ -1,6 +1,6 @@
 ## http://pytest.org/latest/customize.html#adding-default-options
 [tool:pytest]
-DJANGO_SETTINGS_MODULE = config.settings
+DJANGO_SETTINGS_MODULE = config.settings.settings_pytest
 addopts = --doctest-modules --nomigrations
 # these options can be used for faster test discovery if necessary:
 # testpaths = main/tests


### PR DESCRIPTION
This PR adds a test that ensures that each view in `main.urls` is decorated with one or more permissions tests. A permissions test looks like this:

`@perms_test({'method': 'post', 'args': ['casebook'], 'results': {302: ['casebook.owner', 'admin_user'], 403: ['other_user'], 'login': [None]}})`

... which is an assertion that, if you post to the decorated view with the url param `casebook`, you should get a 302 redirect as the casebook's owner or admin, a 403 permission denied as an unrelated user, and a login redirect if not logged in.

The strings like 'casebook.owner' use pytest's fixture resolution combined with Django's template variable syntax, so they're pretty flexible and robust.

@perms_test can also work as a basic success test for the view itself. If the docstring was just going to hit the view and check a response code to ensure success, `perms_test` can take care of that as well. I wasn't sure if we want to encourage that (I think I like the succinctness of encouraging it, though?), so I put the "deleting redundant tests" part in a final commit that we can skip if we want.

To avoid over-complicating things at this point, I also didn't add an option to pass extra arguments to `check_response`, but that would let us delete even more docstrings -- some of the remaining docstrings are fully redundant except for a `content_includes`.

---

Commentary: all of this is somewhere around the line of "too complicated to be worth it." I *think* this level of complexity is worth it in exchange for being able to very succinctly assert the permissions behavior of each view, and being able to assert that all views are tested. Totally open to the idea that it's not worth it, though!

---

Also in this PR (as preliminary commits that could be included on their own if you like):

* vscode support
* fix `annotations` view for draft casebooks by telling DRF to use session auth
* speed up tests by disabling whitenoise
* stylistic tweaks via `Casebook.sections` and `Casebook.resources` methods 