### PR TITLE
Admin query optimization and casebook permissions copying

### DIFF
--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -385,7 +385,7 @@ def full_casebook_with_draft(full_casebook_parts_factory):
         >>> assert has_draft.has_draft and not draftless.has_draft
         >>> assert all(node.has_draft for node in has_draft.contents.all())
         >>> assert has_draft.is_public
-        >>> assert has_draft.drafts().is_private
+        >>> assert has_draft.draft.is_private
     """
     # Use full_casebook_parts_factory instead of the full_casebook fixture
     # so that full_casebook_with_draft and full_casebook are independent objects

--- a/_python/main/templates/includes/content_browser.html
+++ b/_python/main/templates/includes/content_browser.html
@@ -2,7 +2,6 @@
 <div class="content-browser">
   {% for node in content %}{% with node as casebook %}
     {% call_method casebook "editable_by" request.user as user_can_edit %}
-    {% call_method casebook "drafts" as draft %}
     <a class="wrapper" href="{% if casebook.public %}{% url "casebook" casebook %}{% else %}{% url "edit_casebook" casebook %}{% endif %}">
       <div class="content-page {% if casebook.public %}public{% else %}draft{% endif %}">
         <div class="casebook-info">
@@ -10,8 +9,8 @@
           <div class="title">{{ casebook.get_title }}</div>
           <div class="subtitle">{{ casebook.subtitle|default:"" }}</div>
         </div>
-        {% if draft and user_can_edit %}
-          <a class="wrapper" href="{% url "edit_casebook" draft %}">
+        {% if casebook.draft and user_can_edit %}
+          <a class="wrapper" href="{% url "edit_casebook" casebook.draft %}">
             <div class="unpublished-changes">
              <span class="exclamation">!</span>
               <span class="description">This casebook has unpublished changes.</span>

--- a/_python/main/test/test_permissions_helpers.py
+++ b/_python/main/test/test_permissions_helpers.py
@@ -8,33 +8,33 @@
 viewable_section = [
     {'args': ['full_casebook', 'full_casebook.sections.first'], 'results': {200: [None, 'other_user', 'full_casebook.owner']}},
     {'args': ['full_private_casebook', 'full_private_casebook.sections.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.sections.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.draft', 'full_casebook_with_draft.draft.sections.first'], 'results': {200: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 directly_editable_section = [
     {'args': ['full_casebook', 'full_casebook.sections.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
     {'args': ['full_private_casebook', 'full_private_casebook.sections.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.sections.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.draft', 'full_casebook_with_draft.draft.sections.first'], 'results': {200: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 viewable_resource = [
     {'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {200: [None, 'other_user', 'full_casebook.owner']}},
     {'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.draft', 'full_casebook_with_draft.draft.resources.first'], 'results': {200: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 directly_editable_resource = [
     {'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
     {'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {200: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'args': ['full_casebook_with_draft.draft', 'full_casebook_with_draft.draft.resources.first'], 'results': {200: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 patch_directly_editable_resource = [
     {'method': 'patch', 'args': ['full_casebook', 'full_casebook.resources.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
     {'method': 'patch', 'args': ['full_private_casebook', 'full_private_casebook.resources.first'], 'results': {400: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'method': 'patch', 'args': ['full_casebook_with_draft.drafts', 'full_casebook_with_draft.drafts.resources.first'], 'results': {400: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'method': 'patch', 'args': ['full_casebook_with_draft.draft', 'full_casebook_with_draft.draft.resources.first'], 'results': {400: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 # for annotations: args = resource ID rather than casebook and ordinals
 post_directly_editable_resource = [
     {'method': 'post', 'args': ['full_casebook.resources.first'], 'results': {403: ['other_user', 'full_casebook.owner'], 'login': [None]}},
     {'method': 'post', 'args': ['full_private_casebook.resources.first'], 'results': {400: ['full_private_casebook.owner'], 'login': [None], 403: ['other_user']}},
-    {'method': 'post', 'args': ['full_casebook_with_draft.drafts.resources.first'], 'results': {400: ['full_casebook_with_draft.drafts.owner'], 'login': [None], 403: ['other_user']}},
+    {'method': 'post', 'args': ['full_casebook_with_draft.draft.resources.first'], 'results': {400: ['full_casebook_with_draft.draft.owner'], 'login': [None], 403: ['other_user']}},
 ]
 
 

--- a/_python/main/utils.py
+++ b/_python/main/utils.py
@@ -76,9 +76,11 @@ def looks_like_citation(s):
     return bool(re.match(r'\d+(\s+|-).*(\s+|-)\d+$', s))
 
 
-def clone_model_instance(instance):
+def clone_model_instance(instance, **kwargs):
     clone = deepcopy(instance)
     clone.id = clone.pk = clone.created_at = None
+    for k, v in kwargs.items():
+        setattr(clone, k, v)
     return clone
 
 

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -112,7 +112,7 @@ def actions(request, context):
         >>> private_resource = private.resources.first()
         >>> with_draft_section = with_draft.sections.first()
         >>> with_draft_resource = with_draft.resources.first()
-        >>> draft = with_draft.drafts()
+        >>> draft = with_draft.draft
         >>> draft_section = draft.sections.first()
         >>> draft_resource = draft.resources.first()
 
@@ -262,7 +262,7 @@ class AnnotationListView(APIView):
 
     @method_decorator(perms_test(
         {'args': ['resource'], 'results': {200: ['resource.casebook.owner', 'other_user', 'admin_user', None]}},
-        {'args': ['full_casebook_with_draft.drafts.resources.first'], 'results': {200: ['full_casebook_with_draft.drafts.owner', 'admin_user'], 403: ['other_user'], 'login': [None]}},
+        {'args': ['full_casebook_with_draft.draft.resources.first'], 'results': {200: ['full_casebook_with_draft.draft.owner', 'admin_user'], 403: ['other_user'], 'login': [None]}},
     ))
     @method_decorator(user_has_perm('resource', 'viewable_by'))
     def get(self, request, resource, format=None):
@@ -614,7 +614,7 @@ def edit_casebook(request, casebook):
     """
         Given:
         >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> draft = with_draft.drafts()
