### PR TITLE
Re-enable volume mount for pandoc-lambda on local dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: "Test Django"
           command: |
-            docker-compose up -d
+            docker-compose -f docker-compose.yml up -d       # use -f to suppress docker-compose.override.yml
             docker-compose exec web ./manage.py collectstatic --noinput   # collect static files
             mkdir -p junit/pytest                            # storage for circleci test info
             docker-compose exec web pytest \
@@ -61,7 +61,7 @@ jobs:
       - run:
           name: "Test Javascript"
           command: |
-            docker-compose up -d
+            docker-compose -f docker-compose.yml up -d       # use -f to suppress docker-compose.override.yml
             docker-compose exec web bash -c "umask 0 && mkdir /app/web/.npmcache && npm config set cache /app/web/.npmcache && npm install"
             docker-compose exec web npm run lint
             docker-compose exec web npm run build

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+# overrides for local development, not used in CI
+version: '3'
+services:
+  pandoc-lambda:
+    volumes:
+      - ./docker/pandoc-lambda/function/:/function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,12 +63,9 @@ services:
       - AWS_SECRET_ACCESS_KEY=secretkey
       - S3_ENDPOINT_URL=http://minio:9000
       - EXPORT_BUCKET=h2o.exports
-    # To update requirements from requirements.in: uncomment the below line and re-run `docker-compose up -d`.
-    # After a few seconds, a newly-compiled requirements.txt will sync to ./docker/pandoc-lambda/function!
-    # Then, put back the comment, increment the image number, and run `docker-compose up -d` again, to rebuild with the new requirements.
-    # command: 'pip-compile --generate-hashes'
-    # volumes:
-    #   - ./docker/pandoc-lambda/function/:/function
+    # volumes: is set for local dev in docker-compose.override.yml
+    # Uncomment to disable entrypoint if changes to requirements mean container can't start:
+    # command: bash
 
 volumes:
   db_data_12:

--- a/docker/pandoc-lambda/README.md
+++ b/docker/pandoc-lambda/README.md
@@ -2,9 +2,7 @@
 
 ### ...locally, against the Lambda Runtime Interface Emulator
 
-In the H2O app's `settings.py`, set `FORCE_AWS_LAMBDA_EXPORT = True`. Then, every Casebook's export will be routed to a local container that runs the lambda function.
-
-Or, log in to your local H2O as an administrator and click the "AWS Lambda Export" button.
+In development, every Casebook's export will be routed to a local container that runs the lambda function in app.py.
 
 Run `docker-compose logs -f pandoc-lambda` to watch requests come in and review their metrics.
 
@@ -24,8 +22,6 @@ AWS_LAMBDA_EXPORT_SETTINGS = {
 
 Connect to the VPN.
 
-Then, as above, decide whether you want to send all casebook exports to the lambda (add `FORCE_AWS_LAMBDA_EXPORT = True` to `settings.py`) or if you prefer to log in as an administrator and click the "AWS Lambda Export" button.
-
 When the lambda returns, you should see its log printed to the console and should be served a DOCX... or, failing that, at least be given an instructive error message.
 
 
@@ -43,9 +39,13 @@ Increment the image number in `docker-compose.yml` and re-run `docker-compose up
 
 ### ...with new python requirements, including `awslambdaric`
 
-Add new packages or pin versions in `requirements.in`. Then, follow the instructions in `docker-compose.yml` to recompile `requirements.txt` and update the Docker image.
+Add new packages or pin versions in `requirements.in`. Then run `docker-compose exec pandoc-lambda pip-compile --allow-unsafe --generate-hashes`.
 
-To update a single (unpinned) package such as `awslambdaric` do the same thing, except add `--upgrade-package awslambdaric` or similar to the cmd in `docker-compose.yml`.
+Increment the image number in `docker-compose.yml` to produce a new image.
+
+If you can't start the container because of a requirements change, you may need to edit docker-compose.yml to temporarily disable the entrypoint.
+
+To update a single (unpinned) package such as `awslambdaric` do the same thing, except add `--upgrade-package awslambdaric` or similar.
 
 ### ...with a new Lambda Runtime Interface Emulator
 


### PR DESCRIPTION
This adds a docker-compose.override.yml that only runs on local dev and not on CI (I think, assuming I'm adding `-f` to the right CircleCI file, Ben).

This way we can do things like having a `volume` mount for `pandac-lambda` locally without having it on CI. We initially removed the `volume` because it masked an issue on CI with the Dockerfile not copying files over to the image correctly, but it's useful locally.