### PR TITLE
Further correct database initialization script.

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -45,7 +45,5 @@ fi
 
 echo "Loading data from $FILE ..."
 docker cp "$FILE" "$(docker-compose ps -q db)":/tmp/data.dump
-docker-compose exec db bash -c "pg_restore -l /tmp/data.dump | grep -v schema_migrations | grep -v ar_internal_metadata > /tmp/restore.list"
-docker-compose exec db pg_restore -L /tmp/restore.list --disable-triggers --username=postgres --verbose --no-owner -h localhost -d postgres /tmp/data.dump
-docker-compose exec db rm -f /tmp/data.dump /tmp/restore.list
-
+docker-compose exec db pg_restore --username=postgres --verbose --no-owner -h localhost -d postgres /tmp/data.dump
+docker-compose exec db rm -f /tmp/data.dump


### PR DESCRIPTION
I hubristically merged https://github.com/harvard-lil/h2o/pull/1018 before attempting to run migrations..... which failed.

They failed because the initialization script had special handling for two Rails-only tables, `ar_internal_metadata` and `schema_migrations`. Previously, prior to the pg_restore move, Rails would create an empty, but fully migrated database, and this script would attempt to load data into the already-present tables. The database creation move would itself populate `ar_internal_metadata` and `schema_migrations`; the data import therefore intentionally skipped those tables. But now, we don't want any of that special handling: we want the whole DB, as is.... so that we can run migrations, the first of which drops all Rails-only tables, including `ar_internal_metadata` and `schema_migrations`!

With apologies.

I have now run this twice locally, and believe it is now correct.