### PR TITLE
Tweak search results; faster search index update

### DIFF
--- a/_python/fabfile.py
+++ b/_python/fabfile.py
@@ -37,10 +37,18 @@ def run_django(port=None):
 
 @task
 @setup_django
-def refresh_search_index():
-    """ Recreate the search_view materialized view """
+def create_search_index():
+    """ Create (or recreate) the search_view materialized view """
     from search.models import SearchIndex
     SearchIndex.create_search_index()
+
+
+@task
+@setup_django
+def refresh_search_index():
+    """ Update an existing search_view materialized view; will fail if create_search_index hasn't been run once """
+    from search.models import SearchIndex
+    SearchIndex.refresh_search_index()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This changes our substantive search results in two ways:

- only include casebooks that have a user relationship with `has_attribution=True`; this will filter out some duplicate results
- casebook search results include hits based on author attribution or affiliation (so searching casebooks for "lessig" will return all lessig-authored casebooks)

Basically casebook search will include slightly more correct results and slightly fewer incorrect results.

DEPLOYMENT: This also adds a `fab refresh_search_index`, which can be run in crontab instead of the existing `fab create_search_index`. (It will fall back to create if the index doesn't exist yet, so should be safe to run on new dbs as well.) This optimization is slightly faster and also won't block any search queries that happen to be run at the precise moment of indexing.

(This is a pretty marginal optimization, since `create_search_index` is already pretty fast, but per conversation with @rebeccacremona it's good preparation to run `SearchIndex().refresh_search_index()` if we want to add logic to update the index in realtime in the future.)