### PR TITLE
Show generic focus style for search results list

### DIFF
--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -90,6 +90,12 @@ header.advanced-search {
 }
 
 .results-list {
+    .wrapper:focus {
+        outline:none;
+        .results-entry {
+            @include generic-focus-styles;
+        }
+    }
   .results-entry {
     @include make-row();
     padding: 10px 0;


### PR DESCRIPTION
Works around a fun webkit bug where a tags simultaneously do and don't have focus. 