### PR TITLE
Fix casebook attribution in template.

### DIFF
--- a/_python/main/templates/includes/collaborators.html
+++ b/_python/main/templates/includes/collaborators.html
@@ -1,4 +1,4 @@
-{% for user in content.attributors.all %}
+{% for user in content.attributors %}
   <div class="user {% if user.verified_professor %} verified{% endif %}">
     <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>{% if not forloop.last %}, {% endif %}
   </div>


### PR DESCRIPTION
Closes https://github.com/harvard-lil/h2o/issues/951. (Attributor method now returns list, not queryset.)