### PR TITLE
Implements by-casebook full-text search for legal documents

### DIFF
--- a/web/main/create_search_index.sql
+++ b/web/main/create_search_index.sql
@@ -33,7 +33,6 @@ UNION ALL
                'effective_date', effective_date,
                'effective_date_formatted', TO_CHAR(effective_date, 'Month FMDD, YYYY'),
                'citations', array_to_string(c.citations, ', '),
-               'content', coalesce(content),
                'jurisdiction', jurisdiction
            ) AS metadata,
            'legal_doc_fulltext'::text AS category

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -803,7 +803,7 @@ class SearchIndex(models.Model):
         ...         {'affiliation': 'Affiliation 1', 'created_at': '...', 'title': 'Some Title 1', 'attribution': 'Some User 1'},
         ...         {'affiliation': 'Affiliation 2', 'created_at': '...', 'title': 'Some Title 2', 'attribution': 'Some User 2'}
         ...     ],
-        ...     {'user': 3, 'legal_doc': 3, 'casebook': 3},
+        ...     {'user': 3, 'legal_doc': 3, 'casebook': 3, 'legal_doc_fulltext': 3},
         ...     {}
         ... )
 
@@ -824,7 +824,7 @@ class SearchIndex(models.Model):
         ...         {'casebook_count': 1, 'attribution': 'Some User 1', 'affiliation': 'Affiliation 1'},
         ...         {'casebook_count': 1, 'attribution': 'Some User 2', 'affiliation': 'Affiliation 2'},
         ...     ],
-        ...     {'casebook': 3, 'legal_doc': 3, 'user': 3},
+        ...     {'user': 3, 'legal_doc': 3, 'casebook': 3, 'legal_doc_fulltext': 3},
         ...     {},
         ... )
 
@@ -835,7 +835,7 @@ class SearchIndex(models.Model):
         ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 1', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'},
         ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'}
         ...     ],
-        ...     {'legal_doc': 3, 'user': 3, 'casebook': 3},
+        ...     {'user': 3, 'legal_doc': 3, 'casebook': 3, 'legal_doc_fulltext': 3},
         ...     {}
         ... )
         """
@@ -889,12 +889,12 @@ class SearchIndex(models.Model):
         all text within the casebook. Currently, this only searches through legal
         documents. However, this will be expanded to include all casebook text.
         """
-        if isinstance(casebook, Casebook):
-            casebook = casebook.id
-        if not isinstance(casebook, int):
+        if isinstance(casebook, int):
+            casebook = Casebook.objects.get(id=casebook)
+        if not isinstance(casebook, Casebook):
             raise ValueError("param casebook is not an integer id or a Casebook object!")
          
-        legal_doc_ids = [node.resource.id for node in Casebook.objects.get(id=523).contents.filter(resource_type="LegalDocument").prefetch_resources()]
+        legal_doc_ids = [node.resource.id for node in casebook.contents.filter(resource_type="LegalDocument").prefetch_resources()]
         base_query = SearchIndex.objects.filter(result_id__in=legal_doc_ids)
         return SearchIndex.search("legal_doc_fulltext", *args, base_query=base_query, **kwargs)
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -904,9 +904,9 @@ class SearchIndex(models.Model):
         Search in casebook by query:
         >>> assert dump_search_results(SearchIndex().casebook_fts(casebooks[0].id, query='Dubious')) == (
         ...     [
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 0', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'content': 'Dubious legal claim 0'},
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 1', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'content': 'Dubious legal claim 1'},
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'content': 'Dubious legal claim 2'}
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 0', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'},
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 1', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'},
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'}
         ...     ],
         ...     {'legal_doc_fulltext': 3},
         ...     {}
@@ -914,7 +914,7 @@ class SearchIndex(models.Model):
 
         >>> assert dump_search_results(SearchIndex().casebook_fts(casebooks[0].id, '2')) == (
         ...     [
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'content': 'Dubious legal claim 2'}
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'}
         ...     ],
         ...     {'legal_doc_fulltext': 1, 'user': 1, 'casebook': 1, 'legal_doc': 1},
         ...     {}

