### PR TITLE
Add integration in usage dashboard with Matomo API; fixes #1584

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -37,3 +37,5 @@ services:
     environment:
       - CAPAPI_API_KEY
       - GPO_API_KEY
+      - MATOMO_API_KEY
+      - MATOMO_SITE_URL

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -127,6 +127,9 @@ USE_L10N = True
 
 # LIL's analytics JS
 USE_ANALYTICS = False
+MATOMO_SITE_URL = ""
+MATOMO_API_KEY = ""
+MATOMO_SITE_ID = "3"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
@@ -153,6 +156,8 @@ PROFESSOR_VERIFIER_EMAILS = ["info@opencasebook.org"]
 # e.g. <a href="mailto:{{ CONTACT_EMAIL }}">Contact Us</a>
 TEMPLATE_VISIBLE_SETTINGS = (
     "USE_ANALYTICS",
+    "MATOMO_SITE_ID",
+    "MATOMO_SITE_URL",
     "CONTACT_EMAIL",
     "GUIDE_URL",
     "BLOG_URL",

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -12,6 +12,8 @@ SECRET_KEY = "k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5"
 # Set these values in your local shell environment to make them available in the container
 CAPAPI_API_KEY = os.environ.get("CAPAPI_API_KEY", "")
 GPO_API_KEY = os.environ.get("GPO_API_KEY", "")
+MATOMO_API_KEY = os.environ.get("MATOMO_API_KEY", "")
+MATOMO_SITE_URL = os.environ.get("MATOMO_SITE_URL", "")
 
 DEBUG = True
 

--- a/web/conftest.py
+++ b/web/conftest.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from distutils.sysconfig import get_python_lib
 import pytest
 import factory
+from requests_mock import ANY
 
 from django.conf import settings
 from django.db import connections
@@ -941,3 +942,28 @@ def client_with_raise_request_exception():
                 django.test.client.got_request_exception.disconnect(dispatch_uid=exception_uid)
 
     return RaiseRequestExceptionClient
+
+
+@pytest.fixture()
+def mock_successful_matomo_response(requests_mock):
+    requests_mock.get(
+        ANY,
+        json=[
+            {
+                "label": "casebooks",
+                "nb_visits": 3,
+                "idsubdatatable": 1,
+                "segment": "",
+                "subtable": [
+                    {
+                        "label": "1-some-title",
+                        "nb_visits": 1,
+                    },
+                    {
+                        "label": "2-some-title",
+                        "nb_visits": 1,
+                    },
+                ],
+            }
+        ],
+    )

--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -33,9 +33,18 @@
             padding: 0;
         }
         #toolbar th, #toolbar td { vertical-align: middle; }
-        #toolbar { background-color: #eee; margin-bottom: 1em;}
-        #dashboard th small { font-weight: normal; text-style: italic; display: block; }
+        #toolbar {  margin-bottom: 1em;}
+        #dashboard th small { font-weight: normal; display: block; }
         aside { background-color: #eee; padding: 1em; margin-top: 2em;}
+        #dashboard {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            column-gap: 1rem;
+        }
+        #casebooks-by-usage h3 { display: inline; }
+        #casebooks-by-usage li { padding: .5rem 0 .5rem 0; border-bottom: 1px dotted gray; }
+        #casebooks-by-usage ol { margin: 1rem; padding: 0; }
+        .is-public { display: inline-block; margin-left: 1rem; }
     </style>
 {% endblock extrastyle %}
 
@@ -81,18 +90,15 @@
                     <td>
                         <input type="submit">
                     </td>
-
                 </tr>
             </table>
         </form>
     </div>
 
-    <p>
-        Showing all records for users or casebooks created between {{ date_form.start_date.value |date:"Y-m-d" }} and {{ date_form.end_date.value |date:"Y-m-d" }}:
-    </p>
+    <div id="dashboard">
+        <div>
+    <table>
 
