### PR TITLE
Make casebook text resources searchable

### DIFF
--- a/web/main/templates/search/casebook.html
+++ b/web/main/templates/search/casebook.html
@@ -11,7 +11,7 @@
       </div>
       <div class="narrow-inner">
         <div class="input-group">
-          <input type="search" name="q" id="q" class="form-control" placeholder="Search through legal documents in {{ casebook.title }}" aria-label="Find casebooks, legal docs, and authors." value="{{ request.GET.q }}">
+          <input type="search" name="q" id="q" class="form-control" placeholder="Search through documents and text from {{ casebook.title }}" aria-label="Find casebooks, legal docs, and authors." value="{{ request.GET.q }}">
           <span class="input-group-btn">
             <button class="form-control btn" type="submit" aria-label="Search" style="border: 1px solid black; background-color: #f5f4ec;"><i aria-hidden="true" class="fa fa-search"></i></button>
           </span>
@@ -25,9 +25,14 @@
       {% if counts %}
         <div class="results-container">
           <div class="type-tabs">
-            <div class="type-tab {% if category == 'legal_doc' %}active{% endif %}" {% if category == 'legal_doc' %}aria-current="location"{% endif %}>
-              <a href="?{% current_query_string type="legal_doc" page=1 %}" class="wrapper">
+            <div class="type-tab {% if category == 'legal_doc_fulltext' %}active{% endif %}" {% if category == 'legal_doc_fulltext' %}aria-current="location"{% endif %}>
+              <a href="?{% current_query_string type="legal_doc_fulltext" page=1 %}" class="wrapper">
                 Legal Documents ({{ counts.legal_doc_fulltext|default:"0" }})
+              </a>
+            </div>
+            <div class="type-tab {% if category == 'textblock' %}active{% endif %}" {% if category == 'textblock' %}aria-current="location"{% endif %}>
+              <a href="?{% current_query_string type="textblock" page=1 %}" class="wrapper">
+                Text Passages ({{ counts.textblock|default:"0" }})
               </a>
             </div>
           </div>

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -20,6 +20,19 @@
             </div>
           </div>
         </a>
+      {% elif category == 'textblock' %}
+        <a href="{% url 'resource' casebook.id result.metadata.ordinals %}" class="wrapper" data-result-id="{{ result.result_id }}">
+          <div class="results-entry">
+            <div class="title">
+              {{ result.metadata.name }}
+            </div>
+            <div class="owner">
+            </div>
+            <div class="date">
+                {{ result.metadata.ordinals }}
+            </div>
+          </div>
+        </a>
       {% elif category == 'legal_doc' or category == 'legal_doc_fulltext'%}
           <a href="{% url 'display_legal_doc' result.result_id %}" class="wrapper" data-result-id="{{ result.result_id }}">
             <div class="results-entry">

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -40,10 +40,10 @@
                 {{ result.metadata.display_name }}
               </div>
               <div class="citation">
-                {{ result.metadata.citations }}
+                {{ result.metadata.citations | truncatewords:3 }}
               </div>
               <div class="date">
-                {{ result.metadata.decision_date_formatted|default:'' }}
+                {{ result.metadata.effective_date_formatted|default:'' }}
               </div>
             </div>
           </a>

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2416,7 +2416,7 @@ def search_using(request, source):
     return JsonResponse({"results": results}, status=200)
 
 
-type_param_to_category = {'legal_doc': 'legal_doc', 'casebooks': 'casebook', 'users': 'user', 'legal_doc_fulltext': 'legal_doc_fulltext'}
+type_param_to_category = {'legal_doc': 'legal_doc', 'casebooks': 'casebook', 'users': 'user', 'legal_doc_fulltext': 'legal_doc_fulltext', 'textblock':'textblock'}
 @no_perms_test
 def internal_search(request):
     """
@@ -2496,9 +2496,11 @@ def search_casebook(request, casebook):
     except (TypeError, ValueError):
         page = 1
     query = request.GET.get('q')
+    category = type_param_to_category.get(request.GET.get('type', None), 'legal_doc_fulltext')
 
     results, counts, facets = SearchIndex.casebook_fts(
         casebook.id,
+        category,
         page=page,
         query=query,
         order_by=request.GET.get('sort')
@@ -2509,7 +2511,7 @@ def search_casebook(request, casebook):
             'counts': counts,
             'facets': facets,
             'casebook': casebook,
-            'category': 'legal_doc_fulltext',
+            'category': category,
         })
 
 image_storage = get_s3_storage(bucket_name="h2o.images")


### PR DESCRIPTION
Casebook text resources are now searchable. This closes #1594.

I can feel the text search getting noticeably groggy. If you check out this branch, let me know if you experience it too. If so, this is probably something we need to discuss.

The search index went from ~12,000 records to ~162,000, so a little grogginess would certainly be unsurprising.