### PR TITLE
Allow setting an API key from the environment in local dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,3 +26,6 @@ services:
           - linux/arm64
       x-hash-paths:
         - web/requirements.txt
+    environment:
+      - CAPAPI_API_KEY
+      - GPO_API_KEY

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -1,9 +1,15 @@
+import os
 from .settings_base import *  # noqa
+
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', '.local', 'backend', 'django']
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'
+
+# Set these values in your local shell environment to make them available in the container
+CAPAPI_API_KEY = os.environ.get("CAPAPI_API_KEY", "")
+GPO_API_KEY = os.environ.get("GPO_API_KEY", "")
 
 DEBUG = True
 


### PR DESCRIPTION
As shipped, local dev won't have external API keys available, but if the developer adds them to their shell this will propagate it through to the container and have it picked up by Django.

```
root@37c7bcfb6a66:/app/web# env | grep API
CAPAPI_API_KEY=XXXXXX
```

and verified on the front-end that I could add a Cap case now:

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/19571/173421276-11075054-73ef-49f5-8a3b-06c397678846.png">
