### PR TITLE
Add `description` field to merge_draft

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -3808,7 +3808,7 @@ class Casebook(EditTrackedModel, TimestampedModel, BigPkModel, TrackedCloneable)
         # swap all attributes
 
         # start with the fields
-        for attr in ("title", "subtitle", "headnote"):
+        for attr in ("title", "subtitle", "description", "headnote"):
             temp = getattr(draft, attr)
             setattr(draft, attr, getattr(parent, attr))
             setattr(parent, attr, temp)


### PR DESCRIPTION
Previously, descriptions were not updated properly when revising published casebooks. This PR fixes that issue.
