### PR TITLE
Tweaks to new user-related pages.

### DIFF
--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -135,7 +135,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 RAILS_SECRET_KEY_BASE = None
 
-LOGIN_URL = '/user_sessions/new'
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 GUIDE_URL = 'https://about.opencasebook.org/'

--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -32,24 +32,8 @@ def edit_link(obj, as_str=False):
 # Admin site config
 #
 
-# Until we are integrated with Django's authentication system,
-# point login etc. to the Rails app.
-# https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.AdminSite
-# https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#adding-views-to-admin-sites
 class CustomAdminSite(admin.AdminSite):
     site_header = 'H2O Admin'
-
-    def login(self, *args, **kwargs):
-        return redirect(reverse('login'))
-
-    def logout(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def password_change(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def password_change_done(self, *args, **kwargs):
-        raise NotImplementedError()
 
 admin_site = CustomAdminSite(name='h2oadmin')
 

--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -4,7 +4,6 @@ from django.contrib import admin
 from django.db.models import Q, Count
 from django.urls import reverse
 from django.utils.html import format_html
-from django.shortcuts import redirect
 from django.utils.safestring import mark_safe
 
 from .utils import fix_after_rails, clone_model_instance

--- a/_python/main/templates/registration/password_change_done.html
+++ b/_python/main/templates/registration/password_change_done.html
@@ -3,16 +3,18 @@
 {% block page_title %}Password changed{% endblock %}
 
 {% block mainContent %}
-  <header class="users">
-    <div class="content">
-      <h1>
-        Password changed
-      </h1>
-    </div>
-  </header>
-  <section class="sign-in">
-    <div class="content">
-      <p>Your password has been updated.</p>
-    </div>
-  </section>
+  <div class="pages-content">
+    <header class="users">
+      <div class="content">
+        <h1>
+          Password changed
+        </h1>
+      </div>
+    </header>
+    <section class="sign-in">
+      <div class="content">
+          <p>Your password has been updated.</p>
+      </div>
+    </section>
+  </div>
 {% endblock %}

--- a/_python/main/templates/registration/password_change_form.html
+++ b/_python/main/templates/registration/password_change_form.html
@@ -15,7 +15,7 @@
       <div class="form">
         <form method="POST">
           {% crispy form %}
-          <input type="submit" name="submit" value="Sign in" class="btn btn-primary">
+          <input type="submit" name="submit" value="Change my password" class="btn btn-primary">
         </form>
       </div>
     </div>

--- a/_python/main/templates/registration/password_reset_complete.html
+++ b/_python/main/templates/registration/password_reset_complete.html
@@ -3,16 +3,18 @@
 {% block page_title %}Password changed{% endblock %}
 
 {% block mainContent %}
-  <header class="users">
-    <div class="content">
-      <h1>
-        Password changed
-      </h1>
-    </div>
-  </header>
-  <section class="sign-in">
-    <div class="content">
-      <p>Your password has been updated. You can now <a href="{% url "login" %}">log in</a>.</p>
-    </div>
-  </section>
+  <div class="pages-content">
+    <header class="users">
+      <div class="content">
+        <h1>
+          Password changed
+        </h1>
+      </div>
+    </header>
+    <section class="sign-in">
+      <div class="content">
+        <p>Your password has been updated. You can now <a href="{% url "login" %}">log in</a>.</p>
+      </div>
+    </section>
+  </div>
 {% endblock %}

--- a/_python/main/templates/registration/password_reset_confirm.html
+++ b/_python/main/templates/registration/password_reset_confirm.html
@@ -3,6 +3,7 @@
 {% block page_title %}Password reset confirmation{% endblock %}
 
 {% block mainContent %}
+  {% if not validlink %}<div class="pages-content">{% endif %}
   <header class="users">
     <div class="content">
       <h1>
@@ -25,4 +26,5 @@
       {% endif %}
     </div>
   </section>
+  {% if not validlink %}</div>{% endif %}
 {% endblock %}

--- a/_python/main/templates/registration/password_reset_done.html
+++ b/_python/main/templates/registration/password_reset_done.html
@@ -3,17 +3,19 @@
 {% block page_title %}Password changed{% endblock %}
 
 {% block mainContent %}
-  <header class="users">
-    <div class="content">
-      <h1>
-        Password reset
-      </h1>
-    </div>
-  </header>
-  <section class="sign-in">
-    <div class="content">
-      <p>We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.</p>
-      <p>If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.</p>
-    </div>
-  </section>
+  <div class="pages-content">
+    <header class="users">
+      <div class="content">
+        <h1>
+          Password reset
+        </h1>
+      </div>
+    </header>
+    <section class="sign-in">
+      <div class="content">
+        <p>We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.</p>
+        <p>If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.</p>
+      </div>
+    </section>
+  </div>
 {% endblock %}

--- a/_python/main/test/test_permissions.py
+++ b/_python/main/test/test_permissions.py
@@ -109,4 +109,4 @@ def test_permissions(
     # check response
     check_response(response, status_code=status_code, content_type=None)
     if should_redirect_to_login:
-        assert response.url.startswith('/user_sessions/new'), "View failed to redirect to login page"
+        assert response.url.startswith(reverse('login')), "View failed to redirect to login page"


### PR DESCRIPTION
1) Now that auth-related flows are available via python, remove the customizations in the Django Admin

2) Fix up a few templates. For example,
Before:
![image](https://user-images.githubusercontent.com/11020492/70659744-b4771d80-1c2e-11ea-9292-5051aae35c69.png)
After:
![image](https://user-images.githubusercontent.com/11020492/70660049-4da63400-1c2f-11ea-932d-62ada40443eb.png)

3) Fix a button label.

4) Remove the Django setting that customizes `redirect_to_login`, so redirection works correctly.