### PR TITLE
Modifies indexing process to build a new index before chucking the old one

### DIFF
--- a/web/fabfile.py
+++ b/web/fabfile.py
@@ -66,6 +66,19 @@ def refresh_search_index():
     from main.models import SearchIndex
     SearchIndex.refresh_search_index()
 
+@task
+@setup_django
+def create_fts_index():
+    """ Create (or recreate) the search_view materialized view """
+    from main.models import FullTextSearchIndex
+    FullTextSearchIndex.create_search_index()
+
+@task
+@setup_django
+def refresh_fts_index():
+    """ Update an existing search_view materialized view; will create if create_search_index hasn't been run once """
+    from main.models import FullTextSearchIndex
+    FullTextSearchIndex.refresh_search_index()
 
 @task
 @setup_django

--- a/web/main/create_fts_index.sql
+++ b/web/main/create_fts_index.sql
@@ -1,6 +1,6 @@
-DROP MATERIALIZED VIEW IF EXISTS fts_search_view;
-DROP MATERIALIZED VIEW IF EXISTS fts_internal_search_view;
-CREATE MATERIALIZED VIEW fts_internal_search_view AS
+DROP MATERIALIZED VIEW IF EXISTS tmp_fts_search_view;
+DROP MATERIALIZED VIEW IF EXISTS tmp_fts_internal_search_view;
+CREATE MATERIALIZED VIEW tmp_fts_internal_search_view AS
     -- seperate category for full-text search
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
@@ -63,4 +63,10 @@ UNION ALL
         INNER JOIN main_contentnode cn ON cn.resource_id = l.id AND cn.resource_type = 'Link'
     GROUP BY l.id, cn.id
 ;
+DROP MATERIALIZED VIEW IF EXISTS fts_search_view;
+DROP MATERIALIZED VIEW IF EXISTS fts_internal_search_view;
+ALTER MATERIALIZED VIEW IF EXISTS tmp_fts_search_view RENAME to fts_search_view;
+ALTER MATERIALIZED VIEW IF EXISTS tmp_fts_internal_search_view RENAME to fts_internal_search_view;
 CREATE UNIQUE INDEX fts_search_view_refresh_index ON fts_internal_search_view (result_id, category);
+DROP MATERIALIZED VIEW IF EXISTS tmp_fts_search_view;
+DROP MATERIALIZED VIEW IF EXISTS tmp_fts_internal_search_view;


### PR DESCRIPTION
This PR modifies the indexing process to build a new index, delete the old one, and then rename the new to hotswap in for the old.  This process makes sure that search does not hang even if the index needs to be recreated for whatever reason. This also creates two new `fab` commands, `create_fts_index` and `refresh_fts_index` that should help manage the indexing process.

NOTE: if we actually want to suspend searches for some reason (e.g., migration makes search incompatible), then we need to manually drop the index view.

This closes #1610.