### PR TITLE
Show paragraph numbers in CAP html

### DIFF
--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -50,8 +50,8 @@ export default {
       display: inline; /* yes, p in span is illegal, but we have them */
     }
   }
-  /* section numbers */
-  > * {
+  /* paragraph numbers -- section.casebody handles HTML received from CAP */
+  > :not(section.case-body), > section.casebody h4, > section.casebody p, > section.casebody blockquote {
     position: relative;
     &::before {
       counter-increment: index;
@@ -80,6 +80,15 @@ export default {
   vertical-align: super;
   margin: 4px;
 }
+
+// no margin between consecutive blockquotes, only at the end
+blockquote {
+  margin: 0;
+}
+blockquote + :not(blockquote) {
+  margin-top: 20px;
+}
+
 .footnote {
   a {
     float: left;


### PR DESCRIPTION
Tweak the paragraph number selector so it can show paragraph numbers in CAP html without stripping section tags and stuff.

Also includes a tweak to the blockquote styles so there aren't linebreaks between consecutive linebreaks.
