### PR TITLE
Improve casebook date filtering

### DIFF
--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -254,9 +254,16 @@
                 <em>revising</em> state, matching the front end search.
             </p>
 
+            <h3>When filtering by date:</h3>
             <p>
-                Date fields apply to the <em>modification date</em> of casebook content,
-                but to the <em>date of last login</em> for professors.
+                Casebooks are included if their most-recent
+                change in the History tab falls in the range, or if their modification
+                date falls in that range in the case of no History (e.g. unpublished casebooks).
+            </p>
+            <p>
+                Professors are included based on their date of most-recent login.
+                When selecting older date ranges, professors who were active more recently
+                may be omitted.
             </p>
         </aside>
     </div>
@@ -264,6 +271,11 @@
     <div id="casebooks-by-usage">
         <h2>Top casebooks by usage</h2
         <p>Results between {{ web_usage.start_date }} and {{ web_usage.end_date }}</p>
+
+        {% if web_usage.status %}
+           <p><strong>{{ web_usage.status }}</strong></p>
+        {% endif %}
+
         <ol>
         {% for result in web_usage.items %}
             {% with result.instance as casebook %}

--- a/web/reporting/admin/views.py
+++ b/web/reporting/admin/views.py
@@ -112,7 +112,7 @@ class ProfessorExportMixin(CsvResponseMixin):
 class CasebookExportMixin(CsvResponseMixin):
     @property
     def field_list(self) -> Iterable[str]:
-        return ("id", "title", "authors_display", "state", "created_at", "updated_at")
+        return ("id", "title", "authors_display", "state", "created_at", "most_recent_history")
 
 
 class ProfessorAdmin(ProfessorExportMixin, UserAdmin):

--- a/web/reporting/matomo.py
+++ b/web/reporting/matomo.py
@@ -104,6 +104,13 @@ def api(
         logger.error(resp.content)
         return web_usage
 
+    if "message" in data:
+        web_usage.status = data["message"]
+        logger.error(web_usage.status)
+        logger.error(params)
+        logger.error(resp.content)
+        return web_usage
+
     casebooks = [c for c in data[0]["subtable"]]
 
     for casebook in casebooks:

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional
 from main.models import Casebook, User
 
@@ -36,6 +37,12 @@ class ReportingCasebook(Casebook):
     @property
     def authors_display(self) -> str:
         return ", ".join([a.attribution for a in self.attributed_authors])
+
+    @property
+    def most_recent_history(self) -> Optional[date]:
+        if edit_log := self.edit_log.order_by("-entry_date").first():
+            return edit_log.entry_date
+        return None
 
     class Meta:
         proxy = True


### PR DESCRIPTION
This changes the behavior of the casebook reporting views to use the dates of major activity associated with the History tab rather than favoring the most-recent modification date. Partly this is to better reflect what "recent activity" really means—we're concerned with edits and publication status changes more than minor metadata changes. It also make the reporting more resilient to immaterial changes like bulk modification date updates, as has occurred in the past.

The practical outcome of this fewer casebooks are reported as having been recently changed, but the reports should better reflect the kinds of changes we care about.

This PR includes some other small fixes to reporting: 

 * Handling the case where Matomo returns a query validation message but not does strictly return an error response (because you sent it nonsensical date ranges)
 * Modifies the date-modified in the Casebook CSV result to be specific to the history table, so the CSV export better reflects the input query.
 * Switches the assertion in the casebook date test to reflect the new desired behavior favoring the edit log.