### PR TITLE
Full-text legal document search results links to casebook resource

### DIFF
--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -76,7 +76,11 @@
           </div>
         </a>
       {% elif category == 'legal_doc' or category == 'legal_doc_fulltext'%}
-          <a href="{% url 'display_legal_doc' result.result_id %}" class="wrapper" data-result-id="{{ result.result_id }}">
+          {% if category == 'legal_doc_fulltext' %}
+            <a href="{% url 'resource' casebook.id result.metadata.ordinals %}" class="wrapper" data-result-id="{{ result.result_id }}">
+          {% else %}
+            <a href="{% url 'display_legal_doc' result.result_id %}" class="wrapper" data-result-id="{{ result.result_id }}">
+          {% endif %}
             <div class="results-entry">
               <div class="title">
                 {{ result.metadata.display_name }}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3079,6 +3079,7 @@ def casebook_search(request, casebook):
         ...     n.resource_type = 'LegalDocument'
         ...     n.resource_id = d.id
         ...     n.casebook_id = casebooks[0].id
+        ...     n.ordinals = [1, 1]
         ...     n.save()
         >>> FullTextSearchIndex().create_search_index()
         >>> url = reverse('casebook_search', args=[casebooks[0].id])


### PR DESCRIPTION
Closes #1619 

Previously, clicking legal doc search results takes you to the Legal Document page, which is not associated with a casebook and does not include a professor's annotations. This PR adds a legal document's resource ordinals to its search metadata, which allows the result to (correctly) link to its resource page rather than the legal doc page.