### PR TITLE
Use Github Actions for tests

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,16 @@
+name: Lints
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Flake8
+        run: |
+          pip install `egrep -o 'flake8==\S+' web/requirements.txt`  # install our version of flake8
+          flake8 web/
+          flake8 docker/pandoc-lambda/function/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,125 @@
+name: Tests
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    working-directory: capstone
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    # don't run on pushes to forks
+    if: github.event_name == 'pull_request' || github.repository == 'harvard-lil/h2o'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      ### build docker images ###
+
+      - name: Rebuild h2o-python if necessary
+        uses: harvard-lil/docker-compose-update-action@main
+        with:
+          image: "registry.lil.tools/harvardlil/h2o-python"
+          docker-file: "docker/Dockerfile"
+          rebuild-if-changed: "docker/Dockerfile web/requirements.txt web/package-lock.json"
+          registry: "registry.lil.tools"
+          registry-user: ${{ secrets.REPOSITORY_USER }}
+          registry-pass: ${{ secrets.REPOSITORY_TOKEN }}
+
+      - name: Rebuild h2o-pandoc-lambda if necessary
+        id: rebuild-pandoc
+        uses: harvard-lil/docker-compose-update-action@main
+        with:
+          image: "registry.lil.tools/harvardlil/h2o-pandoc-lambda"
+          docker-file: "docker/pandoc-lambda/Dockerfile"
+          rebuild-if-changed: "docker/pandoc-lambda"
+          registry: "registry.lil.tools"
+          registry-user: ${{ secrets.REPOSITORY_USER }}
+          registry-pass: ${{ secrets.REPOSITORY_TOKEN }}
+
+      ### run tests ###
+
+      - name: docker-compose up
+        run: |
+          # separate pull so downloads run in parallel, with
+          # --ignore-pull-failures for PRs with new images that haven't been pushed yet:
+          docker-compose -f docker-compose.yml pull --ignore-pull-failures || true
+          docker-compose -f docker-compose.yml up -d        # use -f to suppress docker-compose.override.yml
+          docker ps -a                                      # show running containers
+          docker-compose logs                               # show logs
+
+      - name: Collect static files
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'  # avoid docker-compose "the input device is not a TTY" -- see https://github.com/actions/runner/issues/241#issuecomment-842566950
+        run: docker-compose exec web ./manage.py collectstatic --noinput   # collect static files
+
+      - name: Python tests
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'  # avoid docker-compose "the input device is not a TTY" -- see https://github.com/actions/runner/issues/241#issuecomment-842566950
+        run: |
+          set -x
+          docker-compose exec web pytest \
+            --cov --cov-config=setup.cfg --cov-report xml  `# write coverage data to .coverage for upload by codecov` \
+            -vv
+
+      - name: Javascript tests
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'  # avoid docker-compose "the input device is not a TTY" -- see https://github.com/actions/runner/issues/241#issuecomment-842566950
+        run: |
+          set -x
+          docker-compose exec web bash -c "umask 0 && mkdir /app/web/.npmcache && npm config set cache /app/web/.npmcache && npm install"
+          docker-compose exec web npm run lint
+          docker-compose exec web npm run build
+          docker-compose exec web npm run test
+
+      ### codecov ###
+      # https://github.com/codecov/codecov-action
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+
+      # build, push, and deploy pandoc-lambda image to stage if necessary
+      # this requires that AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION,
+      # and AWS_ACCOUNT_ID be set.
+      # TODO: this could potentially use existing built image
+      - name: Publish pandoc-lambda image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && steps.rebuild-pandoc.outputs.updated == "1"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          aws --version
+          cd docker/pandoc-lambda/
+          IMG=pandoc-lambda
+          TAG=`git rev-parse --short HEAD`
+          ACCT=${AWS_ACCOUNT_ID}
+          REGION=${AWS_DEFAULT_REGION}
+          ARN=arn:aws:lambda:${REGION}:${ACCT}:function:h2o-export-stage
+          aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ACCT}.dkr.ecr.${REGION}.amazonaws.com
+          docker buildx build --push --build-arg=BUILDARCH=amd64 --platform linux/amd64 --tag ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} .
+          aws lambda update-function-code --function-name ${ARN} --image-uri ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} --region ${REGION}
+
+      # Commit built assets if necessary, then deploy via Salt reactor
+      - name: Deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'  # avoid docker-compose "the input device is not a TTY" -- https://github.com/actions/runner/issues/241#issuecomment-842566950
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          DEPLOY_HEADER: ${{ secrets.DEPLOY_HEADER }}
+        run: |
+          set -x
+          git config user.email "lil@law.harvard.edu"
+          git config user.name "Github Actions"
+          if [[ `git status docker-compose.yml --porcelain` ]] ; then
+            git add docker-compose.yml
+            git commit -m "Bump image version"
+            git push origin develop || exit 1
+          fi
+          if [[ `git status web/static/dist/ web/webpack-stats.json --porcelain` ]] ; then
+              git add web/static/dist/ web/webpack-stats.json
+              git commit -m "Add built JS"
+              git push origin develop || exit 1
+          fi
+          export DEPLOY_CONTENT='{"GITHUB_RUN_NUMBER":"'$GITHUB_RUN_NUMBER'","GITHUB_SHA":"'$GITHUB_SHA'","GITHUB_REF":"'$GITHUB_REF'","GITHUB_REPOSITORY":"'$GITHUB_REPOSITORY'","GITHUB_ACTOR":"'$GITHUB_ACTOR'"}' ;
+          export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;
+          curl -X POST "$DEPLOY_URL" --data "$DEPLOY_CONTENT" -H "Content-Type: application/json" -H "$DEPLOY_HEADER: $DEPLOY_SIG"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,3 +4,9 @@ services:
   pandoc-lambda:
     volumes:
       - ./docker/pandoc-lambda/function/:/function
