### PR TITLE
Add CSV export option to reporting admin; fixes #1627

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -61,7 +61,7 @@ class CustomAdminSite(admin.AdminSite):
 
         urls = super().get_urls()
         my_urls = [
-            path("usage/", usage_dashboard_view, name="usage"),
+            path("reporting/usage/", usage_dashboard_view, name="usage"),
         ]
         return my_urls + urls
 

--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -111,6 +111,8 @@
         <th>Verified professors
             <small>
                 <a href="{% url "admin:reporting_professor_changelist" %}?{{ date_query }}">View as list »</a>
+                <a href="{% url "admin:reporting_professor_changelist" %}?{{ date_query }}&_csv=True">Export as csv »</a>
+
             </small>
 
         </th>
@@ -120,6 +122,8 @@
         <th>Professors with published casebooks
             <small>
                 <a href="{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
 
 
@@ -129,8 +133,11 @@
     <tr>
         <th>Casebooks
             <small>That have been modified within this period</small>
+
             <small>
                 <a href="{% url "admin:reporting_reportingcasebook_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_reportingcasebook_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
 
         </th>
@@ -140,9 +147,9 @@
         <th>Casebooks from verified professors
             <small>
                 <a href="{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}">View as list »</a>
+
+                <a href="{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
             </small>
-
-
         </th>
         <td>{{ stats.casebooks_prof | intcomma }}</td>
     </tr>
@@ -150,6 +157,9 @@
         <th>Casebooks including content from Capstone
             <small>
                 <a href="{% url "admin:reporting_casebookcap_changelist" %}?{{ query }}">View as list »</a>
+
+                <a href="{% url "admin:reporting_casebookcap_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
         </th>
         <td>{{ stats.casebooks_cap | intcomma }}</td>
@@ -158,6 +168,8 @@
         <th>Casebooks including content from GPO
             <small>
                 <a href="{% url "admin:reporting_casebookgpo_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_casebookgpo_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
         </th>
         <td> {{ stats.casebooks_gpo | intcomma }}</td>
@@ -167,6 +179,8 @@
 
             <small>
                 <a href="{% url "admin:reporting_casebookcapprof_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_casebookcapprof_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
 
         </th>
@@ -177,6 +191,8 @@
 
             <small>
                 <a href="{% url "admin:reporting_casebookgpoprof_changelist" %}?{{ query }}">View as list »</a>
+
+                <a href="{% url "admin:reporting_casebookgpoprof_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
             </small>
 
         </th>
@@ -188,6 +204,8 @@
             <small>Where at least one collaborator has attribution</small>
             <small>
                 <a href="{% url "admin:reporting_casebookcollaborators_changelist" %}?{{ query }}">View as list »</a>
+
+                <a href="{% url "admin:reporting_casebookcollaborators_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
             </small>
         </th>
         <td> {{ stats.casebooks_with_collaborators | intcomma }}</td>
@@ -197,6 +215,8 @@
         <th>Casebooks with multiple collaborators, at least one professor
             <small>
                 <a href="{% url "admin:reporting_casebookcollaboratorsprof_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_casebookcollaboratorsprof_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
 
         </th>
@@ -207,6 +227,8 @@
             <small>Where the casebook designated as "latest" is published</small>
             <small>
                 <a href="{% url "admin:reporting_casebookseries_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_casebookseries_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
         </th>
         <td>{{ stats.series | intcomma }}</td>
@@ -216,6 +238,8 @@
 
             <small>
                 <a href="{% url "admin:reporting_casebookseriesprof_changelist" %}?{{ query }}">View as list »</a>
+                <a href="{% url "admin:reporting_casebookseriesprof_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+
             </small>
         </th>
         <td>{{ stats.series_by_prof | intcomma }}</td>

--- a/web/reporting/admin/views.py
+++ b/web/reporting/admin/views.py
@@ -1,18 +1,23 @@
+import csv
 from abc import ABC, abstractmethod
 from datetime import date
-from typing import Any, Iterable, Iterator, List, Optional, Tuple
+from io import StringIO
+from typing import Any, Iterable, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.admin.views.main import ChangeList
 from django.db import connection
 from django.db.models import Count
-from django.http import HttpRequest
-from main.admin import CasebookAdmin, UserAdmin
+from django.db.models.query import QuerySet
+from django.http import HttpRequest, HttpResponse
+from main.admin import BaseAdmin, CasebookAdmin, UserAdmin
 from main.models import Casebook
 from reporting.create_reporting_views import ALL_STATES, OLDEST_YEAR, PUBLISHED_CASEBOOKS
 
+MAX_CSV_RESULTS = 1_000
 
-def get_reporting_ids(query: str, params: List[Any]) -> Iterator[int]:
+
+def get_reporting_ids(query: str, params: list[Any]) -> Iterable[int]:
     with connection.cursor() as cursor:
 
         # Filter out any empty params that might be optional for this query
@@ -22,7 +27,7 @@ def get_reporting_ids(query: str, params: List[Any]) -> Iterator[int]:
         return ids
 
 
-def get_date_ranges(request: HttpRequest) -> Tuple[date, date]:
+def get_date_ranges(request: HttpRequest) -> tuple[date, date]:
 
     start_date = request.GET.get("start_date", date.today() - relativedelta(years=OLDEST_YEAR))
     end_date = request.GET.get("end_date", date.today())
