### PR TITLE
Support add-user and change-password in admin

### DIFF
--- a/_python/config/settings/settings_base.py
+++ b/_python/config/settings/settings_base.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'webpack_loader',
 
     # built-in
-    'main.apps.CustomAdminConfig',
+    'django.contrib.admin.apps.SimpleAdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.db.models import Q, Count
 from django.urls import reverse
 from django.utils.html import format_html
@@ -428,12 +429,52 @@ class TextBlockAdmin(BaseAdmin):
 
 ## Users
 
-class UserAdmin(BaseAdmin):
-    readonly_fields = ['created_at', 'updated_at', 'display_name', 'last_request_at', 'last_login_at', 'login_count', 'login']
+class UserAddForm(forms.ModelForm):
+    """
+        Override DjangoUserAdmin.add_form so "add user" uses a standard form, except for setting random user password
+        on creation so the recover-password feature will work.
+    """
+    class Meta:
+        model = User
+        fields = '__all__'
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        self.instance.set_password(User.objects.make_random_password(length=20))
+        if commit:
+            user.save()
+        return user
+
+
+class UserAdmin(BaseAdmin, DjangoUserAdmin):
+    filter_horizontal = ('roles', 'verified_professor')
+    ordering = ('-created_at',)
+    add_form = UserAddForm
+    add_form_template = None
+    readonly_fields = ['created_at', 'updated_at', 'display_name', 'last_request_at', 'last_login_at', 'login_count']
     list_display = ['id', 'casebook_count', 'display_name', 'login', 'email_address', 'verified_email', 'professor_verification_requested', 'verified_professor', 'get_roles', 'last_request_at', 'last_login_at', 'login_count', 'created_at', 'updated_at']
     list_filter = ['verified_email', 'verified_professor', 'professor_verification_requested', RoleNameFilter]
     search_fields = ['attribution', 'title', 'email_address']
-    fields = ['title', 'attribution', 'login', 'email_address', 'verified_email', 'professor_verification_requested', 'verified_professor', 'affiliation', 'last_request_at', 'last_login_at', 'login_count', 'created_at', 'updated_at']
+    fieldsets = (
+        (None, {'fields': ('email_address', 'password')}),
+        ('Personal info', {'fields': ('title', 'attribution', 'affiliation')}),
+        ('Permissions', {
+            'fields': ('verified_email', 'professor_verification_requested', 'verified_professor'),
+        }),
+        ('User activity', {'fields': (
+            'last_request_at',
+            'login_count',
+            ('current_login_at', 'current_login_ip'),
+            ('last_login_at', 'last_login_ip'),
+            ('created_at', 'updated_at'))}),
+    )
+    add_fieldsets = (
+        (None, {'fields': ('email_address',)}),
+        ('Personal info', {'fields': ('title', 'attribution', 'affiliation')}),
+        ('Permissions', {
+            'fields': ('verified_email', 'professor_verification_requested', 'verified_professor'),
+        }),
+    )
     inlines = [RolesUserInline]
 
     def get_queryset(self, request):

--- a/_python/main/apps.py
+++ b/_python/main/apps.py
@@ -1,9 +1,6 @@
 from django.apps import AppConfig
-from django.contrib.admin.apps import AdminConfig
 
 
 class MainConfig(AppConfig):
     name = 'main'
 
-class CustomAdminConfig(AdminConfig):
-    default_site = 'main.admin.CustomAdminSite'

--- a/_python/main/models.py
+++ b/_python/main/models.py
@@ -2388,6 +2388,7 @@ class Role(NullableTimestampedModel):
     """
         User roles.
     """
+    fix_after_rails("Could remove a lot of boilerplate by switching to Django's built-in is_staff, is_superuser, and groups features.")
     name = models.CharField(max_length=40, blank=True, null=True)
     authorizable_type = models.CharField(max_length=40, blank=True, null=True)
     authorizable_id = models.IntegerField(blank=True, null=True)


### PR DESCRIPTION
This lets our UserAdmin inherit from Django's built-in UserAdmin, which comes along with a free change-password form. Also overrides the new-user form to set a random password, which means the reset password form will work.

*Suggested workflow for creating accounts that don't end in .edu:*

- Create the account in the Django admin, with no password and with verified_email off
- Either use the forgot-password form or tell the user to use it, and they should then be able to verify their email, set a password, and get the welcome email as normal

Fixes #999 