### PR TITLE
(Issue #1566) UI Fix -Create a Casebook Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -56,6 +56,7 @@
                 Body
                 <editor
                   v-model="textContent"
+                  
                 ></editor>
                 <span class="help-block has-error" v-if="errors.content">
                   <strong>{{errors.content[0].message}}</strong>

--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -5,20 +5,23 @@
       v-on:click.stop.prevent="displayModal()"
     >Add Content</button>
     <Modal v-if="showModal" @close="showModal = false" :initial-focus="focusTarget">
-      <template slot="title">Add Resource</template>
+      <template slot="title" title="Add Content">Add Resource</template>
       <template slot="body">
         <div class="search-tabs">
           <a
             v-bind:class="{ active: caseTab, 'search-tab': true }"
             v-on:click.stop.prevent="setTab('case')"
+            title="Find a Caselaw"
           >Find a Legal Document</a>
           <a
             v-bind:class="{ active: textTab, 'search-tab': true }"
             v-on:click.stop.prevent="setTab('text')"
+            title="Create a Custom Content"
           >Create Custom Content</a>
           <a
             v-bind:class="{ active: linkTab, 'search-tab': true }"
             v-on:click.stop.prevent="setTab('link')"
+            title="Add a Link"
           >Add Link</a>
         </div>
 

--- a/web/frontend/components/CaseResults.vue
+++ b/web/frontend/components/CaseResults.vue
@@ -12,13 +12,18 @@
     </div>
   </div>
   <div class="search-results-wrapper" v-else-if="searchResults.unRun">
+  <!-- can we add search as we type here?  -->
     <div class="search-alert">
+      <!-- change message: type in ~ to search for law sections or caselaws to add to your book. Then press search to see results.  -->
       <span>Click Search to run your search</span>
     </div>
   </div>
   <div class="search-results-wrapper" v-else>
     <div class="search-results-entry" v-for="c in searchResults.results" :key="c.id">
       <div class="name-column">
+        <!-- add headers for all these columns -->
+         <!-- clarification on how to add cases to your book. double click? click the link?  -->
+         <!-- add feedback to user when case has been added succesfully to your book -->
         <a v-on:click.stop.prevent="emitChoice(c)" class="wrapper">
           <span :title="c.fullName">{{c.shortName}}</span>
         </a>
@@ -31,6 +36,7 @@
       <div class="date-column">
         <a v-on:click.stop.prevent="emitChoice(c)" class="wrapper">{{c.effectiveDate}}</a>
       </div>
+      <!--link to open book in ~ add title to table columns -->
       <div class="preview-column">
         <a :href="c.url" target="_blank" rel="noopener noreferrer">{{ c.sourceName }}</a>
       </div>

--- a/web/frontend/components/CaseSearcher.vue
+++ b/web/frontend/components/CaseSearcher.vue
@@ -22,6 +22,7 @@
         v-on:click.stop.prevent="runCaseSearch"
         />
     </div>
+    <!-- Why is the Advanced search options hidden? Just make the search boxes smaller? -->
     <div v-if="!showingLimits">
       <a v-on:click.stop.prevent="showLimits">Advanced search options</a>
     </div>
@@ -30,6 +31,7 @@
         <a v-on:click.stop.prevent="hideLimits">Basic search</a>
       </div>
       <div class="source-row">
+        <!-- Source meaning clarification. What is CAP, What is GPO, What is Search all Sources? -->
       <label>
         Source:
           <select class="form-control" v-model="searchLimit">
@@ -42,6 +44,7 @@
       </div>
       </div>
       <div class="jurisdiction-row">
+        <!-- Jursidiction (State) -->
         <label>
           Jurisdiction:
           <select class="form-control" v-model="jurisdiction" name="jurisdiction">

--- a/web/frontend/components/PublishButton.vue
+++ b/web/frontend/components/PublishButton.vue
@@ -1,16 +1,19 @@
 <template>
   <div id="publish-button">
+    <!-- The button comment (some resources are incomplete ~~ ) did not show up. The button was only disabled -->
     <button type="button" 
             class="action publish one-line" 
             :disabled="disabled"
             :title="disabled ? 'Some resources are incomplete. Finalize Entries below.' : 'Publish'"
-            @click="attemptPublish">
+            @click="attemptPublish"
+            >
             Publish
     </button>
     <Modal v-if="showModal" @close="showModal = false">
       <template slot="title">Confirm Publish</template>
       <template slot="body">
         <p>Are you ready to publish your book?</p>
+        <!-- What does it mean to publish a book? Is it viewable to everyone? Add more descriptions -->
         <div class="modal-footer">
           <button class="modal-button cancel" @click="cancelPublish">No</button>
           <button class="modal-button confirm" @click="confirmPublish">Yes</button>

--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -1,4 +1,6 @@
 <template>
+<!-- This part needs a title. It is confusing what is does since this is a second point of creation -->
+<!-- Maybe having a plus sign would help. -->
   <div id="quick-add">
     <div class="form-control-group">
       <form @submit.stop.prevent="handleSubmit">
@@ -46,6 +48,8 @@ import { createNamespacedHelpers } from "vuex";
 const globals = createNamespacedHelpers("globals");
 const search = createNamespacedHelpers("case_search");
 
+// clarification on what section,search, customcontent,link is. 
+// maybe change styling of drop down? 
 const optionsWithoutCloning = [{name: 'Section',        value: {resource_type: 'Section'}, k: 0},
                                {name: 'Search',         value: {resource_type: 'LegalDocument'}, k: 1},
                                {name: 'Custom Content', value: {resource_type: 'TextBlock'}, k: 2},

--- a/web/frontend/components/TinyMCEEditor.vue
+++ b/web/frontend/components/TinyMCEEditor.vue
@@ -1,4 +1,5 @@
 <template>
+<!-- is it possible to customize this text editor? -->
 <textarea ref="textarea" :id="taID" v-model="value">
   </textarea>
 </template>


### PR DESCRIPTION
### Add Content Button UI Fix Suggestions

1. (title) Add Resource --> Add Content 
> consistency with button name 

2. Tab Names 

> Find a Legal Document --> Find a Caselaw
add descriptions to what is in the search database
Catherine: it contains us code sections & caselaws


> Create Custom Content
add descriptions on what this could be. 
Can it be a section for discussion questions? Series of related photos? Related Essays? 
Catherine: intros to a case, questions following, videos 


> Add Links
add descriptions on the difference btw adding a link(image) here and adding a link to the create a custom content page. 