@@ -47,7 +52,7 @@ class AbstractProfessorChangeList(AbstractReportingChangeList):
     def get_state(self, request: HttpRequest) -> Optional[Iterable[str]]:
         return None
 
-    def get_queryset(self, request: HttpRequest):
+    def get_queryset(self, request: HttpRequest) -> QuerySet:
 
         start_date, end_date = get_date_ranges(request)
         state = self.get_state(request)
@@ -59,7 +64,58 @@ class AbstractProfessorChangeList(AbstractReportingChangeList):
         return qs.order_by(*ordering)
 
 
-class ProfessorAdmin(UserAdmin):
+class CsvResponseMixin(BaseAdmin):
+    @property
+    def field_list(self) -> Iterable[str]:
+        """Return a list of fields to be included in the CSV output for this class"""
+        return []
+
+    def changelist_view(self, request: HttpRequest, extra_context=None) -> HttpResponse:
+        if "_csv" in request.GET:
+            qs: QuerySet = self.get_changelist_instance(request).queryset[:MAX_CSV_RESULTS]
+
+            output = StringIO()
+            export = [[f for f in self.field_list]]
+            for obj in qs:
+                row: list[str] = [str(getattr(obj, field)) for field in self.field_list]
+                export.append(row)
+            csv.writer(output).writerows(export)
+            return self.csv_response(output)
+
+        return super().changelist_view(request, extra_context)
+
+    def csv_response(self, output_rows: StringIO) -> HttpResponse:
+        """Return a response object of type CSV given a datastructure of rows of string output"""
+        return HttpResponse(
+            output_rows.getvalue().encode(),
+            headers={
+                "Content-Type": "text/csv",
+                "Content-Disposition": f'attachment; filename="{self.model._meta.model_name}-{date.today().isoformat()}.csv',
+            },
+        )
+
+
+class ProfessorExportMixin(CsvResponseMixin):
+    @property
+    def field_list(self) -> Iterable[str]:
+        return (
+            "id",
+            "attribution",
+            "email_address",
+            "affiliation",
+            "most_recent_casebook_title",
+            "most_recent_casebook_modified",
+            "last_login_at",
+        )
+
+
+class CasebookExportMixin(CsvResponseMixin):
+    @property
+    def field_list(self) -> Iterable[str]:
+        return ("id", "title", "authors_display", "state", "created_at", "updated_at")
+
+
+class ProfessorAdmin(ProfessorExportMixin, UserAdmin):
     """Override the default changelist method to return the customized change list class"""
 
     def get_changelist(self, request: HttpRequest):
@@ -75,7 +131,7 @@ class ProfessorAdmin(UserAdmin):
         return ChangeList
 
 
-class ProfessorWithCasebooksAdmin(UserAdmin):
+class ProfessorWithCasebooksAdmin(ProfessorExportMixin, UserAdmin):
     """Return a User/Professor changelist that respects the publication status of casebooks
     by this author"""
 
@@ -116,7 +172,7 @@ class AbstractCasebookChangeList(AbstractReportingChangeList):
         return qs.order_by(*ordering)
 
 
-class AbstractCasebooksAdmin(CasebookAdmin):
+class AbstractCasebooksAdmin(CasebookExportMixin, CasebookAdmin):
     """Return a Casebook list where subclasses can specify the database view to select from,
     and indicate whether to join on the professor view to restrict results to casebooks by professors."""
 

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -1,7 +1,24 @@
+from typing import Optional
 from main.models import Casebook, User
 
 
 class Professor(User):
+    @property
+    def most_recent_casebook(self) -> Optional[Casebook]:
+        return self.casebooks.all().order_by("-created_at").first()
+
+    @property
+    def most_recent_casebook_title(self) -> str:
+        if casebook := self.most_recent_casebook:
+            return casebook.title
+        return ""
+
+    @property
+    def most_recent_casebook_modified(self) -> str:
+        if casebook := self.most_recent_casebook:
+            return casebook.updated_at
+        return ""
+
     class Meta:
         proxy = True
         verbose_name = "Professor"
@@ -16,6 +33,10 @@ class ProfessorWithCasebooks(Professor):
 
 
 class ReportingCasebook(Casebook):
+    @property
+    def authors_display(self) -> str:
+        return ", ".join([a.attribution for a in self.attributed_authors])
+
     class Meta:
         proxy = True
         verbose_name = "Casebook"


### PR DESCRIPTION
Adds the ability to export any of the reporting views as a CSV in addition to a Django admin changelist view.

<img width="319" alt="image" src="https://user-images.githubusercontent.com/19571/180859134-18138908-6ae1-4298-92e8-2479dea2ef18.png">


This hooks in to the changelist view and checks for a `csv=True` query param; if so it returns a CSV view that auto-downloads; otherwise it returns an admin list view.

The list of fields in the CSV is not the same as the corresponding admin view; they have to be coerced into strings anyway, and I assume what is useful in a CSV export (like for sending a mailing) is different from other use cases, like editing a record. Those are defined in a mix-in class as `field_list` and in some cases reference new properties on the reporting models. This lets us customize the reporting output in a reusable way without cluttering up the main models.  I made a guess at fields that might be useful in a CSV report; Catherine can give me additional feedback later about changes or additions.

Since a CSV view can't be paginated there's a danger this view could take too long to render or exhaust all the RAM available to a request. That's especially plausible if the user unchecks "published casebooks only", where the number of casebooks can exceed 5,000. I set an arbitrary cap of 1,000 records on CSV results; we can adjust that downward if that's too generous on prod.

