### PR TITLE
Update Postgres to 9.6.16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:9.5.15
+    image: postgres:9.6.16
     volumes:
       - db_data:/var/lib/postgresql/data:delegated
     ports:


### PR DESCRIPTION
You will need to `docker volume rm h2o_db_data` before rebuilding.