### PR TITLE
Workaround for FFDevEdition contenteditable oninput issue

### DIFF
--- a/web/frontend/components/ReplacementAnnotation.vue
+++ b/web/frontend/components/ReplacementAnnotation.vue
@@ -86,6 +86,8 @@ export default {
 
     submit() {
       if(this.isModified && this.content){
+        // Work around FirefoxDevEdition bug that isn't properly populating event.target.innerText reliably
+        this.newVals.content = this.$refs.replacementText.innerText;
         this[this.isNew ? "createAndUpdate" : "update"](
           {obj: this.annotation, vals: this.newVals}
         );

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -51,7 +51,7 @@
                 {% if not editing %}
                     {% include 'includes/headnote.html' with content=section %}
                     {% include section.body_template %}
-            {% endif %}
+                {% endif %}
             {% else %}
                 {% if not editing %}
                     {% include 'includes/headnote.html' with content=casebook %}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -92,6 +92,8 @@ def hydrate_params(func):
                 if old_cb_ids:
                     cb_param = {'casebook': casebook_param['id']}
                     kwargs['casebook'] = old_cb_ids[0]
+                else:
+                    raise Http404
         for param in ('section_param', 'section_id', 'resource_param', 'resource_id', 'node_param', 'node_id'):
             param_value = kwargs.pop(param, None)
             if not param_value:


### PR DESCRIPTION
Also properly throw 404 instead of 500 when looking up nonexistent casebooks. 