### PR TITLE
Usage dashboard 

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.admin.apps.SimpleAdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.humanize',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -14,8 +14,10 @@ AUTH_PASSWORD_VALIDATORS = []
 # STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
 # django-debug-toolbar:
-# ddt can be useful but also be a hassle, so it only runs optionally, if you choose to `pip install django-debug-toolbar`
+# ddt can be useful but also be a hassle, so it only runs optionally, if you choose to `pip install django-debug-toolbar==3.2.2`
 # If installed, there will be a sidebar when viewing front-end pages, including useful tools such as a SQL profiler.
+# Do not use a version more recent than django-debug-toolbar==3.2.2, as Django 2.2 support is dropped in 3.3.x
+# and 3.2.3+ introduced a config bug.
 import sys
 if 'pytest' not in sys.modules:  # don't run this from tests
     try:

--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -6,18 +6,18 @@ from django.contrib.postgres import fields
 from django.core.mail import send_mail
 from django.db.models import Count
 from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django_json_widget.widgets import JSONEditorWidget
 from simple_history.admin import SimpleHistoryAdmin
 
+from .usage import view as usage_dashboard_view
 from .models import (Casebook, ContentAnnotation, ContentCollaborator,
                      ContentNode, EmailWhitelist, LegalDocument,
                      LegalDocumentSource, Link, Resource, Section, TextBlock,
                      User, LiveSettings)
 from .utils import (clone_model_instance, fix_after_rails)
-
 #
 # Helpers
 #
@@ -38,6 +38,14 @@ def edit_link(obj, as_str=False):
 
 class CustomAdminSite(admin.AdminSite):
     site_header = 'H2O Admin'
+    index_template = "admin/h2o_index.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        my_urls = [
+            path('usage/', usage_dashboard_view, name="usage"),
+        ]
+        return my_urls + urls
 
 admin_site = CustomAdminSite(name='h2oadmin')
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2771,6 +2771,10 @@ class Resource(ContentNode):
 
 
 class CommonTitle(BigPkModel):
+    """
+    Commonly referred to as 'series', a many-to-many relationship among casebooks
+    where a single casebook is designated as the current edition
+    """
     name = models.CharField(max_length=300, blank=False, null=False)
     public_url = models.CharField(max_length=300, blank=False, null=False, validators=[validate_unicode_slug])
     current = models.ForeignKey('Casebook', on_delete=models.DO_NOTHING, blank=False, null=False, related_name='title_name')

--- a/web/main/templates/admin/h2o_index.html
+++ b/web/main/templates/admin/h2o_index.html
@@ -1,0 +1,8 @@
+{% extends "admin/index.html" %}
+
+{% block userlinks %}
+
+    <a href="{% url 'admin:usage' %}">Usage</a> /
+    {{ block.super }}
+
+{% endblock userlinks %}

