### PR TITLE
Add headline previews for search results

### DIFF
--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -144,6 +144,7 @@ header.advanced-search {
       width: 100%;
       padding: 2px;
       margin-left: 15px;
+      font-family: $font-family-serif;
     }
   }
 }

--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -101,6 +101,7 @@ header.advanced-search {
     padding: 10px 0;
     border-top: 1px solid $dark-gray;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
 
     .title {
@@ -139,8 +140,10 @@ header.advanced-search {
     }
 
     .description {
-      // put it on the next line somehow
-      @include make-row();
+      flex-basis: 100%;
+      width: 100%;
+      padding: 2px;
+      margin-left: 15px;
     }
   }
 }

--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -137,6 +137,11 @@ header.advanced-search {
     .citation {
       text-align: right;
     }
+
+    .description {
+      // put it on the next line somehow
+      @include make-row();
+    }
   }
 }
 

--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -146,6 +146,10 @@ header.advanced-search {
       margin-left: 15px;
       font-family: $font-family-serif;
     }
+
+    .and-more {
+      font-family: $font-family-sans-serif;
+    }
   }
 }
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1038,7 +1038,7 @@ class FullTextSearchIndex(models.Model):
         ids = sorted([r.result_id for r in results[0]])
         query_class = ({"legal_doc_fulltext": LegalDocument, "textblock": TextBlock, "link":Link})[category]
         content_name = "description" if category == "link" else "content"
-        headlines = query_class.objects.filter(id__in=ids).order_by('id').annotate(headlines=SearchHeadline(content_name, query, max_fragments=10, min_words=10, max_words=20)).values_list("headlines")
+        headlines = query_class.objects.filter(id__in=ids).order_by('id').annotate(headlines=SearchHeadline(content_name, query, max_fragments=20, min_words=10, max_words=20)).values_list("headlines")
         headlines = {i: h for i, h in zip(ids, headlines)}
         for r in results[0]:
             try:

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1018,7 +1018,7 @@ class FullTextSearchIndex(models.Model):
         ... )
         >>> assert dump_search_results(FullTextSearchIndex().casebook_fts(casebooks[0].id, 'textblock', '2')) == (
         ...     [
-        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': '', 'headlines': ['Some TextBlock Content <b>2</b>']}
+        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': '', 'headlines': ['Some TextBlock Content <b>2</b>'], 'casebook_id': casebooks[0].id}
         ...     ],
         ...     {'legal_doc_fulltext': 1, 'textblock': 1},
         ...     {}

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1038,10 +1038,13 @@ class FullTextSearchIndex(models.Model):
         ids = sorted([r.result_id for r in results[0]])
         query_class = ({"legal_doc_fulltext": LegalDocument, "textblock": TextBlock, "link":Link})[category]
         content_name = "description" if category == "link" else "content"
-        headlines = query_class.objects.filter(id__in=ids).order_by('id').annotate(headline=SearchHeadline(content_name, query, max_fragments=1)).values_list("headline")
+        headlines = query_class.objects.filter(id__in=ids).order_by('id').annotate(headlines=SearchHeadline(content_name, query, max_fragments=10, min_words=10, max_words=20)).values_list("headlines")
         headlines = {i: h for i, h in zip(ids, headlines)}
         for r in results[0]:
-            r.metadata["headline"] = headlines[r.result_id][0]
+            try:
+                r.metadata["headlines"] = headlines[r.result_id][0].split("...")
+            except AttributeError:
+                continue
         return results
 
 class USCodeIndex(models.Model):

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1001,9 +1001,9 @@ class FullTextSearchIndex(models.Model):
         Search in casebook by query:
         >>> assert dump_search_results(FullTextSearchIndex().casebook_fts(casebooks[0].id, "legal_doc_fulltext", query='Dubious')) == (
         ...     [
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 0', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'},
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 1', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'},
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'}
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 0', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'headlines': ['<b>Dubious</b> legal claim']},
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 1', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'headlines': ['<b>Dubious</b> legal claim']},
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'headlines': ['<b>Dubious</b> legal claim']}
         ...     ],
         ...     {'legal_doc_fulltext': 3},
         ...     {}
