### PR TITLE
Correct DB initialization and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,13 @@ The first time this runs it will build the Docker images, which
 may take several minutes. (After the first time, it should only take
 1-3 seconds.)
 
-Finally, initialize an empty database...
-
-    $ bash docker/init.sh
-
-...or a database seeded with data from a pg_dump file:
+If the H2O team has provided you with a pg_dump file, seed the database with data:
 
     $ bash docker/init.sh -f ~/database.dump
 
 Then log into the main Docker container:
 
     $ docker-compose exec web bash
-    #
 
 (Commands from here on out that start with `#` are being run in Docker.)
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -2,10 +2,10 @@
 set -e
 
 display_usage() {
-    echo "Create dev and test databases. Dev database may optionally be seeded with data from a pg_dump file."
+    echo "Seed dev database with data from a pg_dump file."
     echo
     echo "Usage:"
-    echo "  bash docker/init.sh [-f dump_file]"
+    echo "  bash docker/init.sh -f dump_file"
 }
 
 # Help
@@ -14,42 +14,38 @@ if [[ ( $1 == "--help") ||  ($1 == "-h")]]; then
     exit 0
 fi
 
-# Optional flag to use dump file
-if [[ $# -gt 0 ]]; then
-    getopts ":f:" opt || true;
-    case $opt in
-        f)
-            if [ -f "$OPTARG" ]
-            then
-                FILE=$OPTARG
-            else
-                echo "Invalid path."
-                exit 1
-            fi
-            ;;
-        \?)
-            # illegal option or argument
-            display_usage
+
+getopts ":f:" opt || true;
+case $opt in
+    f)
+        if [ -f "$OPTARG" ]
+        then
+            FILE=$OPTARG
+        else
+            echo "Invalid path."
             exit 1
-            ;;
-        :)
-            # -f present, but no path provided
-            echo "Please specify the path."
-            exit 1
-            ;;
-    esac
-    if [[ $((OPTIND - $#)) -ne 1 ]]; then
-        # too many args
+        fi
+        ;;
+    \?)
+        # illegal option or argument
         display_usage
         exit 1
-    fi
+        ;;
+    :)
+        # -f present, but no path provided
+        echo "Please specify the path."
+        exit 1
+        ;;
+esac
+if [[ $((OPTIND - $#)) -ne 1 ]]; then
+    # wrong number of args
+    display_usage
+    exit 1
 fi
 
-echo "Creating databases ..."
-if [ "$FILE" ]; then
-    echo "Loading data from $FILE ..."
-    docker cp "$FILE" "$(docker-compose ps -q db)":/tmp/data.dump
-    docker-compose exec db bash -c "pg_restore -l /tmp/data.dump | grep -v schema_migrations | grep -v ar_internal_metadata > /tmp/restore.list"
-    docker-compose exec db pg_restore -L /tmp/restore.list --disable-triggers --username=postgres --verbose --no-owner -h localhost -d postgres /tmp/data.dump
-    docker-compose exec db rm -f /tmp/data.dump /tmp/restore.list
-fi
+echo "Loading data from $FILE ..."
+docker cp "$FILE" "$(docker-compose ps -q db)":/tmp/data.dump
+docker-compose exec db bash -c "pg_restore -l /tmp/data.dump | grep -v schema_migrations | grep -v ar_internal_metadata > /tmp/restore.list"
+docker-compose exec db pg_restore -L /tmp/restore.list --disable-triggers --username=postgres --verbose --no-owner -h localhost -d postgres /tmp/data.dump
+docker-compose exec db rm -f /tmp/data.dump /tmp/restore.list
+


### PR DESCRIPTION
In Rails land, `init.sh` created test and dev databases, and then, if run with `-f` and provided a pg_dump file, it would seed the database.

Now there is no need to manually create any databases: we only need one, and we are using the default that comes with the postgres docker image.

This PR updates the README and tweaks the init script. 

It retains use of the `-f` flag, which is a slightly awkward API, now, because it is mandatory.... Shall I remove it? I am pretty rusty on bash script argument parsing, and am a little hesitant to dive back in, especially if we think we might want the existing framework to parse more flags in the future (for instance, running with or without `disable-triggers`). But, I am happy to do so if this feels too peculiar!