### PR TITLE
Change date filters in reporting to apply more to recent usage than creation time

### DIFF
--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -34,7 +34,7 @@
         }
         #toolbar th, #toolbar td { vertical-align: middle; }
         #toolbar {  margin-bottom: 1em;}
-        #dashboard th small { font-weight: normal; display: block; }
+        #dashboard th small { font-weight: normal; display: block; padding-bottom: .5rem; }
         aside { background-color: #eee; padding: 1em; margin-top: 2em;}
         #dashboard {
             display: grid;
@@ -101,7 +101,7 @@
 
     <tr>
         <th>Number of accounts
-            <small>All active, non-staff users</small>
+            <small>All active, non-staff users who have ever logged in during this period</small>
         </th>
 
         <td> {{ stats.registered_users | intcomma }}
@@ -128,9 +128,10 @@
     </tr>
     <tr>
         <th>Casebooks
-                <small>
-                    <a href="{% url "admin:reporting_reportingcasebook_changelist" %}?{{ query }}">View as list »</a>
-                </small>
+            <small>That have been modified within this period</small>
+            <small>
+                <a href="{% url "admin:reporting_reportingcasebook_changelist" %}?{{ query }}">View as list »</a>
+            </small>
 
         </th>
         <td>{{ stats.casebooks | intcomma }}</td>
@@ -222,8 +223,17 @@
     </table>
 
         <aside>
-            Note: "Published" casebooks will include casebooks in either the <em>published</em> or
-            <em>revising</em> state, matching the front end search.
+            <h3>Notes:</h3>
+
+            <p>
+                "Published" casebooks will include casebooks in either the <em>published</em> or
+                <em>revising</em> state, matching the front end search.
+            </p>
+
+            <p>
+                Date fields apply to the <em>modification date</em> of casebook content,
+                but to the <em>date of last login</em> for professors.
+            </p>
         </aside>
     </div>
 

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -64,8 +64,8 @@ def view(request: HttpRequest):
         cursor.execute(
             """--sql
         select count(*) from reporting_users
-        where date(created_at) >= %s
-            and date(created_at) <= %s
+        where date(last_login_at) >= %s
+            and date(last_login_at) <= %s
         """,
             [start_date, end_date],
         )
@@ -75,8 +75,8 @@ def view(request: HttpRequest):
             """--sql
             select count(*) from reporting_casebooks
             where state in %s
-                and date(created_at) >= %s
-                and date(created_at) <= %s
+                and date(updated_at) >= %s
+                and date(updated_at) <= %s
             """,
             [state, start_date, end_date],
         )
@@ -85,8 +85,8 @@ def view(request: HttpRequest):
         cursor.execute(
             """--sql
         select count(*) from reporting_professors
-        where date(created_at) >= %s
-            and date(created_at) <= %s
+        where date(last_login_at) >= %s
+            and date(last_login_at) <= %s
         """,
             [start_date, end_date],
         )
@@ -97,8 +97,8 @@ def view(request: HttpRequest):
         select count(*) from (
         select user_id from reporting_professors_with_casebooks
         where state in %s
-            and date(created_at) >= %s
-            and date(created_at) <= %s
+            and date(last_login_at) >= %s
+            and date(last_login_at) <= %s
             group by user_id
         ) as r
         """,
@@ -115,8 +115,8 @@ def view(request: HttpRequest):
             """--sql
             select count(*) from reporting_casebooks_from_professors
             where state in %s
-                and date(created_at) >= %s
-                and date(created_at) <= %s
+                and date(updated_at) >= %s
+                and date(updated_at) <= %s
         """,
             [
                 state,
@@ -131,8 +131,8 @@ def view(request: HttpRequest):
             """--sql
             select count(*) from reporting_casebooks_including_source_cap
                 where state in %s