-
-    <table id="dashboard">
     <tr>
         <th>Number of accounts
             <small>All active, non-staff users</small>
@@ -215,10 +221,46 @@
     </tr>
     </table>
 
-    <aside>
-        Note: "Published" casebooks will include casebooks in either the <em>published</em> or
-        <em>revising</em> state, matching the front end search.
-    </aside>
+        <aside>
+            Note: "Published" casebooks will include casebooks in either the <em>published</em> or
+            <em>revising</em> state, matching the front end search.
+        </aside>
+    </div>
+
+    <div id="casebooks-by-usage">
+        <h2>Top casebooks by usage</h2
+        <p>Results between {{ web_usage.start_date }} and {{ web_usage.end_date }}</p>
+        <ol>
+        {% for result in web_usage.items %}
+            {% with result.instance as casebook %}
+           <li>{% if casebook %}
+                <h3><a href="{{ casebook.get_absolute_url }}">{{ casebook.title }}</a></h3>
+                <span class="is-public">{% if casebook.is_public %}
+                    ✅ published
+                {% else %}
+                    ❌ not published
+                {% endif %}
+                </span>
+                <p>
+                    {% for author in casebook.primary_authors %}
+                        <a href="{% url "admin:main_user_change" author.id %}">{{ author }}</a> {% if author.verified_professor %}(prof){% endif %}
+                        {% if author.affiliation %} at {{ author.affiliation }} {% endif %}
+                        {% if not forloop.last%}, {% endif %}
+                    {% endfor %}
+
+                </p>
+                <p>
+                    {{ result.visits | intcomma }} visit{{ result.visits| pluralize }}
+                </p>
+            {% else %}
+                {{ result.slug }}
+            {% endif %}
+            {% endwith %}
+        </li>
+        {% endfor %}
+        </ol>
+    </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/web/main/templates/includes/analytics.html
+++ b/web/main/templates/includes/analytics.html
@@ -1,5 +1,6 @@
 {% if USE_ANALYTICS %}
-  {% verbatim %}
+{# Ensure that MATOMO_SITE_ID and MATOMO_SITE_URL are both set for this environment #}
+{% verbatim %}
     <script>
       var _gaq = [];
       var _paq = _paq || [];
@@ -7,9 +8,9 @@
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
-      var u="//analytics.lil.tools/";
+      var u="{{ MATOMO_SITE_URL }}";
       _paq.push(['setTrackerUrl', u+'piwik.php']);
-      _paq.push(['setSiteId', '3']);
+      _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2750,7 +2750,7 @@ def export(request, node, file_type="docx"):
             docx_footnotes=docx_footnotes,
         )
     except LambdaExportTooLarge as too_large:
-        logger.warn(f"Export node({node.id}): " + too_large.args[0])
+        logger.warning(f"Export node({node.id}): " + too_large.args[0])
         return render(request, "export_too_large.html", {"casebook": node})
     if response_data is None:
         return render(request, "export_error.html", {"casebook": node})

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -15,6 +15,7 @@ from reporting.create_reporting_views import (
     PUBLISHED_CASEBOOKS,
 )
 from main.models import Casebook
+from reporting.matomo import usage
 
 
 class DateForm(forms.Form):
@@ -53,6 +54,9 @@ def view(request: HttpRequest):
         )
 
     state = PUBLISHED_CASEBOOKS if published_casebooks_only else ALL_STATES
+
+    # Get the usage data from Matomo:
+    web_usage = usage(start_date, end_date, published_casebooks_only)
 
     with connection.cursor() as cursor:
 
