### PR TITLE
Add missing test for invitation form

### DIFF
--- a/web/main/test/test_forms.py
+++ b/web/main/test/test_forms.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock
+from main.forms import InviteCollaboratorForm
+from main.models import User
+
+
+def test_collaborator_invite(casebook_factory, faker):
+    """Inviting the same user with differently-cased email addresses should
+    not result in duplicate users."""
+
+    # Given a new email address...
+    email = faker.email()
+    assert User.objects.filter(email_address__iexact=email).count() == 0
+
+    # Invite that email address to a casebook
+    casebook = casebook_factory()
+    form = InviteCollaboratorForm(data={"casebook": casebook.id, "email": email})
+    assert form.is_valid()
+    form.save(Mock())
+    assert User.objects.filter(email_address__iexact=email).count() == 1
+
+    # Invite the same email address with different case to a different casebook
+    casebook = casebook_factory()
+    form = InviteCollaboratorForm(data={"casebook": casebook.id, "email": email.upper()})
+    assert form.is_valid()
+    form.save(Mock())
+
+    # Only one user is created
+    assert User.objects.filter(email_address__iexact=email).count() == 1


### PR DESCRIPTION
This test was once part of the invitation flow; you can even see it in the [code coverage report for the original PR](https://github.com/harvard-lil/h2o/pull/1592#issuecomment-1175536455). It didn't make it to merging, probably because that got held up in the long chain from black -> flake8 -> merge. Somewhere along the way that typo got introduced too. :(

This puts the test back (I confirmed the test would've caught the typo. Tests work, assuming you add them.)