### PR TITLE
update class for in-text pagenumbers to match CAP

### DIFF
--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -74,7 +74,7 @@ export default {
     }
   }
 }
-.page-number {
+.page-number, .page-label {
   font-size: small;
   color: darkgrey;
   vertical-align: super;


### PR DESCRIPTION
Some existing h2o cases use `class='page-number'`, and cap delivers html with `class='page-label'`

This PR assigns same styles to both classes.