--- a/web/main/templates/admin/usage/index.html
+++ b/web/main/templates/admin/usage/index.html
@@ -1,0 +1,151 @@
+{% extends "admin/base.html" %}
+
+{% load static  %}
+{% load humanize %}
+
+{% block title %}
+    Activity dashboard | H2O Admin
+{% endblock %}
+
+{% block extrahead %}
+
+    {{ date_form.media }}
+
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/base.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}" />
+
+    <script>
+        function updateDate (start_date, end_date) {
+            document.getElementById('id_start_date').value=start_date;
+            document.getElementById('id_end_date').value=end_date;
+        }
+    </script>
+{% endblock extrahead %}
+
+{% block extrastyle %}
+    <style>
+        button.date-preset {
+            text-decoration: underline;
+            background: none;
+            cursor: pointer;
+            border: none;
+            padding: 0;
+        }
+        #toolbar th, #toolbar td { vertical-align: middle; }
+        #toolbar { background-color: #eee; margin-bottom: 1em;}
+        #dashboard th small { font-weight: normal; text-style: italic; display: block; }
+    </style>
+{% endblock extrastyle %}
+
+{% block branding %}
+    <h1 id="site-name">H2O Admin</h1>
+{% endblock %}
+
+
+{% block content %}
+
+<h1>Usage dashboard</h1>
+
+<div id="content-main">
+
+    <div id="toolbar">
+        <form action="" method="get">
+            <table>
+                <tr>
+                    <th>
+                        {{ date_form.start_date.label_tag}}
+                    </th>
+                    <td>
+                        {{ date_form.start_date }}
+                    </td>
+                    <th>
+                        {{ date_form.end_date.label_tag}}
+                    </th>
+                    <td>
+                        {{ date_form.end_date }}
+                    </td>
+                    <td>
+                        {% for key, preset in date_presets.items %}
+                            <button type="button" class="date-preset"
+                                onclick="updateDate('{{ preset.start_date | escapejs }}', '{{ preset.end_date | escapejs }}')"
+                                >{{ preset.label }}
+                            </button>  {% if not forloop.last %} | {% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {{ date_form.published.help_text }} {{ date_form.published }}
+                    </td>
+                    <td>
+                        <input type="submit">
+                    </td>
+
+                </tr>
+            </table>
+        </form>
+    </div>
+
+    <p>
+        Showing all records for users or casebooks created between {{ date_form.start_date.value }} and {{ date_form.end_date.value }}:
+    </p>
+
+
+    <table id="dashboard">
+    <tr>
+        <th>Number of accounts
+            <small>All active, non-staff users</small>
+        </th>
+
+        <td> {{ stats.registered_users | intcomma }}
+        </td>
+    </tr>
+    <tr>
+        <th>Verified professors</th>
+        <td>{{ stats.verified_professors | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Professors with published casebooks</th>
+        <td>{{ stats.profs_with_books | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks</th>
+        <td>{{ stats.casebooks | intcomma}} </td>
+    </tr>
+    <tr>
+        <th>Casebooks including content from Capstone</th>
+        <td>{{ stats.casebooks_cap | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks including content from GPO</th>
+        <td> {{ stats.casebooks_gpo | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks including content from Capstone with at least one professor as contributor</th>
+        <td>{{ stats.casebooks_cap_prof | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks including content from GPO with at least one professor as contributor</th>
+        <td> {{ stats.casebooks_gpo_prof | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks with multiple collaborators</th>
+        <td> {{ stats.casebooks_with_collaborators | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks with multiple collaborators, at least one professor</th>
+        <td> {{ stats.casebooks_with_collaborators_prof | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Series
+            <small>Where the latest casebook is published</small>
+        </th>
+        <td>{{ stats.series | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Series by professors</th>
+        <td>{{ stats.series_by_prof | intcomma }}</td>
+    </tr>
+    </table>
+</div>
+
+{% endblock %}

--- a/web/main/usage.py
+++ b/web/main/usage.py
@@ -1,0 +1,254 @@
+from datetime import date
+
+from typing import Dict
+from django import forms
+from django.http import HttpRequest
+from django.shortcuts import render
+from django.db import connection
+from django.db.models import Count
+from django.contrib.admin.widgets import AdminDateWidget
+from dateutil.relativedelta import *
+from .models import Casebook, User
+
+
+class DateForm(forms.Form):
+    start_date = forms.DateField(
+        required=False, widget=AdminDateWidget(attrs={"type": "date"})
+    )
+    end_date = forms.DateField(
+        required=False, widget=AdminDateWidget(attrs={"type": "date"})
+    )
+    published = forms.BooleanField(
+        required=False, initial=True, help_text="Published casebooks only"
+    )
+
+
+def view(request: HttpRequest):
+    """Render a usage dashboard of useful metrics"""
+
+    stats: Dict[str, int] = {}
+
+    today = date.today()
+    oldest = today - relativedelta(years=20)  # A long time ago
+
+    start_date = oldest
+    end_date = today
+    published_casebooks_only = True
+
+    if "start_date" in request.GET or "end_date" in request.GET:
+        form = DateForm(request.GET)
+
+        if form.is_valid():
+            start_date = form.cleaned_data["start_date"]
+            end_date = form.cleaned_data["end_date"]
+            published_casebooks_only = form.cleaned_data["published"]
+    else:
+        form = DateForm(
+            initial={
+                "start_date": start_date,
+                "end_date": end_date,
+                "published": published_casebooks_only,
+            }
+        )
+
+    # Users and derived users have the date filter applied
+    users = User.objects.filter(
+        is_active=True,
+        is_superuser=False,
+        created_at__gte=start_date,
+        created_at__lte=end_date,
+    )
+    profs = users.filter(verified_professor=True)
+    profs_with_books = profs.annotate(has_books=Count("casebooks")).filter(
+        has_books__gt=0
+    )
+    stats["registered_users"] = users.count()
+    stats["verified_professors"] = profs.count()
+    stats["profs_with_books"] = profs_with_books.count()
+
+    # Casebooks also have the creation date filter applied
+    casebooks = Casebook.objects.filter(
+        created_at__gte=start_date, created_at__lte=end_date
+    )
+
+    state = tuple(tag.value for tag in Casebook.LifeCycle)
+
+    if published_casebooks_only:
+        casebooks = casebooks.filter(state=Casebook.LifeCycle.PUBLISHED.value)
+        state = (Casebook.LifeCycle.PUBLISHED.value,)
+
+    stats["casebooks"] = casebooks.count()
+
+    with connection.cursor() as cursor:
+
+        # Create a little data warehouse of prefiltered reporting-ready tables for reuse in this session
+        cursor.execute(
+            """
+        create temp table if not exists casebooks_from_professors as
+            select casebook_id from main_contentcollaborator
+            inner join main_user u on main_contentcollaborator.user_id = u.id
+            inner join main_casebook c on main_contentcollaborator.casebook_id = c.id
+            where u.verified_professor is true
+                and c.created_at >= %s
+                and c.created_at <= %s
+                and c.state in %s
+            group by casebook_id
+            """,
+            [start_date, end_date, state],
+        )
+
+        cursor.execute(
+            """
+        create temp table if not exists casebooks_with_multiple_collaborators as
+            select casebook_id from main_contentcollaborator
+            inner join main_casebook c on main_contentcollaborator.casebook_id = c.id
+            where c.created_at >= %s
+                and c.created_at <= %s
+                and c.state in %s
+
+            group by casebook_id
+            having count(user_id) > 1
+        """,
+            [start_date, end_date, state],
+        )
+
+        for source in (
+            "CAP",
+            "GPO",
+        ):
+            cursor.execute(
+                f"""
+                create temp table if not exists casebooks_including_source_{source.lower()} as
+                    select casebook_id
+                    from main_contentnode
+                    inner join main_casebook c on main_contentnode.casebook_id = c.id
+                    where resource_type = 'LegalDocument'
+                    and resource_id in
+                    (
+                        select doc.id from main_legaldocument doc
+                        inner join main_legaldocumentsource source on source.id = source_id
+                        where source.name = %s
+                    )
+                    and c.created_at >= %s
+                    and c.created_at <= %s
+                    and state in %s
+                    group by casebook_id
+
+                """,
+                [source, start_date, end_date, state],
+            )
+
+        # Run the specific queries needed for the reports
+
+        # Casebooks including content from Capstone
+        cursor.execute(
+            """
+            select count(*) from main_casebook where main_casebook.id
+                in (select * from casebooks_including_source_cap)
+            """
+        )
+        stats["casebooks_cap"] = cursor.fetchone()[0]
+
+        # Casebooks including content from Cap created by verified professors
+        cursor.execute(
+            """
+            select count(*) from main_casebook where main_casebook.id
+                in (select * from casebooks_including_source_cap)
+                and main_casebook.id in
+                   (select * from casebooks_from_professors)
+            """
+        )
+        stats["casebooks_cap_prof"] = cursor.fetchone()[0]
+
+        # Casebooks including content from GPO
+        cursor.execute(
+            """
+            select count(*) from main_casebook where main_casebook.id
+                in (select * from casebooks_including_source_gpo)
+            """
+        )
+
+        stats["casebooks_gpo"] = cursor.fetchone()[0]
+
+        # Casebooks including content from GPO created by verified professors
+        cursor.execute(
+            """
+            select count(*) from main_casebook where main_casebook.id
+                in (select * from casebooks_including_source_gpo)
+                and main_casebook.id in
+                   (select * from casebooks_from_professors)
+            """
+        )
+        stats["casebooks_gpo_prof"] = cursor.fetchone()[0]
+
+        # Casebooks with multiple collaborators
+        cursor.execute(
+            """
+        select count(*) from casebooks_with_multiple_collaborators
+        """
+        )
+        stats["casebooks_with_collaborators"] = cursor.fetchone()[0]
+
+        # Casebooks with multiple collaborators including professors
+        cursor.execute(
+            """
+        select count(*) from main_casebook where main_casebook.id
+            in (select * from casebooks_with_multiple_collaborators)
+            and main_casebook.id
+            in (select * from casebooks_from_professors)
+        """
+        )
+        stats["casebooks_with_collaborators_prof"] = cursor.fetchone()[0]
+
+        # Series
+        cursor.execute(
+            """
+        select count(*) from main_commontitle ct
+        inner join main_casebook c on c.id = ct.current_id
+        where c.created_at >= %s
+              and c.created_at <= %s
+              and c.state in %s
+        """, [start_date, end_date, state]
+        )
+        stats["series"] = cursor.fetchone()[0]
+
+        # Series by professors
+        # This only checks the most-current title's authorship, but probably sufficient?
+        cursor.execute(
+            """
+        select count(*) from main_commontitle where main_commontitle.current_id
+            in (select * from casebooks_from_professors)
+        """
+        )
+        stats["series_by_prof"] = cursor.fetchone()[0]
+
+    return render(
+        request,
+        "admin/usage/index.html",
+        {
+            "stats": stats,
+            "date_form": form,
+            "date_presets": {
+                "last_month": {
+                    "start_date": today + relativedelta(months=-1, day=1),
+                    "end_date": today + relativedelta(months=-1, day=31),
+                    "label": "Last full month",
+                },
+                "last_30_days": {
+                    "start_date": today + relativedelta(days=-30),
+                    "end_date": today,
+                    "label": "Last 30 days",
+                },
+                "year_to_date": {
+                    "start_date": today + relativedelta(day=1, month=1),
+                    "end_date": today,
+                    "label": "Year-to-date",
+                },
+                "all_dates": {
+                    "start_date": oldest,
+                    "end_date": today,
+                    "label": "All time",
+                },
+            },
+        },
+    )


### PR DESCRIPTION
Start of a usage dashboard to live in the Django admin and provide current usage stats about the product.

Most of the queries are artisanal SQL; at the start of the request session it creates a few temp tables for expensive queries and those get cleaned up by postgres at the end of the session. 

I've omitted two types of metrics requested: counts of books with multimedia (which is expensive to compute because hotlinking means we must introspect the HTML with regexp) and top-N lists by user views, which must be computed from web logs rather than Django db values.

This runs very quickly on my local machine, but will see once merged how this does on staging.

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/19571/173127266-ac6ff9a9-b625-4033-99ff-067dcebff7f8.png">