-                and date(created_at) >= %s
-                and date(created_at) <= %s
+                and date(updated_at) >= %s
+                and date(updated_at) <= %s
             """,
             [
                 state,
@@ -148,8 +148,8 @@ def view(request: HttpRequest):
             select count(*) from reporting_casebooks_including_source_cap rc
                 inner join reporting_casebooks_from_professors rp on rp.casebook_id = rc.casebook_id
                 where rc.state in %s
-                and date(rc.created_at) >= %s
-                and date(rc.created_at) <= %s
+                and date(rc.updated_at) >= %s
+                and date(rc.updated_at) <= %s
             """,
             [
                 state,
@@ -164,8 +164,8 @@ def view(request: HttpRequest):
             """--sql
             select count(*) from reporting_casebooks_including_source_gpo
                 where state in %s
-                and date(created_at) >= %s
-                and date(created_at) <= %s
+                and date(updated_at) >= %s
+                and date(updated_at) <= %s
             """,
             [
                 state,
@@ -182,8 +182,8 @@ def view(request: HttpRequest):
             select count(*) from reporting_casebooks_including_source_gpo rc
                 inner join reporting_casebooks_from_professors rp on rp.casebook_id = rc.casebook_id
                 where rc.state in %s
-                and date(rc.created_at) >= %s
-                and date(rc.created_at) <= %s
+                and date(rc.updated_at) >= %s
+                and date(rc.updated_at) <= %s
             """,
             [
                 state,
@@ -199,8 +199,8 @@ def view(request: HttpRequest):
             """--sql
         select count(*) from reporting_casebooks_with_multiple_collaborators
         where state in %s
-            and date(created_at) >= %s
-            and date(created_at) <= %s
+            and date(updated_at) >= %s
+            and date(updated_at) <= %s
         """,
             [
                 state,
@@ -216,8 +216,8 @@ def view(request: HttpRequest):
         select count(*) from reporting_casebooks_with_multiple_collaborators rc
                 inner join reporting_casebooks_from_professors rp on rc.casebook_id = rp.casebook_id
                 where rc.state in %s
-                and date(rc.created_at) >= %s
-                and date(rc.created_at) <= %s
+                and date(rc.updated_at) >= %s
+                and date(rc.updated_at) <= %s
         """,
             [
                 state,
@@ -232,8 +232,8 @@ def view(request: HttpRequest):
             """--sql
         select count(*) from reporting_casebooks_series as c
         where c.state in %s
-              and date(c.created_at) >= %s
-              and date(c.created_at) <= %s
+              and date(c.updated_at) >= %s
+              and date(c.updated_at) <= %s
         """,
             [
                 state,
@@ -249,8 +249,8 @@ def view(request: HttpRequest):
             """--sql
         select count(*) from reporting_casebooks_series_from_professors as c
             where c.state in %s
-                and date(c.created_at) >= %s
-                and date(c.created_at) <= %s
+                and date(c.updated_at) >= %s
+                and date(c.updated_at) <= %s
         """,
             [state, start_date, end_date],
         )

--- a/web/reporting/admin/views.py
+++ b/web/reporting/admin/views.py
@@ -68,8 +68,8 @@ class ProfessorAdmin(UserAdmin):
             def sql(self):
                 return """--sql
                 select user_id from reporting_professors
-                where created_at >= %s
-                and created_at <= %s
+                where date(last_login_at) >= %s
+                and date(last_login_at) <= %s
                 """
 
         return ChangeList
@@ -93,15 +93,15 @@ class ProfessorWithCasebooksAdmin(UserAdmin):
                 return """--sql
                 select user_id from reporting_professors_with_casebooks
                 where state in %s
-                and created_at >= %s
-                and created_at <= %s
+                and date(last_login_at) >= %s
+                and date(last_login_at) <= %s
                 """
 
         return ChangeList
 
 
 class AbstractCasebookChangeList(AbstractReportingChangeList):
-    """Return a Casebook changelist that respects the publication and creation date ranges
+    """Return a Casebook changelist that respects the publication and usage date ranges
     requested by the usage dashboard user."""
 
     def get_queryset(self, request: HttpRequest):
@@ -117,8 +117,8 @@ class AbstractCasebookChangeList(AbstractReportingChangeList):
 
 
 class AbstractCasebooksAdmin(CasebookAdmin):
-    """Return a Casebook list where subclasses can specify the specific view to report from
-    and whether to join from the professor view to restrict results to casebooks by professors."""
+    """Return a Casebook list where subclasses can specify the database view to select from,
+    and indicate whether to join on the professor view to restrict results to casebooks by professors."""
 
     @property
     @abstractmethod
@@ -141,8 +141,8 @@ class AbstractCasebooksAdmin(CasebookAdmin):
                     if parent.join_on_professor
                     else ""}
                 where c.state in %s
-                and c.created_at >= %s
-                and c.created_at <= %s
+                and date(c.updated_at) >= %s
+                and date(c.updated_at) <= %s
 
                 """
 

--- a/web/reporting/create_reporting_views.py
+++ b/web/reporting/create_reporting_views.py
@@ -9,7 +9,15 @@ PUBLISHED_CASEBOOKS = (
     Casebook.LifeCycle.PUBLISHED.value,
     Casebook.LifeCycle.REVISING.value,
 )
-ALL_STATES = tuple(tag.value for tag in Casebook.LifeCycle)
+# Don't include "previous saves" as they aren't useful for reporting
+ALL_STATES = (
+    Casebook.LifeCycle.PUBLISHED.value,
+    Casebook.LifeCycle.REVISING.value,
+    Casebook.LifeCycle.PRIVATELY_EDITING.value,
+    Casebook.LifeCycle.NEWLY_CLONED.value,
+    Casebook.LifeCycle.ARCHIVED.value,
+    Casebook.LifeCycle.REVISING.value,
+)
 
 OLDEST_YEAR = 20  # How far back in time we'll go
 

--- a/web/reporting/sql/reporting.sql
+++ b/web/reporting/sql/reporting.sql
@@ -17,7 +17,8 @@ select
     id as user_id,
     verified_professor,
     attribution,
-    created_at
+    created_at,
+    last_login_at
 from main_user
 where is_active is true
     and is_superuser is false;
@@ -26,7 +27,8 @@ where is_active is true
 create materialized view if not exists reporting_professors as
 select
     user_id,
-    created_at
+    created_at,
+    last_login_at
 from reporting_users
 where verified_professor is true
     and attribution != '';
@@ -36,40 +38,50 @@ create materialized view if not exists reporting_professors_with_casebooks as
 select
     reporting_professors.user_id,
     main_casebook.state,
-    main_casebook.created_at
+    main_casebook.created_at,
+    reporting_professors.last_login_at
 from main_contentcollaborator
 inner join reporting_professors
     on main_contentcollaborator.user_id = reporting_professors.user_id
 inner join
     main_casebook on main_contentcollaborator.casebook_id = main_casebook.id
-group by reporting_professors.user_id, main_casebook.state, main_casebook.created_at;
+group by reporting_professors.user_id, main_casebook.state, main_casebook.created_at, reporting_professors.last_login_at;
 
 -- Casebooks
 create materialized view if not exists reporting_casebooks as
-select id as casebook_id,
-    state,
-    created_at
-from  main_casebook;
+select c.id as casebook_id,
+    c.state,
+    c.created_at,
+    greatest(max_entry_date.entry_date, c.updated_at) as updated_at
+from main_casebook c
+left outer join (
+    select casebook_id, greatest(entry_date) as entry_date from main_casebookeditlog
+    group by casebook_id, entry_date
+) max_entry_date on c.id = max_entry_date.casebook_id
+group by c.id, c.created_at, max_entry_date.entry_date
+order by greatest(max_entry_date.entry_date, c.updated_at) desc limit 1;
 
 -- Casebooks created by professors
 create materialized view if not exists reporting_casebooks_from_professors as
 select
     main_contentcollaborator.casebook_id,
     c.state,
-    c.created_at
+    c.created_at,
+    c.updated_at
 from main_contentcollaborator
 inner join reporting_professors
     on main_contentcollaborator.user_id = reporting_professors.user_id
 inner join
     reporting_casebooks c on main_contentcollaborator.casebook_id = c.casebook_id
-group by main_contentcollaborator.casebook_id, c.state, c.created_at;
+group by main_contentcollaborator.casebook_id, c.state, c.created_at, c.updated_at;
 
 -- Casebooks with multiple collaborators, at least one of whom is a professor
 create materialized view if not exists reporting_casebooks_with_multiple_collaborators as
 select
     main_contentcollaborator.casebook_id,
     reporting_casebooks.state,
-    reporting_casebooks.created_at
+    reporting_casebooks.created_at,
+    reporting_casebooks.updated_at
 from main_contentcollaborator
 inner join
     reporting_casebooks on main_contentcollaborator.casebook_id = reporting_casebooks.casebook_id
@@ -78,7 +90,8 @@ where main_contentcollaborator.casebook_id in
         select casebook_id
         from main_contentcollaborator where has_attribution is true
     )
-group by main_contentcollaborator.casebook_id, reporting_casebooks.state, reporting_casebooks.created_at
+group by main_contentcollaborator.casebook_id, reporting_casebooks.state, reporting_casebooks.created_at,
+    reporting_casebooks.updated_at
 having count(user_id) > 1;
 
 -- Casebooks with any content derived from CAP
@@ -86,7 +99,8 @@ create materialized view if not exists reporting_casebooks_including_source_cap 
 select
     c.casebook_id,
     c.state,
-    c.created_at
+    c.created_at,
+    c.updated_at
 from main_contentnode
 inner join reporting_casebooks as c on main_contentnode.casebook_id = c.casebook_id
 where resource_type = 'LegalDocument'
@@ -96,14 +110,15 @@ where resource_type = 'LegalDocument'
         inner join main_legaldocumentsource as source on source.id = source_id
         where source.name = 'CAP'
     )
-group by c.casebook_id, c.state, c.created_at;
+group by c.casebook_id, c.state, c.created_at, c.updated_at;
 
 -- Casebooks with any content derived from GPO
 create materialized view if not exists reporting_casebooks_including_source_gpo as
 select
     c.casebook_id,
     c.state,
-    c.created_at
+    c.created_at,
+    c.updated_at
 from main_contentnode
 inner join reporting_casebooks as c on main_contentnode.casebook_id = c.casebook_id
 where resource_type = 'LegalDocument'
@@ -113,14 +128,15 @@ where resource_type = 'LegalDocument'
         inner join main_legaldocumentsource as source on source.id = source_id
         where source.name = 'GPO'
     )
