### PR TITLE
Tweaks for adding users via the admin

### DIFF
--- a/_python/conftest.py
+++ b/_python/conftest.py
@@ -6,8 +6,9 @@ from datetime import datetime
 from distutils.sysconfig import get_python_lib
 import pytest
 import factory
-from django.conf import settings
 
+from django.conf import settings
+from django.contrib.auth.hashers import make_password
 from django.db import connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.test.utils import CaptureQueriesContext
@@ -84,6 +85,12 @@ class UserFactory(factory.DjangoModelFactory):
     affiliation = factory.Sequence(lambda n: 'Affiliation %s' % n)
     verified_email = True
     password_salt = '7'
+    crypted_password = make_password('somepassword')
+
+
+@register_factory
+class UnconfirmedUserFactory(UserFactory):
+    verified_email = False
 
 
 @register_factory

--- a/_python/main/admin.py
+++ b/_python/main/admin.py
@@ -504,7 +504,7 @@ class UserAdmin(BaseAdmin, DjangoUserAdmin):
                 user’s password, but you can change the password using
                 <a href="../password/">this form</a>.
             """
-            formfield.widget.attrs['disabled'] = True
+            formfield.disabled = True
         return formfield
 
     def get_roles(self, obj):

--- a/_python/main/templates/admin/main/user/change_form.html
+++ b/_python/main/templates/admin/main/user/change_form.html
@@ -7,7 +7,7 @@
     <form id="send_email" method="POST" action="{% url 'password_reset' %}" onsubmit="event.preventDefault(); fetch(this.action, {method: 'POST', body: new FormData(this)}).then(data => document.getElementById('email_result').textContent = (data.ok ? 'Success!' : 'Error!'));">
       {% csrf_token %}
       <input type="hidden" name="email" value="{{ original.email_address }}">
-      <button class="button" type="submit" value="Upload file and update statuses" style="padding: 7px 15px;">Send {{ original.verified_email|yesno:"Password Reset, Activation"}} Email</button>
+      <button class="button" type="submit" style="padding: 7px 15px;">Send {{ original.verified_email|yesno:"Password Reset, Activation"}} Email</button>
       <div id="email_result" class="help"></p>
     </form>
   </div>

--- a/_python/main/templates/admin/main/user/change_form.html
+++ b/_python/main/templates/admin/main/user/change_form.html
@@ -1,6 +1,18 @@
 {% extends "admin/change_form.html" %}
 {% load admin_urls %}
 
+{% block object-tools %}
+  {{ block.super }}
+  <div class="module">
+    <form id="send_email" method="POST" action="{% url 'password_reset' %}" onsubmit="event.preventDefault(); fetch(this.action, {method: 'POST', body: new FormData(this)}).then(data => document.getElementById('email_result').textContent = (data.ok ? 'Success!' : 'Error!'));">
+      {% csrf_token %}
+      <input type="hidden" name="email" value="{{ original.email_address }}">
+      <button class="button" type="submit" value="Upload file and update statuses" style="padding: 7px 15px;">Send {{ original.verified_email|yesno:"Password Reset, Activation"}} Email</button>
+      <div id="email_result" class="help"></p>
+    </form>
+  </div>
+{% endblock %}
+
 {% block after_related_objects %}
   {{ block.super }}
   <div class="module aligned">

--- a/_python/main/urls.py
+++ b/_python/main/urls.py
@@ -32,8 +32,8 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('accounts/new/', views.sign_up, name='sign_up'),
     path('accounts/edit/', views.edit_user, name='edit_user'),
 
-    # built-in Django auth views for login/logout/password update/password reset, with overrides to replace the form in some views
-    path('accounts/password_reset/', no_perms_test(auth_views.PasswordResetView.as_view(form_class=forms.PasswordResetForm)), name='password_reset'),
+    # built-in Django auth views for login/logout/password update/password reset, with overrides to replace the form or tweak behavior in some views
+    path('accounts/password_reset/', no_perms_test(views.reset_password), name='password_reset'),
     path('accounts/reset/<uidb64>/<token>/', no_perms_test(auth_views.PasswordResetConfirmView.as_view(form_class=forms.SetPasswordForm)), name='password_reset_confirm'),
     path('accounts/', include('django.contrib.auth.urls')),
 

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -1353,6 +1353,6 @@ def reset_password(request):
         except User.DoesNotExist:
             target_user = None
         if target_user and not target_user.verified_email:
-                send_verification_email(request, target_user)
+            send_verification_email(request, target_user)
 
     return PasswordResetView.as_view(form_class=PasswordResetForm)(request)

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.views import redirect_to_login
+from django.contrib.auth.views import redirect_to_login, PasswordResetView
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, JsonResponse, Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
@@ -27,11 +27,11 @@ from .test.test_permissions_helpers import perms_test, viewable_section, directl
 from test.test_helpers import check_response, assert_url_equal, dump_content_tree_children
 from pytest import raises as assert_raises
 
-from .utils import parse_cap_decision_date, fix_after_rails, CapapiCommunicationException, StringFileResponse
+from .utils import parse_cap_decision_date, fix_after_rails, CapapiCommunicationException, StringFileResponse, send_verification_email
 from .serializers import AnnotationSerializer, NewAnnotationSerializer, UpdateAnnotationSerializer, CaseSerializer, TextBlockSerializer
 from .models import Casebook, Section, Resource, Case, User, CaseCourt, ContentNode, TextBlock, Default, ContentAnnotation
 from .forms import CasebookForm, SectionForm, ResourceForm, LinkForm, TextBlockForm, NewTextBlockForm, UserProfileForm, \
-    SignupForm
+    SignupForm, PasswordResetForm
 
 
 ### helpers ###
@@ -1326,3 +1326,33 @@ def export(request, node, file_type='docx'):
         '_annotated' if include_annotations else ''
     )
     return StringFileResponse(response_data, as_attachment=True, filename=filename)
+
+
+def reset_password(request):
+    """
+        Displays the reset password form. We wrap the default Django view to add a custom redirect
+        if unconfirmed users try to reset their password.
+
+        Given:
+        >>> client, user, unconfirmed_user, mailoutbox = [getfixture(i) for i in ['client', 'user', 'unconfirmed_user', 'mailoutbox']]
+        >>> url = reverse('password_reset')
+
+        Confirmed users receive the password reset email as usual:
+        >>> response = client.post(url, {"email": user.email_address})
+        >>> assert len(mailoutbox) == 1
+        >>> assert 'Password reset' in  mailoutbox[0].subject
+
+        Unconfirmed users receive the verification email:
+        >>> response = client.post(url, {"email": unconfirmed_user.email_address})
+        >>> assert len(mailoutbox) == 2
+        >>> assert 'An H2O account has been created for you' in  mailoutbox[1].subject
+    """
+    if request.method == "POST":
+        try:
+            target_user = User.objects.get(email_address=request.POST.get('email'))
+        except User.DoesNotExist:
+            target_user = None
+        if target_user and not target_user.verified_email:
+                send_verification_email(request, target_user)
+
+    return PasswordResetView.as_view(form_class=PasswordResetForm)(request)

--- a/_python/main/views.py
+++ b/_python/main/views.py
@@ -1330,8 +1330,8 @@ def export(request, node, file_type='docx'):
 
 def reset_password(request):
     """
-        Displays the reset password form. We wrap the default Django view to add a custom redirect
-        if unconfirmed users try to reset their password.
+        Displays the reset password form. We wrap the default Django view to send
+        an email verification email if unconfirmed users try to reset their password.
 
         Given:
         >>> client, user, unconfirmed_user, mailoutbox = [getfixture(i) for i in ['client', 'user', 'unconfirmed_user', 'mailoutbox']]


### PR DESCRIPTION
This PR addresses [my comments](https://github.com/harvard-lil/h2o/pull/1005#issuecomment-566782502) on the PR to "Support add-user and change-password in admin"

- It switches the admin to display `crypted_password` instead of `password`, pending further changes to our auth setup.
- It arranges for users without verified email addresses to receive a new verification email if they attempt to reset their password
- It adds a button to the Django admin letting admins trigger the sending of a verification email (for unverified users) or a password reset email (for verified users).


![image](https://user-images.githubusercontent.com/11020492/71125609-4cd44b80-21b5-11ea-9485-4e5fb0708d23.png)

![image](https://user-images.githubusercontent.com/11020492/71125555-2d3d2300-21b5-11ea-9c68-5c0e7d819dfb.png)

And yes.... that did take all day 😁 