### PR TITLE
Fix logout link for python pages

### DIFF
--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -141,8 +141,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 RAILS_SECRET_KEY_BASE = None
 
-LOGIN_URL = '/user_sessions/new'
-SIGNUP_URL = '/users/new'
 GUIDE_URL = 'https://about.opencasebook.org/'
 BLOG_URL = 'https://about.opencasebook.org/blog/'
 CAPAPI_CASE_URL_FSTRING = 'https://api.case.law/v1/cases/{}/'
@@ -154,8 +152,6 @@ CONTACT_EMAIL = 'info@opencasebook.org'
 # Make these settings available for use in Django's templates.
 # e.g. <a href="mailto:{{ CONTACT_EMAIL }}">Contact Us</a>
 TEMPLATE_VISIBLE_SETTINGS = (
-    'LOGIN_URL',
-    'SIGNUP_URL',
     'CONTACT_EMAIL',
     'GUIDE_URL',
     'BLOG_URL'

--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -19,7 +19,7 @@ class CustomAdminSite(admin.AdminSite):
     site_header = 'H2O Admin'
 
     def login(self, *args, **kwargs):
-        return redirect(settings.LOGIN_URL)
+        return redirect(reverse('login'))
 
     def logout(self, *args, **kwargs):
         raise NotImplementedError()

--- a/_python/main/templates/includes/header.html
+++ b/_python/main/templates/includes/header.html
@@ -25,13 +25,18 @@
             <ul class="user-links dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
               <li><a class="user-link" href="{% url 'dashboard' request.user.id %}">Dashboard</a></li>
               <li><a class="user-link" href="{% url 'dashboard' request.user.id %}/edit">Edit Profile</a></li>
-              <li><button class="user-link">Sign Out</button></li>
+              <li>
+                <form class="button_to" method="post" action="{% url "logout" %}">
+                  {% csrf_token %}
+                  <button type="submit" class="user-link">Sign Out</button>
+                </form>
+              </li>
             </ul>
           </div>
         </div>
       {% else %}
-        <a class="sign-up" href="{{ SIGNUP_URL }}">Sign Up</a>
-        <a class="sign-in" href="{{ LOGIN_URL }}">Sign In</a>
+        <a class="sign-up" href="{% url "sign_up" %}">Sign Up</a>
+        <a class="sign-in" href="{% url "login" %}">Sign In</a>
       {% endif %}
     </div>
   </div>

--- a/_python/main/templates/index.html
+++ b/_python/main/templates/index.html
@@ -88,6 +88,6 @@
 <section class="stinger">
     <img src="{% rails_static "assets/logo.png" %}" title="H2O"/>
     <h1>"Build coursebooks better, faster and smarter — today."</h1>
-    <a class="call-to-action" href="{{ SIGNUP_URL }}">Get started</a>
+    <a class="call-to-action" href="{% url "sign_up" %}">Get started</a>
 </section>
 {% endblock %}

--- a/_python/main/templates/pages/faq.html
+++ b/_python/main/templates/pages/faq.html
@@ -24,7 +24,7 @@
 
     <h2>How do I create a casebook?</h2>
 
-    <p>Anyone can create a casebook by first <a href="{{ SIGNUP_URL }}">creating an account</a>. Once logged-in, click the “Create casebook” button, where you can select “Make a New Casebook” or, if you want to adapt an existing casebook, “Search Casebooks.” For more on creating casebooks and adding content, <a href="{{ GUIDE_URL }}making-casebooks/#creating-casebooks">view the entry on creating casebooks</a> in our user guide.</p>
+    <p>Anyone can create a casebook by first <a href="{% url "sign_up" %}">creating an account</a>. Once logged-in, click the “Create casebook” button, where you can select “Make a New Casebook” or, if you want to adapt an existing casebook, “Search Casebooks.” For more on creating casebooks and adding content, <a href="{{ GUIDE_URL }}making-casebooks/#creating-casebooks">view the entry on creating casebooks</a> in our user guide.</p>
 
     <h2>How do I get a case that is not in the database yet?</h2>
 

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -99,7 +99,11 @@ drf_urlpatterns = [
 
 urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('', views.index, name='index'),
+    path('users/new', views.not_implemented_yet, name='sign_up'),
     path('users/<int:user_id>/', views.dashboard, name='dashboard'),
+    path('user_sessions/new', views.not_implemented_yet, name='login'),
+    path('user_sessions/logout/', views.logout, name='logout'),
+    path('user_sessions/<id>', views.logout),
     # resources
     path('casebooks/<idslug:casebook_param>/resources/<ordslug:resource_param>/layout/', RedirectView.as_view(pattern_name='resource', permanent=True)),
     path('casebooks/<idslug:casebook_param>/resources/<ordslug:resource_param>/edit/', views.edit_resource, name='edit_resource'),

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -21,7 +21,7 @@ from django.views import View
 from test_helpers import check_response, assert_url_equal, dump_content_tree_children
 from pytest import raises as assert_raises
 
-from .utils import parse_cap_decision_date
+from .utils import parse_cap_decision_date, fix_after_rails
 from .serializers import ContentAnnotationSerializer, CaseSerializer, TextBlockSerializer
 from .models import Casebook, Resource, Case, User, CaseCourt, ContentNode
 from .forms import CasebookForm, SectionForm, ResourceForm, LinkForm, TextBlockForm
@@ -320,6 +320,14 @@ def dashboard(request, user_id):
     """
     user = get_object_or_404(User, pk=user_id)
     return render(request, 'dashboard.html', {'user': user})
+
+
+@require_POST
+def logout(request, id=None):
+    fix_after_rails("id isn't used; just kept for rails compat")
+    response = HttpResponseRedirect(reverse('index'))
+    response.delete_cookie('_h2o_session')
+    return response
 
 
 class CasebookView(View):


### PR DESCRIPTION
This will fix the Sign Out link that is currently broken on python pages on h2o-experiment and prod:

![image](https://user-images.githubusercontent.com/376272/68692898-46aed780-0544-11ea-91cf-82c5da5071ca.png)

When deploying, you can add `/user_sessions/logout/` to the nginx config -- the ruby pages use a different route, so won't be affected.