### PR TITLE
Semicolonectomy

### DIFF
--- a/web/main/templates/export/node.html
+++ b/web/main/templates/export/node.html
@@ -97,4 +97,4 @@
 {% if not is_child %}
   {% include 'export/about.html' %}
 {% endif %}
-<div data-custom-style="Node End">_h2o_keep_element;</div>
+<div data-custom-style="Node End">_h2o_keep_element</div>


### PR DESCRIPTION
Addresses #1507 

Extracted a stray semicolon left in a structural tag during the non-breaking space-> spacer text replacement. It wasn't noticeable in word because it's very small white text on a white background. I'm pretty sure it was the only one. 