### PR TITLE
[#1562] Correct some usage dashboard counts to better align with front-end

### DIFF
--- a/web/fabfile.py
+++ b/web/fabfile.py
@@ -60,7 +60,7 @@ def create_search_index():
 @task
 @setup_django
 def refresh_search_index():
-    """ Update an existing search_view materialized view; will fail if create_search_index hasn't been run once """
+    """ Update an existing search_view materialized view; will create if create_search_index hasn't been run once """
     from main.models import SearchIndex
     SearchIndex.refresh_search_index()
 

--- a/web/main/templates/admin/usage/index.html
+++ b/web/main/templates/admin/usage/index.html
@@ -35,6 +35,7 @@
         #toolbar th, #toolbar td { vertical-align: middle; }
         #toolbar { background-color: #eee; margin-bottom: 1em;}
         #dashboard th small { font-weight: normal; text-style: italic; display: block; }
+        aside { background-color: #eee; padding: 1em; margin-top: 2em;}
     </style>
 {% endblock extrastyle %}
 
@@ -46,6 +47,7 @@
 {% block content %}
 
 <h1>Usage dashboard</h1>
+
 
 <div id="content-main">
 
@@ -109,7 +111,11 @@
     </tr>
     <tr>
         <th>Casebooks</th>
-        <td>{{ stats.casebooks | intcomma}} </td>
+        <td>{{ stats.casebooks | intcomma }}</td>
+    </tr>
+    <tr>
+        <th>Casebooks from verified professors</th>
+        <td>{{ stats.casebooks_prof | intcomma }}</td>
     </tr>
     <tr>
         <th>Casebooks including content from Capstone</th>
@@ -128,8 +134,12 @@
         <td> {{ stats.casebooks_gpo_prof | intcomma }}</td>
     </tr>
     <tr>
-        <th>Casebooks with multiple collaborators</th>
+        <th>
+            Casebooks with multiple collaborators
+            <small>Where at least one collaborator has attribution</small>
+        </th>
         <td> {{ stats.casebooks_with_collaborators | intcomma }}</td>
+
     </tr>
     <tr>
         <th>Casebooks with multiple collaborators, at least one professor</th>
@@ -146,6 +156,11 @@
         <td>{{ stats.series_by_prof | intcomma }}</td>
     </tr>
     </table>
+
+    <aside>
+        Note: "Published" casebooks will include casebooks in either the <em>published</em> or
+        <em>revising</em> state, matching the front end search.
+    </aside>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Re-use the logic found in the search "index" SQL to allow counts to match the front end. Replace one usage of the Django ORM for professors with a reporting table to better align the logic with the other tables.

Key updated numbers:

<img width="582" alt="image" src="https://user-images.githubusercontent.com/19571/174856348-37e69fa2-ad58-47a0-9126-7c95718675bf.png">

Now match values on the front end for Casebooks and Authors:

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/19571/174856397-728c6ba5-8b7e-4235-8b65-de32e0bdf695.png">


