### PR TITLE
Fix glob, attempt 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       context: ./docker/pandoc-lambda
       args:
         lambda-rie-cache-buster: 9af4d93c-23f9-4cb1-99c4-b9af89f94668
-    image: h2o-pandoc-lambda:0.53
+    image: h2o-pandoc-lambda:0.54
     tty: true
     environment:
       - USE_S3_CREDENTIALS=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
     # After a few seconds, a newly-compiled requirements.txt will sync to ./docker/pandoc-lambda/function!
     # Then, put back the comment, increment the image number, and run `docker-compose up -d` again, to rebuild with the new requirements.
     # command: 'pip-compile --generate-hashes'
-    volumes:
-      - ./docker/pandoc-lambda/function/:/function
+    # volumes:
+    #   - ./docker/pandoc-lambda/function/:/function
 
 volumes:
   db_data_12:

--- a/docker/pandoc-lambda/Dockerfile
+++ b/docker/pandoc-lambda/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install pip==21.3.1 \
 # Add the function code
 RUN mkdir -p /function
 WORKDIR /function
-COPY function/** ./
+COPY function /function
 
 # Set CMD to the handling function defined in app.py, and via the entrypoint, arrange for
 # that function to be run via actual AWS Lambda or via the container's own Lambda runtime emulator,


### PR DESCRIPTION
I tested https://github.com/harvard-lil/h2o/pull/1502 incorrectly, by continuing to inspect the files in the volume, not the image.

This PR comments out the volume for clarity, in addition to switching to a syntax that doesn't use globs.

```
docker run --rm -it h2o-pandoc-lambda:0.54 ls
README.md  __pycache__	app.py	old_pr1491  reference.docx  requirements.in  requirements.txt  setup.cfg  table_of_contents.lua
```
No volume, and all files are present.