### PR TITLE
Upgrade to Postgres 12.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3'
 services:
   db:
-    image: registry.lil.tools/library/postgres:9.6.16
+    image: registry.lil.tools/library/postgres:12.8
     volumes:
-      - db_data:/var/lib/postgresql/data:delegated
+      - db_data_12:/var/lib/postgresql/data:delegated
     ports:
       - "127.0.0.1:54320:5432"
+    environment:
+      - POSTGRES_PASSWORD=example
 
   web:
     build:
@@ -43,6 +45,6 @@ services:
       - "127.0.0.1:9000:9000"
 
 volumes:
-  db_data:
+  db_data_12:
   node_modules:
   minio_data:

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -86,6 +86,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'postgres',
         'USER': 'postgres',
+        'PASSWORD': 'example',
         'HOST': 'db',
         'PORT': 5432,
     }


### PR DESCRIPTION
This PR upgrades the dev environment's database server to 12.8, in anticipation of an obligatory upgrade in production.

For what it's worth, I was able to load a recent database dump into the new DB, and the application works. I'm not sure if there's more specific tire-kicking to do.