### PR TITLE
Remove experimental export button; related to #1669

### DIFF
--- a/web/main/templates/includes/action_buttons.html
+++ b/web/main/templates/includes/action_buttons.html
@@ -48,20 +48,10 @@
     </form>
       {% endif %}
   {% endif %}
-    
+
   {% if exportable %}
 
-    {% if request.user.is_superuser %}
-      {% if section.casebook is section %} {# at the top level of a casebook, the 'section' you're looking is the casebook itself. Sections only make sense at the top level. #}
-        <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
-        <a class="action one-line export fancy export-docx-sections export-{{ section.is_annotated|yesno:"has,no" }}-annotations" style="font-weight: lighter; font-style: italic;" role="button" rel="nofollow" href="#">avec des sections</a>
-      {% else %}
-        <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export w/o format <br>changes for sections</a>
-        <a class="action one-line export fancy export-docx-sections export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Proposed Export</a>
-      {% endif %}
-    {% else %}
       <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
-    {% endif %}
 
   {% endif %}
 


### PR DESCRIPTION
Part of cleanup in #1669 : remove the admin-only purple export button which does the same thing as the regular export button now.

Was: 

<img width="199" alt="image" src="https://user-images.githubusercontent.com/19571/181249130-9583a546-e864-4c27-b562-5463c706a176.png">

Now admins see the same thing as everyone else:

<img width="155" alt="image" src="https://user-images.githubusercontent.com/19571/181249196-94b860de-9fec-4322-98d2-b3203b92f00d.png">

Non-admin users should see nothing new.