-group by c.casebook_id, c.state, c.created_at;
+group by c.casebook_id, c.state, c.created_at, c.updated_at;
 
 -- Casebooks that are part of a series
 create materialized view if not exists reporting_casebooks_series as
 select
     c.casebook_id,
     c.state,
-    c.created_at
+    c.created_at,
+    c.updated_at
 from main_commontitle
     inner join reporting_casebooks c on c.casebook_id = main_commontitle.current_id;
 
@@ -129,7 +145,8 @@ create materialized view if not exists reporting_casebooks_series_from_professor
 select
     c.casebook_id,
     c.state,
-    c.created_at
+    c.created_at,
+    c.updated_at
 from main_commontitle
     inner join reporting_casebooks_from_professors c on c.casebook_id = main_commontitle.current_id;
 

--- a/web/reporting/tests/test_reporting_views.py
+++ b/web/reporting/tests/test_reporting_views.py
@@ -1,8 +1,11 @@
+import dateutil.rrule as rrule
 import pytest
 from django.apps import apps
 from django.db import connection
 from django.test import override_settings
 from django.urls import reverse
+from freezegun import freeze_time
+from main.models import CasebookEditLog
 from reporting.create_reporting_views import VIEW_LIST, create, refresh
 
 
@@ -42,6 +45,86 @@ def test_usage_dashboard(client, casebook_factory, mock_successful_matomo_respon
     refresh()
     resp = client.get(reverse("admin:usage"))
     assert 1 == resp.context["stats"]["casebooks"]
+
+
+@override_settings(
+    MATOMO_SITE_URL="http://example.com", MATOMO_API_KEY="fake", MATOMO_SITE_ID="fake"
+)
+def test_dashboard_casebook_date_fields(
+    client, casebook_factory, casebook_edit_log_factory, mock_successful_matomo_response
+):
+    """The reporting dashboard should report dates based on casebook usage including the edit log"""
+
+    early_date = "2000-01-01"
+    later_date = "2050-01-01"
+
+    # Pick a time to create a casebook and then check whether any exist "now"
+    with freeze_time(early_date):
+        casebook = casebook_factory()
+        refresh()
+        resp = client.get(
+            reverse("admin:usage"), {"start_date": early_date, "end_date": early_date}
+        )
+        assert 1 == resp.context["stats"]["casebooks"]
+
+    with freeze_time(later_date):
+        # At a later time, casebook will no longer fall in the filter range
+        resp = client.get(
+            reverse("admin:usage"), {"start_date": later_date, "end_date": later_date}
+        )
+        assert 0 == resp.context["stats"]["casebooks"]
+
+        # However, if we generate new edit log values...
+        casebook_edit_log_factory(casebook=casebook)
+        refresh()
+
+        # The casebook is now considered to be modified recently
+        resp = client.get(
+            reverse("admin:usage"), {"start_date": later_date, "end_date": later_date}
+        )
+        assert 1 == resp.context["stats"]["casebooks"]
+
+
+def test_greatest_mod_date(casebook_edit_log_factory, casebook_factory, cursor):
+    """The `updated_at` date in the reporting table for a casebook should be the most recent
+    date of any edit log value, or the casebook itself"""
+    with freeze_time("1970-01-01"):
+        casebook = casebook_factory()
+
+        for recurring_date in rrule.rrule(rrule.YEARLY, count=10):
+            # Generate 10 edit log entries
+            with freeze_time(recurring_date):
+                casebook_edit_log_factory(casebook=casebook)
+
+    assert 10 == CasebookEditLog.objects.count()
+    max_date = CasebookEditLog.objects.all().order_by("-entry_date").first().entry_date
+    refresh()
+
+    cursor.execute(
+        "select updated_at from reporting_casebooks where casebook_id = %s",
+        [casebook.id],
+    )
+    rows = cursor.fetchall()
+
+    # There should only be 1 entry...
+    assert 1 == len(rows)
+
+    # ...and its date should be the max date of the edit log values, which are more recent than
+    # the casebook
+    assert max_date == rows[0][0]
+
+    # Jump ahead into the future and update the casebook's timestamp
+    with freeze_time("2099-01-01"):
+        casebook.save()
+        refresh()
+        cursor.execute(
+            "select updated_at from reporting_casebooks where casebook_id = %s",
+            [casebook.id],
+        )
+        rows = cursor.fetchall()
+
+        # Now the reporting table greatest date should apply to the casebook, not the edit log
+        assert max_date < rows[0][0]
 
 
 @pytest.mark.parametrize("model", apps.all_models["reporting"])

--- a/web/requirements.in
+++ b/web/requirements.in
@@ -33,6 +33,7 @@ flake8==4.0.1
 requests-mock       # mock the requests library
 pytest-mock
 py-spy
+freezegun
 
 # Dev convenience
 django-debug-toolbar

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -264,6 +264,10 @@ flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
     # via -r requirements.in
+freezegun==1.2.1 \
+    --hash=sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09 \
+    --hash=sha256:b4c64efb275e6bc68dc6e771b17ffe0ff0f90b81a2a5189043550b6519926ba4
+    # via -r requirements.in
 future==0.18.2 \
     --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
     # via django-json-widget
@@ -522,6 +526,7 @@ python-dateutil==2.8.1 \
     # via
     #   botocore
     #   faker
+    #   freezegun
 python-docx==0.8.11 \
     --hash=sha256:1105d233a0956dd8dd1e710d20b159e2d72ac3c301041b95f4d4ceb3e0ebebc4
     # via -r requirements.in


### PR DESCRIPTION
It's more useful in outreach activity to sort and filter by active use of the product, than when an account or casebook was first created.

This switches the date filters in usage reporting to reflect usage rather than blunt instance creation time. The specific date varies by the type of object being reported on:

* For users (e.g. professors), the date filters apply to the time they last logged in to the product, regardless of when their account was created.
* For casebooks, the date filters apply to either the last-modified date of the `Casebook` instance, or the most recent modified date based on the edit log, whichever is greatest.

Introduces the [freezegun](https://github.com/spulec/freezegun) dependency for testing, which I find extremely useful for any date-based testing.

Fixes #1628

This generally makes the reported numbers go up. For example, with casebooks:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/19571/181048277-1ef73177-7622-484c-90fd-b074166662ba.png">

All of the ones with created-by dates prior to 2022 would not have shown up in the prior report, but we want to know about them! 
