### PR TITLE
Add new desired local hostname

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -76,14 +76,9 @@ let vueConfig = {
     host: devServerHost,
     headers: { 'Access-Control-Allow-Origin': '*' },
     allowedHosts: [
-      '.h2o-dev.local'
+	'.h2o-dev.local',
+	'opencasebook.test',
     ],
-    // hopefully we don't need active polling ...
-    // watchOptions: {
-    //   poll: true,
-    //   ignored: ['node_modules'],
-    // }
-
   },
 
   chainWebpack: config => {


### PR DESCRIPTION
When accessing the site using `opencasebook.test` per the README, Chrome was showing an infinite loop of "Invalid Host/Origin" in the console. 

This adds that hostname following the pattern done to CAP in https://github.com/harvard-lil/capstone/commit/e8fa291ca3d3b698ec9c4ef99e9a62005ac74233

Also deletes some apparently unneeded config.