### PR TITLE
Stores `casebook_id` in search metadata instead of join-ing

### DIFF
--- a/web/main/create_fts_index.sql
+++ b/web/main/create_fts_index.sql
@@ -32,7 +32,8 @@ UNION ALL
            jsonb_build_object(
                'name', t.name,
                'description', t.description,
-               'ordinals', array_to_string(cn.ordinals, '.')
+               'ordinals', array_to_string(cn.ordinals, '.'),
+               'casebook_id', cn.casebook_id
            ) AS metadata,
            'textblock'::text AS category
     FROM
@@ -53,7 +54,8 @@ UNION ALL
                'name', coalesce(l.name, cn.title),
                'url', l.url,
                'description', l.description,
-               'ordinals', array_to_string(cn.ordinals, '.')
+               'ordinals', array_to_string(cn.ordinals, '.'),
+               'casebook_id', cn.casebook_id
            ) AS metadata,
            'link'::text AS category
     FROM

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1016,7 +1016,7 @@ class FullTextSearchIndex(models.Model):
         ... )
         >>> assert dump_search_results(FullTextSearchIndex().casebook_fts(casebooks[0].id, 'textblock', '2')) == (
         ...     [
-        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': ''}
+        ...         {'name': 'Some TextBlock Name 2', 'description': 'Some TextBlock Description 2', 'ordinals': '', 'casebook_id': casebooks[0].id}
         ...     ],
         ...     {'legal_doc_fulltext': 1, 'textblock': 1},
         ...     {}
@@ -1027,11 +1027,9 @@ class FullTextSearchIndex(models.Model):
         legal_doc_ids = casebook.contents.filter(resource_type="LegalDocument").values_list("resource_id", flat=True)
         legal_doc_query = FullTextSearchIndex.objects.filter(category="legal_doc_fulltext").filter(result_id__in=legal_doc_ids)
 
-        textblock_ids = casebook.contents.filter(resource_type="TextBlock").values_list("resource_id", flat=True)
-        textblock_query = FullTextSearchIndex.objects.filter(category="textblock").filter(result_id__in=textblock_ids)
+        textblock_query = FullTextSearchIndex.objects.filter(category="textblock").filter(metadata__casebook_id=casebook_id)
 
-        link_ids = casebook.contents.filter(resource_type="Link").values_list("resource_id", flat=True)
-        link_query = FullTextSearchIndex.objects.filter(category="link").filter(result_id__in=link_ids)
+        link_query = FullTextSearchIndex.objects.filter(category="link").filter(metadata__casebook_id=casebook_id)
 
         base_query = legal_doc_query | textblock_query | link_query
 


### PR DESCRIPTION
TextBlock and Link resources form the vast, vast majority of our search index. Unlike LegalDocuments, they have a one-to-one relationship with casebooks. In order to filter down to the TextBlocks present in a single casebook, we were previously using the same strategy we used for LegalDocuments: get a list of PKs from Casebook.contents, and then do an `id__in` filter against this list of primary keys.

This is necessary for LegalDocuments, which have a one-to-many relationship with casebooks. However, for other resources, we can pack casebook_ids directly into their search metadata and save us this join step. This speeds search up considerably, because we previously had to perform expensive IN lookups.