--- a/web/main/templates/search/casebook.html
+++ b/web/main/templates/search/casebook.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% load current_query_string %}
+
+{% block mainContent %}
+  <header class="advanced-search view-searches-show">
+    <form novalidate="novalidate" class="simple_form search" accept-charset="UTF-8">
+      {# Hidden field to preserve active tab's category during form submission #}
+      {# Note that 'category' is singular, but 'type' is plural #}
+      <div class="form-group hidden search_type">
+        <input class="form-control hidden" name="type" value="{{ category }}s" type="hidden" id="search_type">
+      </div>
+      <div class="narrow-inner">
+        <div class="input-group">
+          <input type="search" name="q" id="q" class="form-control" placeholder="Search through legal documents in {{ casebook.title }}" aria-label="Find casebooks, legal docs, and authors." value="{{ request.GET.q }}">
+          <span class="input-group-btn">
+            <button class="form-control btn" type="submit" aria-label="Search" style="border: 1px solid black; background-color: #f5f4ec;"><i aria-hidden="true" class="fa fa-search"></i></button>
+          </span>
+        </div>
+      </div>
+      {% include 'search/filters.html' %}
+    </form>
+  </header>
+  <section class="search-results">
+    <div class="content">
+      {% if counts %}
+        <div class="results-container">
+          <div class="type-tabs">
+            <div class="type-tab {% if category == 'legal_doc' %}active{% endif %}" {% if category == 'legal_doc' %}aria-current="location"{% endif %}>
+              <a href="?{% current_query_string type="legal_doc" page=1 %}" class="wrapper">
+                Legal Documents ({{ counts.legal_doc_fulltext|default:"0" }})
+              </a>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+      {% if results %}
+        {% include 'search/results.html' %}
+      {% else %}
+        <div class="no-results">
+          <h3>No results found</h3>
+        </div>
+      {% endif %}
+    </div>
+  </section>
+{% endblock %}

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -20,7 +20,7 @@
             </div>
           </div>
         </a>
-      {% elif category == 'legal_doc' %}
+      {% elif category == 'legal_doc' or category == 'legal_doc_fulltext'%}
           <a href="{% url 'display_legal_doc' result.result_id %}" class="wrapper" data-result-id="{{ result.result_id }}">
             <div class="results-entry">
               <div class="title">

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -99,6 +99,7 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path('casebooks/<idslug:casebook_param>/history/', views.casebook_history, name='casebook_history'),
     path('casebooks/<idslug:casebook_param>/outline/', views.casebook_outline, name='casebook_outline'),
     path('casebooks/<idslug:casebook_param>/follow/', views.follow_casebook, name='follow_casebook'),
+    path('casebooks/<idslug:casebook_param>/search/', views.search_casebook, name='search_casebook'),
     
     # TODO: we temporarily need to list with and without trailing slash, to handle POSTs without slashes
     path('casebooks/<idslug:casebook_param>/', views.CasebookView.as_view(), name='casebook'),

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2416,9 +2416,7 @@ def search_using(request, source):
     return JsonResponse({"results": results}, status=200)
 
 
-
-type_param_to_category = {'legal_doc': 'legal_doc', 'casebooks': 'casebook', 'users': 'user'}
-
+type_param_to_category = {'legal_doc': 'legal_doc', 'casebooks': 'casebook', 'users': 'user', 'legal_doc_fulltext': 'legal_doc_fulltext'}
 @no_perms_test
 def internal_search(request):
     """
@@ -2468,6 +2466,36 @@ def internal_search(request):
             'category': category,
         })
 
+
+@no_perms_test
+@hydrate_params
+def search_casebook(request, casebook):
+    """
+        Search inside casebook --- currently only for legal docs.
+
+        Returns not a 
+    """
+    # read query parameters
+    try:
+        page = int(request.GET.get('page'))
+    except (TypeError, ValueError):
+        page = 1
+    query = request.GET.get('q')
+
+    results, counts, facets = SearchIndex.casebook_fts(
+        casebook,
+        page=page,
+        query=query,
+        order_by=request.GET.get('sort')
+    )
+    results.from_capapi = False
+    return render(request, 'search/casebook.html', {
+            'results': results,
+            'counts': counts,
+            'facets': facets,
+            'casebook': casebook,
+            'category': 'legal_doc_fulltext',
+        })
 
 image_storage = get_s3_storage(bucket_name="h2o.images")
 


### PR DESCRIPTION
This PR is the first-step in enabling full-text search through casebooks. It implements the `/casebooks/<id>/search view`, which displays a list of legal documents associated with casebook `<id>` and displays a search bar that searches the full text of all the listed documents. To implement this view, it full-text indexes all of the cases used by H2O. This functionality has more potential uses that are not fully explored in this PR.

In order to complete full-text search through resources, we need to:
- [ ] index text resources
- [ ] index link resources
- [ ] (optionally) index annotations
- [ ] integrate search functionality into casebook view UI.

This PR is standalone and complete --- it can be merged now, or it can be merged together with other changes that complete the larger project at hand.

Closes #1568; should add a more detailed issue to address the problems directly above.