### PR TITLE
Removing focus box for mouse only

### DIFF
--- a/web/frontend/components/TheTableOfContents.vue
+++ b/web/frontend/components/TheTableOfContents.vue
@@ -439,7 +439,7 @@ export default {
                 color: $white;
                 border-color: $white;
             }
-            *:focus {
+            *:focus-visible {
                 outline: 2px solid $white;
                 outline-offset: 2px;
             }

--- a/web/frontend/components/TheTableOfContents.vue
+++ b/web/frontend/components/TheTableOfContents.vue
@@ -439,9 +439,11 @@ export default {
                 color: $white;
                 border-color: $white;
             }
+            *:focus {
+                outline: none !important;
+            }
             *:focus-visible {
-                outline: 2px solid $white;
-                outline-offset: 2px;
+                outline: 2px solid $white !important;
             }
             .transmute-dropdown {
                 color: black;


### PR DESCRIPTION
Small thing but it has been bothering me...
Getting rid of the white focus box when we click drop downs in the casebook and only having it for keyboard users.

The white box will appear for keyboard users still!

Before 
<img width="982" alt="Screen Shot 2022-07-19 at 4 56 54 PM" src="https://user-images.githubusercontent.com/59305253/179847159-df12293c-69eb-4dce-87c0-2faf4a86f91d.png">

After
<img width="898" alt="Screen Shot 2022-07-19 at 4 57 00 PM" src="https://user-images.githubusercontent.com/59305253/179847166-5fb77af5-76e9-4f7e-8b59-183123d62660.png">

