### PR TITLE
Fix [View Archived Casebook] link from 404'ing on canonical user URL

### DIFF
--- a/web/frontend/components/Dashboard.vue
+++ b/web/frontend/components/Dashboard.vue
@@ -40,7 +40,7 @@
     </Modal>
     <div v-if="user.active">
       <h2 class="casebooks">My Casebooks</h2>
-      <div class="archived-link"><a href="casebooks/archived/">[View Archived Casebooks]</a></div>
+      <div class="archived-link"><a href="/casebooks/archived/">[View Archived Casebooks]</a></div>
       <hr class="owned"/>
     </div>
     <div v-else>


### PR DESCRIPTION
# What 

Change the [View Archived Casebook] link on a user's profile from a relative to absolute URL.

# Why

Currently, if you view your own profile from the canonical URL, `opencasebook.org/users/$N`, clicking on the `archived-link` tag will send you to `opencasebook.org/users/$N/casebooks/archived/` instead of the intended URL (`https://opencasebook.org/casebooks/archived/`), resulting in a 404.