### PR TITLE
Fix glob so nested directories are copied in.

### DIFF
--- a/docker/pandoc-lambda/Dockerfile
+++ b/docker/pandoc-lambda/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install pip==21.3.1 \
 # Add the function code
 RUN mkdir -p /function
 WORKDIR /function
-COPY function/* ./
+COPY function/** ./
 
 # Set CMD to the handling function defined in app.py, and via the entrypoint, arrange for
 # that function to be run via actual AWS Lambda or via the container's own Lambda runtime emulator,


### PR DESCRIPTION
With this change:
```
docker-compose exec pandoc-lambda bash
root@ae845f0b4d55:/function# ls
README.md    old_pr1491       requirements.txt
__pycache__  reference.docx   setup.cfg
app.py	     requirements.in  table_of_contents.lua
```

Versus live:
```
docker run --rm -it {redacted}.dkr.ecr.us-east-1.amazonaws.com/pandoc-lambda:{redacted} bash
root@997eb1031332:/function# ls
README.md  app.cpython-39.pyc  app.py  reference.docx  requirements.in	requirements.txt  setup.cfg  table_of_contents.lua
```