@@ -1011,14 +1011,14 @@ class FullTextSearchIndex(models.Model):
 
         >>> assert dump_search_results(FullTextSearchIndex().casebook_fts(casebooks[0].id, 'legal_doc_fulltext', '2')) == (
         ...     [
-        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900'}
+        ...         {'citations': 'Adventures in criminality, 1 Fake 1, (2001)', 'display_name': 'Legal Doc 2', 'jurisdiction': None, 'effective_date': '1900-01-01T00:00:00+00:00', 'effective_date_formatted': 'January   1, 1900', 'headlines': ['Dubious legal claim <b>2</b>']}
         ...     ],
         ...     {'legal_doc_fulltext': 1, 'textblock': 1},
         ...     {}
         ... )
         >>> assert dump_search_results(FullTextSearchIndex().casebook_fts(casebooks[0].id, 'textblock', '2')) == (
         ...     [
-        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': '', 'casebook_id': casebooks[0].id}
+        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': '', 'headlines': ['Some TextBlock Content <b>2</b>']}
         ...     ],
         ...     {'legal_doc_fulltext': 1, 'textblock': 1},
         ...     {}

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1037,7 +1037,7 @@ class FullTextSearchIndex(models.Model):
         results = FullTextSearchIndex.search(category, *args, base_query=base_query, query=query, **kwargs)
         ids = sorted([r.result_id for r in results[0]])
         query_class = ({"legal_doc_fulltext": LegalDocument, "textblock": TextBlock, "link":Link})[category]
-        content_name = "url" if category == "link" else "content"
+        content_name = "description" if category == "link" else "content"
         headlines = query_class.objects.filter(id__in=ids).order_by('id').annotate(headline=SearchHeadline(content_name, query, max_fragments=1)).values_list("headline")
         headlines = {i: h for i, h in zip(ids, headlines)}
         for r in results[0]:

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -31,6 +31,9 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
+            <div class="description">
+                {{ result.metadata.headline }}
+            </div>
           </div>
         </a>
       {% elif category == 'link' %}

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -32,7 +32,9 @@
                 {{ result.metadata.ordinals }}
             </div>
             <div class="description">
-                {{ result.metadata.headline }}
+               {% autoescape off %}
+                 {{ result.metadata.headline }}
+               {% endautoescape %}
             </div>
           </div>
         </a>
@@ -48,6 +50,11 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
+            <div class="description">
+               {% autoescape off %}
+                 {{ result.metadata.headline }}
+               {% endautoescape %}
+            </div>
           </div>
         </a>
       {% elif category == 'legal_doc' or category == 'legal_doc_fulltext'%}
@@ -61,6 +68,11 @@
               </div>
               <div class="date">
                 {{ result.metadata.effective_date_formatted|default:'' }}
+              </div>
+              <div class="description">
+                 {% autoescape off %}
+                   {{ result.metadata.headline }}
+                 {% endautoescape %}
               </div>
             </div>
           </a>

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -31,11 +31,13 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
-            <div class="description">
-               {% autoescape off %}
-                 {{ result.metadata.headline }}
-               {% endautoescape %}
-            </div>
+            {% if result.metadata.headline %}
+              <div class="description">
+                 {% autoescape off %}
+                   {{ result.metadata.headline }}
+                 {% endautoescape %}
+              </div>
+            {% endif %}
           </div>
         </a>
       {% elif category == 'link' %}
@@ -50,11 +52,13 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
-            <div class="description">
-               {% autoescape off %}
-                 {{ result.metadata.headline }}
-               {% endautoescape %}
-            </div>
+            {% if result.metadata.headline %}
+              <div class="description">
+                 {% autoescape off %}
+                   {{ result.metadata.headline }}
+                 {% endautoescape %}
+              </div>
+            {% endif %}
           </div>
         </a>
       {% elif category == 'legal_doc' or category == 'legal_doc_fulltext'%}
@@ -69,11 +73,13 @@
               <div class="date">
                 {{ result.metadata.effective_date_formatted|default:'' }}
               </div>
-              <div class="description">
-                 {% autoescape off %}
-                   {{ result.metadata.headline }}
-                 {% endautoescape %}
-              </div>
+              {% if result.metadata.headline %}
+                <div class="description">
+                   {% autoescape off %}
+                     {{ result.metadata.headline }}
+                   {% endautoescape %}
+                </div>
+              {% endif %}
             </div>
           </a>
       {% elif category == 'user' %}

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -31,10 +31,10 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
-            {% if result.metadata.headline %}
+            {% if result.metadata.headlines %}
               <div class="description">
                  {% autoescape off %}
-                   {{ result.metadata.headline }}
+                   {{ result.metadata.headlines }}
                  {% endautoescape %}
               </div>
             {% endif %}
@@ -52,10 +52,10 @@
             <div class="date">
                 {{ result.metadata.ordinals }}
             </div>
-            {% if result.metadata.headline %}
+            {% if result.metadata.headlines %}
               <div class="description">
                  {% autoescape off %}
-                   {{ result.metadata.headline }}
+                   {{ result.metadata.headlines }}
                  {% endautoescape %}
               </div>
             {% endif %}
@@ -73,11 +73,16 @@
               <div class="date">
                 {{ result.metadata.effective_date_formatted|default:'' }}
               </div>
-              {% if result.metadata.headline %}
+              {% if result.metadata.headlines %}
                 <div class="description">
                    {% autoescape off %}
-                     {{ result.metadata.headline }}
+                     {{ result.metadata.headlines.0 }}
                    {% endautoescape %}
+                   {% if result.metadata.headlines|length > 1 %}
+                    <span class="and-more">
+                      ...and {{ result.metadata.headlines|length }} more.
+                    </span>
+                   {% endif %}
                 </div>
               {% endif %}
             </div>

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -34,8 +34,15 @@
             {% if result.metadata.headlines %}
               <div class="description">
                  {% autoescape off %}
-                   {{ result.metadata.headlines }}
+                   ...
+                   {{ result.metadata.headlines.0 }}
+                   ...
                  {% endautoescape %}
+                 {% if result.metadata.headlines|length > 1 %}
+                  <span class="and-more">
+                    and {% if result.metadata.headlines|length < 10 %} {{ result.metadata.headlines|length }} {% else %} many {% endif %} more.
+                  </span>
+                 {% endif %}
               </div>
             {% endif %}
           </div>
@@ -55,8 +62,15 @@
             {% if result.metadata.headlines %}
               <div class="description">
                  {% autoescape off %}
-                   {{ result.metadata.headlines }}
+                   ...
+                   {{ result.metadata.headlines.0 }}
+                  ...
                  {% endautoescape %}
+                 {% if result.metadata.headlines|length > 1 %}
+                  <span class="and-more">
+                    and {% if result.metadata.headlines|length < 10 %} {{ result.metadata.headlines|length }} {% else %} many {% endif %} more.
+                  </span>
+                 {% endif %}
               </div>
             {% endif %}
           </div>
@@ -76,11 +90,13 @@
               {% if result.metadata.headlines %}
                 <div class="description">
                    {% autoescape off %}
+                     ...
                      {{ result.metadata.headlines.0 }}
+                     ...
                    {% endautoescape %}
                    {% if result.metadata.headlines|length > 1 %}
                     <span class="and-more">
-                      ...and {{ result.metadata.headlines|length }} more.
+                      and {% if result.metadata.headlines|length < 10 %} {{ result.metadata.headlines|length }} {% else %} many {% endif %} more.
                     </span>
                    {% endif %}
                 </div>


### PR DESCRIPTION
Currently, only one headline is shown, but all are put in the annotations in case we want to change that view later.

This closes #1600.