### PR TITLE
Get paragraph numbers back by tweaking css

### DIFF
--- a/app/webpacker/components/TheResourceBody.vue
+++ b/app/webpacker/components/TheResourceBody.vue
@@ -51,7 +51,7 @@ export default {
     }
   }
   /* paragraph numbers -- section.casebody handles HTML received from CAP */
-  > :not(section.case-body), > section.casebody h4, > section.casebody p, > section.casebody blockquote {
+  > :not(section), > section.casebody h4, > section.casebody p, > section.casebody blockquote {
     position: relative;
     &::before {
       counter-increment: index;


### PR DESCRIPTION
https://github.com/harvard-lil/h2o/pull/969/files should work, but something funny is happening with the `:not` selector.... verified by playing around with adding borders to elements: The selector inside `:not()` has to be simple (`p`, or `div`, not `p.foo` or `p, span`) or the entire block of css gets dropped.

Switching to `:not(section)` seems to work.