### PR TITLE
Dismiss note annotations in FF friendly way

### DIFF
--- a/web/frontend/components/NoteAnnotation.vue
+++ b/web/frontend/components/NoteAnnotation.vue
@@ -18,7 +18,7 @@
           ref="noteForm"
           class="form note-content"
           :id= "`${annotation.id}`"
-          @focusout="focusOut">
+          v-click-outside="dismissNote">
       <textarea ref="noteInput"
                 id="note-textarea"
                 required="true"
@@ -48,10 +48,14 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import AnnotationBase from './AnnotationBase';
+import vClickOutside from 'v-click-outside'
 import { createNamespacedHelpers } from 'vuex';
 const { _mapGetters } = createNamespacedHelpers('annotations_ui');
 const { mapActions } = createNamespacedHelpers("annotations");
+
+Vue.use(vClickOutside)
 
 export default {
   extends: AnnotationBase,
@@ -73,11 +77,9 @@ export default {
         {obj: annotation, vals: {content: content}}
       );
     },
-    focusOut(e){
-      if (Math.sign(this.annotation.id) === -1 && e.relatedTarget == null || e.relatedTarget !== null && ["save-note", "note-textarea"].includes(e.relatedTarget.id) == false){     
+    dismissNote(){
         this.$store.commit('annotations/destroy', this.annotation);
         this.$store.commit('annotations_ui/destroy', this.uiState);
-      }
     }
   },
   mounted() {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15461,6 +15461,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
+    "v-click-outside": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v-click-outside/-/v-click-outside-3.0.1.tgz",
+      "integrity": "sha512-FITcAM0R3JEPUSGiO7hfhKDODZHkOQTk/FyI9mwxNcz6LbMbJhABhjevLI5VsU00PRksloQx8vmpFIqlAfX6nw=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "query-string": "^4.3.4",
     "serialize-javascript": "2.1.1",
     "set-value": "^2.0.1",
+    "v-click-outside": "^3.0.1",
     "vue": "^2.6.10",
     "vue-contenteditable-directive": "^1.2.0",
     "vue-loader": "^15.6.2",


### PR DESCRIPTION
Firefox doesn't handle relatedTarget for focusOut events in a way we are trying to use it.
Use vue directive for detecting clicks outside the note annotation save box.