### PR TITLE
Fix django admin's collaborator name filter

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -9,7 +9,7 @@ from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib import messages
 from django.contrib.postgres import fields
 from django.core.mail import send_mail
-from django.db.models import Q, Count
+from django.db.models import Count
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
@@ -151,7 +151,7 @@ class CollaboratorNameFilter(InputFilter):
     def queryset(self, request, queryset):
         value = self.value()
         if value is not None:
-            users = User.objects.filter(Q(title__icontains=value) | Q(attribution__icontains=value))
+            users = User.objects.filter(attribution__icontains=value)
             return queryset.filter(casebook__collaborators__in=users)
 
 class CollaboratorIdFilter(InputFilter):


### PR DESCRIPTION
The User 'title' field was removed long ago in https://github.com/harvard-lil/h2o/commit/a58d83301bd9b2378032e64be6a29f5a1dd84d7c, but I didn't remove it here!

Hence, I just triggered:
```
Internal Server Error: /django-admin/main/casebook/

FieldError at /django-admin/main/casebook/
Cannot resolve keyword 'title' into field. Choices are: affiliation, attribution, casebookfollow, casebooks, contentcollaborator, created_at, current_login_at, current_login_ip, email_address, groups, id, is_active, is_staff, is_superuser, last_login_at, last_login_ip, last_request_at, logentry, login_count, password, professor_verification_requested, public_url, saved_images, updated_at, user_permissions, verified_professor

Request Method: GET
Request URL: http://opencasebook.org/django-admin/main/casebook/?collaborator-name=<redacted>
```