+        >>> draft = with_draft.draft
 
         Users can edit their unpublished and draft casebooks:
         >>> for book in [private, draft]:
@@ -804,7 +804,7 @@ class SectionView(View):
             >>> published, private, with_draft, client = [getfixture(f) for f in ['full_casebook', 'full_private_casebook', 'full_casebook_with_draft', 'client']]
             >>> published_section = published.sections.first()
             >>> private_section = private.sections.first()
-            >>> draft_section = with_draft.drafts().sections.first()
+            >>> draft_section = with_draft.draft.sections.first()
 
             All users can see sections in public casebooks:
             >>> check_response(client.get(published_section.get_absolute_url(), content_includes=published_section.title))
@@ -839,7 +839,7 @@ class SectionView(View):
             Given:
             >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
             >>> private_section = private.sections.first()
-            >>> draft_section = with_draft.drafts().sections.first()
+            >>> draft_section = with_draft.draft.sections.first()
 
             Users can delete sections in their unpublished and draft casebooks:
             >>> for section in [private_section, draft_section]:
@@ -866,7 +866,7 @@ def edit_section(request, casebook, section):
         Given:
         >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
         >>> private_section = private.sections.first()
-        >>> draft_section = with_draft.drafts().sections.first()
+        >>> draft_section = with_draft.draft.sections.first()
 
         Users can edit sections in their unpublished and draft casebooks:
         >>> for section in [private_section, draft_section]:
@@ -909,7 +909,7 @@ class ResourceView(View):
             >>> published, private, with_draft, client = [getfixture(f) for f in ['full_casebook', 'full_private_casebook', 'full_casebook_with_draft', 'client']]
             >>> published_resource = published.resources.first()
             >>> private_resource = private.resources.first()
-            >>> draft_resource = with_draft.drafts().resources.first()
+            >>> draft_resource = with_draft.draft.resources.first()
 
             All users can see resources in public casebooks:
             >>> check_response(client.get(published_resource.get_absolute_url(), content_includes=published_resource.title))
@@ -948,7 +948,7 @@ class ResourceView(View):
             Given:
             >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
             >>> private_resource = private.resources.first()
-            >>> draft_resource = with_draft.drafts().resources.first()
+            >>> draft_resource = with_draft.draft.resources.first()
 
             Users can delete resources in their unpublished and draft casebooks:
             >>> for resource in [private_resource, draft_resource]:
@@ -974,7 +974,7 @@ def edit_resource(request, casebook, resource):
 
         Given:
         >>> private, with_draft, client = [getfixture(f) for f in ['full_private_casebook', 'full_casebook_with_draft', 'client']]
-        >>> draft = with_draft.drafts()
+        >>> draft = with_draft.draft
         >>> private_resources = {'TextBlock': private.contents.all()[1], 'Case': private.contents.all()[2], 'Default': private.contents.all()[3]}
         >>> draft_resources = {'TextBlock': draft.contents.all()[1], 'Case': draft.contents.all()[2], 'Default': draft.contents.all()[3]}
 


### PR DESCRIPTION
The headline features here are to have user permissions for casebooks also get applied to their drafts (and vice versa) in the admin, and to improve the performance of some admin screens. This moved a bunch of stuff around under the hood but hopefully didn't change much actual functionality. Details:

- Add cached properties `draft` and `draft_of` to `Casebook`, which work more or less like they will if we turn the relationship into a one-to-one field in the future
- Drop the existing `drafts()` method
- Saving a casebook in the admin edit screen copies its user collaborators to its draft/draft_of
- Refactor admin.py a bit with an edit_link() helper
- Optimize some admin.py screens with get_queryset 
- Have the casebook collaborator methods (like `.owner`) always use `contentcollaborator_set.all()` so `.prefetch_related('contentcollaborator_set__user')` will work on a collection of casebooks to prevent further queries
- for convenience, `clone_model_instance` helper now accepts arbitrary properties to apply to the new instance