+    build:
+      context: docker/pandoc-lambda
+  web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,7 @@ services:
       - POSTGRES_PASSWORD=example
 
   web:
-    build:
-      context: .
-      dockerfile: ./docker/Dockerfile
-    image: h2o-python:0.64
+    image: registry.lil.tools/harvardlil/h2o-python:0.64-nohash
     tty: true
     command: bash
     environment:
@@ -50,11 +47,7 @@ services:
       - "127.0.0.1:9000:9000"
 
   pandoc-lambda:
-    build:
-      context: ./docker/pandoc-lambda
-      args:
-        lambda-rie-cache-buster: 9af4d93c-23f9-4cb1-99c4-b9af89f94677
-    image: h2o-pandoc-lambda:0.56
+    image: registry.lil.tools/harvardlil/h2o-pandoc-lambda:0.56-nohash
     tty: true
     environment:
       - USE_S3_CREDENTIALS=True
@@ -68,5 +61,4 @@ services:
 
 volumes:
   db_data_12:
-  node_modules:
   minio_data:

--- a/docker/pandoc-lambda/Dockerfile
+++ b/docker/pandoc-lambda/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get update && \
     unzip \
     libcurl4-openssl-dev
 
-# (Add Lambda Runtime Interface Emulator and set up the entrypoint script
-ARG lambda-rie-cache-buster
-ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/local/bin/aws-lambda-rie
+# Add Lambda Runtime Interface Emulator and set up the entrypoint script
+ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/v1.5/aws-lambda-rie /usr/local/bin/aws-lambda-rie
 COPY entrypoint.sh /
 RUN chmod 755 /usr/local/bin/aws-lambda-rie /entrypoint.sh
 EXPOSE 8080


### PR DESCRIPTION
First cut at using Github Actions for h2o. This is mostly a direct translation without changing much substance, using the Github Actions setup from CAP and the series of test steps from h2o's CircleCI config.

One change: Lambda Runtime Interface Emulator is pinned by url version in Dockerfile, rather than refreshed by changing a UUID in docker-compose.yml.

Second change: like CAP, built dev images for h2o-python and h2o-pandoc-lambda are now pushed to the Docker repository. Unlike CAP I'm trying to use registry.lil.tools instead of DockerHub, will see how that goes. The upshot is tests will now pull from the registry instead of rebuilding if possible. Another upshot is you can do `docker-compose pull` before `docker-compose up` and avoid a rebuild if the image already exists.