@@ -257,6 +261,7 @@ def view(request: HttpRequest):
         "admin/reporting/index.html",
         {
             "stats": stats,
+            "web_usage": web_usage,
             "date_form": form,
             "query": urlencode(
                 {

--- a/web/reporting/matomo.py
+++ b/web/reporting/matomo.py
@@ -1,0 +1,128 @@
+# Connect to the Matomo instance associated with this H2O install and pull reports
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Optional
+
+import requests
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from requests import HTTPError
+from requests import ConnectTimeout
+from main.models import Casebook
+
+from reporting.create_reporting_views import ALL_STATES, PUBLISHED_CASEBOOKS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CasebookResult:
+    slug: str
+    visits: int
+    instance: Optional[Casebook] = None
+
+
+@dataclass
+class UsageData:
+    start_date: date
+    end_date: date
+    status: str
+    items: list[CasebookResult] = field(default_factory=list)
+
+
+def usage(
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    published_casebook_only=False,
+) -> UsageData:
+    if not all((settings.MATOMO_SITE_URL, settings.MATOMO_API_KEY, settings.MATOMO_SITE_ID)):
+        raise NotImplementedError(
+            "Both of MATOMO_SITE_URL and MATOMO_API_KEY must be set to retrieve analytics"
+        )
+    return api(
+        settings.MATOMO_SITE_URL,
+        settings.MATOMO_API_KEY,
+        settings.MATOMO_SITE_ID,
+        start_date,
+        end_date,
+        published_casebook_only,
+    )
+
+
+def api(
+    api_url: str,
+    api_key: str,
+    id_site: str,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    published_casebooks_only=False,
+) -> UsageData:
+
+    if not start_date:
+        start_date = date.today() - relativedelta(months=1)
+    if not end_date:
+        end_date = date.today()
+
+    # Cap the oldest part of the range to keep Matomo from running out of memory
+    start_date = max(end_date - relativedelta(months=6), start_date)
+    start_date_str = start_date.strftime("%Y-%m-%d")
+    end_date_str = end_date.strftime("%Y-%m-%d")
+
+    web_usage = UsageData(status="OK", start_date=start_date, end_date=end_date)
+
+    params = {
+        "module": "API",
+        "idSite": id_site,
+        "token_auth": api_key,
+        "format": "JSON",
+        "method": "Actions.getPageUrls",
+        "period": "range",
+        "date": f"{start_date_str},{end_date_str}",
+        "expanded": "1",
+        "filter_column": "label",
+        "filter_pattern": "^casebooks$",
+        "showColumns": "nb_visits",
+    }
+
+    try:
+        resp = requests.get(api_url, params=params)
+        resp.raise_for_status()
+    except (HTTPError, ConnectTimeout) as exc:
+        web_usage.status = "The Matomo API returned an error code; this will be logged"
+        logger.error(exc)
+        logger.error(params)
+        return web_usage
+
+    try:
+        data = resp.json()
+    except ValueError:
+        web_usage.status = "The Matomo API did not return JSON as expected"
+        logger.error(web_usage.status)
+        logger.error(params)
+        logger.error(resp.content)
+        return web_usage
+
+    casebooks = [c for c in data[0]["subtable"]]
+
+    for casebook in casebooks:
+        cr = CasebookResult(slug=casebook["label"], visits=casebook["nb_visits"])
+        web_usage.items.append(cr)
+        try:
+            casebook_id_part = re.findall(r"^\d+", cr.slug)
+            if len(casebook_id_part) == 0:
+                logger.warning(f"Could not parse slug {cr.slug} for integer value")
+                continue
+            casebook_id = int(casebook_id_part[0])
+
+            instance = Casebook.objects.get(
+                id=casebook_id,
+                state__in=PUBLISHED_CASEBOOKS if published_casebooks_only else ALL_STATES,
+            )
+            cr.instance = instance
+        except Casebook.DoesNotExist:
+            logger.warning(f"Could not find casebook instance matching slug {cr.slug}")
+            continue
+
+    return web_usage

--- a/web/reporting/tests/test_matomo_integration.py
+++ b/web/reporting/tests/test_matomo_integration.py
@@ -1,0 +1,59 @@
+from datetime import date
+from functools import partial
+
+import pytest
+import requests
+from main.models import Casebook
+from reporting.matomo import api
+from requests_mock import ANY
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_matomo_api(casebook_factory, mock_successful_matomo_response):
+    """The API call should find matching casebooks from the usage data"""
+
+    c1 = casebook_factory()
+    c2 = casebook_factory()
+    res = api("http://example.com", "", "", date.today(), date.today())
+    assert res.items[0].instance.id == c1.id
+    assert res.items[1].instance.id == c2.id
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_matomo_api_filter(casebook_factory, mock_successful_matomo_response):
+    """The API call should respect the publication filter"""
+
+    c1 = casebook_factory(state=Casebook.LifeCycle.PUBLISHED.value)
+    casebook_factory(state=Casebook.LifeCycle.ARCHIVED.value)
+
+    res = api(
+        "http://example.com", "", "", date.today(), date.today(), published_casebooks_only=True
+    )
+    assert res.items[0].instance.id == c1.id
+    assert res.items[1].instance is None
+
+
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_matomo_api_no_match(mock_successful_matomo_response):
+    """The API call should still return some data even if the casebooks can't be found in the DB"""
+
+    res = api("http://example.com", "", "", date.today(), date.today())
+    assert res.items[0].slug == "1-some-title"
+    assert res.items[0].instance is None
+
+
+def test_matomo_api_error(requests_mock):
+    """The API call should be resilient to the Matomo API being unavailable"""
+
+    api_call = partial(api, "http://example.com", "", "", date.today(), date.today())
+    requests_mock.get(ANY, status_code=500)
+    res = api_call()
+    assert "error" in res.status
+
+    requests_mock.get(ANY, exc=requests.exceptions.ConnectTimeout)
+    res = api_call()
+    assert "error" in res.status
+
+    requests_mock.get(ANY, text="I'm not JSON")
+    res = api_call()
+    assert "did not return JSON" in res.status

--- a/web/reporting/tests/test_reporting_views.py
+++ b/web/reporting/tests/test_reporting_views.py
@@ -32,7 +32,7 @@ def test_refresh_views(db, casebook_factory, cursor):
     assert 1 == cursor.fetchone()[0]
 
 
-def test_usage_dashboard(client, casebook_factory):
+def test_usage_dashboard(client, casebook_factory, mock_successful_matomo_response):
     """The reporting dashboard should return a datastructure with result counts"""
     casebook_factory()
     refresh()

--- a/web/reporting/tests/test_reporting_views.py
+++ b/web/reporting/tests/test_reporting_views.py
@@ -1,6 +1,7 @@
 import pytest
 from django.apps import apps
 from django.db import connection
+from django.test import override_settings
 from django.urls import reverse
 from reporting.create_reporting_views import VIEW_LIST, create, refresh
 
@@ -32,6 +33,9 @@ def test_refresh_views(db, casebook_factory, cursor):
     assert 1 == cursor.fetchone()[0]
 
 
+@override_settings(
+    MATOMO_SITE_URL="http://example.com", MATOMO_API_KEY="fake", MATOMO_SITE_ID="fake"
+)
 def test_usage_dashboard(client, casebook_factory, mock_successful_matomo_response):
     """The reporting dashboard should return a datastructure with result counts"""
     casebook_factory()


### PR DESCRIPTION
Incorporate usage data from Matomo (like Google Analytics but open source and self-hosted) into the usage dashboard.

It looks like this:

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/19571/180555889-aed2355c-f61c-4097-bf05-3bbe11718283.png">

The usage data will respect the filters provided at the top (date range and whether the casebook is published), except that the possible date range is capped at 6 months max or else Matomo will crap out.

**Note for deployment**

This needs to be paired with a salt change as two new Django settings/secrets have been added: `MATOMO_API_KEY` (a real secret; we should generate a key specifically for prod) and `MATOMO_SITE_URL` (not really a secret but specific to our environment, which should be parametrized.) Could do the same for `MATOMO_SITE_ID`, which corresponds to H2O in our Matomo install.

