### PR TITLE
Disable add and delete in django admin

### DIFF
--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -62,6 +62,46 @@ admin_site = CustomAdminSite(name='h2oadmin')
 admin.TabularInline.extra = 0
 admin.StackedInline.extra = 0
 
+# don't allow inline objects to be deleted or added by default:
+admin.TabularInline.can_delete = False  # use True to allow deleting
+admin.StackedInline.can_delete = False
+admin.TabularInline.max_num = 0  # use max_num = None to allow adding
+admin.StackedInline.max_num = 0
+
+
+class BaseAdmin(admin.ModelAdmin):
+    fix_after_rails("""
+        The LogEntry class tracks additions, changes, and deletions of objects
+        done through the admin interface. It requires the Django app to be
+        fully integrated with the AUTH_USER_MODEL... which we aren't yet. So,
+        for now, disable logging.
+    """)
+    def log_addition(self, request, object, message):
+        pass
+    def log_change(self, request, object, message):
+        pass
+    def log_deletion(self, request, object, object_repr):
+        pass
+
+    actions = None  # use ['delete_selected'] to allow delete action
+
+    def has_add_permission(self, request):
+        """
+            Don't allow objects to be added by default. To override, use this on a subclass:
+
+                def has_add_permission(self, request):
+                    return super(BaseAdmin, self).has_add_permission(request)
+        """
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+            Don't allow objects to be deleted by default. To override, use this on a subclass:
+
+                def has_delete_permission(self, request, obj=None):
+                    return super(BaseAdmin, self).has_delete_permission(request, obj)
+        """
+        return False
 
 #
 # Filters
@@ -159,6 +199,8 @@ class CollaboratorInline(admin.TabularInline):
     model = ContentCollaborator
     fields = ['role', 'user', 'content', 'has_attribution']
     raw_id_fields = ['user', 'content']
+    max_num = None
+    can_delete = True
 
 
 class AnnotationInline(admin.TabularInline):
@@ -167,6 +209,8 @@ class AnnotationInline(admin.TabularInline):
     fields = ['id', 'resource', ('global_start_offset', 'global_end_offset'), ('start_paragraph', 'end_paragraph'), ('start_offset', 'end_offset'), 'kind', 'content', 'created_at', 'updated_at']
     raw_id_fields = ['resource']
     ordering = ['global_start_offset',  'global_end_offset']
+    max_num = None
+    can_delete = True
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         formfield = super().formfield_for_dbfield(db_field, **kwargs)
@@ -187,26 +231,9 @@ class RolesUserInline(admin.TabularInline):
 #
 
 
-fix_after_rails("""
-    The LogEntry class tracks additions, changes, and deletions of objects
-    done through the admin interface. It requires the Django app to be
-    fully integrated with the AUTH_USER_MODEL... which we aren't yet. So,
-    for now, disable logging.
-""")
-class NonLoggingAdmin(admin.ModelAdmin):
-    def log_addition(self, request, object, message):
-        pass
-
-    def log_change(self, request, object, message):
-        pass
-
-    def log_deletion(self, request, object, object_repr):
-        pass
-
-
 ## Casebooks
 
-class CasebookAdmin(NonLoggingAdmin):
+class CasebookAdmin(BaseAdmin):
     list_display = ['id', 'get_title', 'owner_link', 'public', 'source', 'draft_link', 'root_user', 'created_at', 'updated_at']
     list_filter = [CollaboratorNameFilter, CollaboratorIdFilter, 'public', 'draft_mode_of_published_casebook']
     search_fields = ['title']
@@ -252,7 +279,7 @@ class CasebookAdmin(NonLoggingAdmin):
     source.short_description = 'source'
 
 
-class SectionAdmin(NonLoggingAdmin):
+class SectionAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'owner_link', 'casebook_link', 'copy_of', 'ordinals']
     list_select_related = ['casebook', 'copy_of']
     list_display = ['id', 'casebook_link', 'owner_link', 'get_title', 'ordinals', 'created_at', 'updated_at']
@@ -273,7 +300,7 @@ class SectionAdmin(NonLoggingAdmin):
     casebook_link.short_description = 'casebook'
 
 
-class ResourceAdmin(NonLoggingAdmin):
+class ResourceAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'owner_link', 'casebook_link', 'copy_of', 'resource_id', 'resource_type', 'ordinals']
     list_select_related = ['casebook', 'copy_of']
     list_display = ['id', 'casebook_link', 'owner_link', 'get_title', 'ordinals', 'resource_type', 'resource_id', 'annotation_count', 'created_at', 'updated_at']
@@ -298,7 +325,7 @@ class ResourceAdmin(NonLoggingAdmin):
         return 'n/a' if obj.resource_type == 'Default' else obj.annotations_count
 
 
-class AnnotationsAdmin(NonLoggingAdmin):
+class AnnotationsAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'start_paragraph', 'end_paragraph', 'start_offset', 'end_offset', 'kind']
     fields = ['resource', ('global_start_offset', 'global_end_offset'), ('start_paragraph', 'end_paragraph'), ('start_offset', 'end_offset'), 'kind', 'content', 'created_at', 'updated_at']
     list_select_related = ['resource']
@@ -315,7 +342,7 @@ class AnnotationsAdmin(NonLoggingAdmin):
     resource_id.admin_order_field = 'resource__resource_id'
 
 
-class UnpublishedRevisionAdmin(NonLoggingAdmin):
+class UnpublishedRevisionAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'casebook', 'node', 'node_parent', 'annotation', 'field', 'value']
     list_select_related = ['casebook', 'node', 'node_parent', 'annotation']
     list_display = ['id', 'the_draft', 'node', 'parent','field', 'value_preview', 'annotation', 'created_at', 'updated_at']
@@ -339,7 +366,7 @@ class UnpublishedRevisionAdmin(NonLoggingAdmin):
 
 ## Resources
 
-class CaseAdmin(NonLoggingAdmin):
+class CaseAdmin(BaseAdmin):
     # Content is readonly until we implement the annotation-shifting logic on the python side
     readonly_fields = ['created_at', 'updated_at', 'annotations_count', 'content']
     list_select_related = ['case_court']
@@ -377,7 +404,7 @@ class CaseAdmin(NonLoggingAdmin):
         )
 
 
-class DefaultAdmin(NonLoggingAdmin):
+class DefaultAdmin(BaseAdmin):
     # reminder that a "Default" is a Link Resource
     readonly_fields = ['created_at', 'updated_at', 'user_link', 'user', 'ancestry']
     list_select_related = ['user']
@@ -399,7 +426,7 @@ class DefaultAdmin(NonLoggingAdmin):
         )
 
 
-class TextBlockAdmin(NonLoggingAdmin):
+class TextBlockAdmin(BaseAdmin):
     # Content is readonly until we implement the annotation-shifting logic on the python side
     readonly_fields = ['created_at', 'updated_at', 'user', 'version', 'annotations_count', 'content']
     list_select_related = ['user']
@@ -427,7 +454,7 @@ class TextBlockAdmin(NonLoggingAdmin):
 
 ## Users
 
-class UserAdmin(NonLoggingAdmin):
+class UserAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'display_name', 'last_request_at', 'last_login_at', 'login_count']
     list_display = ['id', 'display_name', 'login', 'email_address', 'verified_email', 'professor_verification_requested', 'verified_professor', 'get_roles', 'last_request_at', 'last_login_at', 'login_count', 'created_at', 'updated_at']
     list_filter = ['verified_email', 'verified_professor', 'professor_verification_requested', RoleNameFilter]
@@ -442,8 +469,11 @@ class UserAdmin(NonLoggingAdmin):
         return ','.join(str(o) for o in set(r.name for r in obj.roles.all())) or None
     get_roles.short_description = 'Roles'
 
+    def has_add_permission(self, request):
+        return super(BaseAdmin, self).has_add_permission(request)
 
-class RolesUserAdmin(NonLoggingAdmin):
+
+class RolesUserAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'role', 'user']
     list_select_related = ['user', 'role']
     list_display = ['id', 'user', 'role', 'created_at', 'updated_at']
@@ -451,14 +481,14 @@ class RolesUserAdmin(NonLoggingAdmin):
     raw_id_fields = ['user', 'role']
 
 
-class RoleAdmin(NonLoggingAdmin):
+class RoleAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'authorizable_type', 'authorizable_id']
     list_display = ['id', 'name', 'authorizable_type', 'authorizable_id', 'created_at', 'updated_at']
     list_filter = ['name', 'authorizable_type']
     ordering = ['-name']
 
 
-class CollaboratorsAdmin(NonLoggingAdmin):
+class CollaboratorsAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'user', 'content']
     list_select_related = ['user', 'content']
     list_display = ['user', 'role']
@@ -469,7 +499,7 @@ class CollaboratorsAdmin(NonLoggingAdmin):
 
 ## Courts
 
-class CaseCourtAdmin(NonLoggingAdmin):
+class CaseCourtAdmin(BaseAdmin):
     readonly_fields = ['created_at', 'updated_at', 'capapi_link']
     list_display = ['id', 'name', 'name_abbreviation', 'created_at', 'case_count_link', 'updated_at', 'capapi_link']
     search_fields = ['name_abbreviation', 'name']


### PR DESCRIPTION
Disable add and delete buttons in Django admin, except for:

- add user
- add and delete collaborators for casebooks
- add and delete annotations when editing a resource

We can add in any other exceptions as needed.