### PR TITLE
Fix: span tag grabbing event

### DIFF
--- a/web/main/templates/includes/action_buttons.html
+++ b/web/main/templates/includes/action_buttons.html
@@ -54,8 +54,7 @@
     {% if request.user.is_superuser %}
       {% if section.casebook is section %} {# at the top level of a casebook, the 'section' you're looking is the casebook itself. Sections only make sense at the top level. #}
         <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
-        <a class="action one-line export fancy export-docx-sections export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#"><span style="font-weight: lighter; font-style: italic;">avec des sections</span></a>
-
+        <a class="action one-line export fancy export-docx-sections export-{{ section.is_annotated|yesno:"has,no" }}-annotations" style="font-weight: lighter; font-style: italic;" role="button" rel="nofollow" href="#">avec des sections</a>
       {% else %}
         <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export w/o format <br>changes for sections</a>
         <a class="action one-line export fancy export-docx-sections export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Proposed Export</a>


### PR DESCRIPTION
Last minute, I changed an `<i>` tag to a `<span style=` tag without considering that `span` might be the target of the click event while the `I` tag wouldn't. I just took that style information and put it in the parent `div` that needed to be the target.