### PR TITLE
Upgrade Sentry JS SDK

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@holtchesley/vue-nestable": "git://github.com/holtchesley/vue-nestable.git#063a64e67e5a1acbb2b7d7556748a3ce00d1ca52",
-        "@sentry/vue": "^7.7.0",
+        "@sentry/vue": "^7.8.1",
         "@trevoreyre/autocomplete-vue": "^2.2.0",
         "axios": "^0.21.4",
         "bluebird": "^3.5.0",
@@ -1982,13 +1982,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.7.0.tgz",
-      "integrity": "sha512-oyzpWcsjVZTaf14zAL89Ng1DUHlbjN+V8pl8dR9Y9anphbzL5BK9p0fSK4kPIrO4GukK+XrKnLJDPuE/o7WR3g==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.8.1.tgz",
+      "integrity": "sha512-9JuagYqHyaZu/4RqyxrAgEHo71oV592XBuUKC33gajCVKWbyG3mNqudSMoHtdM1DrV9REZ4Elha7zFaE2cJX6g==",
       "dependencies": {
-        "@sentry/core": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/core": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1996,13 +1996,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.7.0.tgz",
-      "integrity": "sha512-Z15ACiuiFINFcK4gbMrnejLn4AVjKBPJOWKrrmpIe8mh+Y9diOuswt5mMUABs+jhpZvqht3PBLLGBL0WMsYMYA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.8.1.tgz",
+      "integrity": "sha512-PRivbdIzApi/gSixAxozhOBTylSVdw/9VxaStYHd7JJGhs36KXkV8ylpbCmYO4ap7/Ue9/slzwpvPOJJzmzAgA==",
       "dependencies": {
-        "@sentry/hub": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/hub": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2010,12 +2010,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.7.0.tgz",
-      "integrity": "sha512-6gydK234+a0nKhBRDdIJ7Dp42CaiW2juTiHegUVDq+482balVzbZyEAmESCmuzKJhx5BhlCElVxs/cci1NjMpg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.8.1.tgz",
+      "integrity": "sha512-AxwyGyS9Lp4XsURu4t8opa5vZ+NAB6I/n+B/Uix3YZea9z8jdWYAu9vsXSizOrtxekc/i7ZN4bnlNgXVHix0iA==",
       "dependencies": {
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2023,19 +2023,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.7.0.tgz",
-      "integrity": "sha512-4x8O7uerSGLnYC10krHl9t8h7xXHn5FextqKYbTCXCnx2hC8D+9lz8wcbQAFo0d97wiUYqI8opmEgFVGx7c5hQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.8.1.tgz",
+      "integrity": "sha512-LOoaeBXVI23Kh5SpIbxSRiJ6+eYZXVOFyPFH1T1mGBj95LPwRMqOdg0lUTmFJGBKbDGDB/YNjNnu1kQ7GrXBXw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.7.0.tgz",
-      "integrity": "sha512-fD+ROSFpeJlK7bEvUT2LOW7QqgjBpXJwVISKZ0P2fuzclRC3KoB2pbZgBM4PXMMTiSzRGWhvfRRjBiBvQJBBJQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.8.1.tgz",
+      "integrity": "sha512-isUZjft4HWTOk1Z58KFJ/zzXeFtIJgP82CkYQlW464ZR2WCqPHYlXXXRWZpOHOfMnrf+gWeX9WAGS9rTAdhiSg==",
       "dependencies": {
-        "@sentry/types": "7.7.0",
+        "@sentry/types": "7.8.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2043,14 +2043,14 @@
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.7.0.tgz",
-      "integrity": "sha512-0gtUJ5ngdEYS2CnlOW76U6sMs5RoALpfhk7QMqPn7nGCMHP2uthwi8/T1HMKjg5JTZqLcfssf059fg3ZnhpGYQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.8.1.tgz",
+      "integrity": "sha512-vFIyqBmg/ldkNr4fmvUNms5r9HaXG645QoUsNtJYJxCXe9bUx+cVara3fKENHXYqHlpE+prx83XVP331TQNr5w==",
       "dependencies": {
-        "@sentry/browser": "7.7.0",
-        "@sentry/core": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/browser": "7.8.1",
+        "@sentry/core": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -19755,60 +19755,60 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.7.0.tgz",
-      "integrity": "sha512-oyzpWcsjVZTaf14zAL89Ng1DUHlbjN+V8pl8dR9Y9anphbzL5BK9p0fSK4kPIrO4GukK+XrKnLJDPuE/o7WR3g==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.8.1.tgz",
+      "integrity": "sha512-9JuagYqHyaZu/4RqyxrAgEHo71oV592XBuUKC33gajCVKWbyG3mNqudSMoHtdM1DrV9REZ4Elha7zFaE2cJX6g==",
       "requires": {
-        "@sentry/core": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/core": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.7.0.tgz",
-      "integrity": "sha512-Z15ACiuiFINFcK4gbMrnejLn4AVjKBPJOWKrrmpIe8mh+Y9diOuswt5mMUABs+jhpZvqht3PBLLGBL0WMsYMYA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.8.1.tgz",
+      "integrity": "sha512-PRivbdIzApi/gSixAxozhOBTylSVdw/9VxaStYHd7JJGhs36KXkV8ylpbCmYO4ap7/Ue9/slzwpvPOJJzmzAgA==",
       "requires": {
-        "@sentry/hub": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/hub": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.7.0.tgz",
-      "integrity": "sha512-6gydK234+a0nKhBRDdIJ7Dp42CaiW2juTiHegUVDq+482balVzbZyEAmESCmuzKJhx5BhlCElVxs/cci1NjMpg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.8.1.tgz",
+      "integrity": "sha512-AxwyGyS9Lp4XsURu4t8opa5vZ+NAB6I/n+B/Uix3YZea9z8jdWYAu9vsXSizOrtxekc/i7ZN4bnlNgXVHix0iA==",
       "requires": {
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.7.0.tgz",
-      "integrity": "sha512-4x8O7uerSGLnYC10krHl9t8h7xXHn5FextqKYbTCXCnx2hC8D+9lz8wcbQAFo0d97wiUYqI8opmEgFVGx7c5hQ=="
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.8.1.tgz",
+      "integrity": "sha512-LOoaeBXVI23Kh5SpIbxSRiJ6+eYZXVOFyPFH1T1mGBj95LPwRMqOdg0lUTmFJGBKbDGDB/YNjNnu1kQ7GrXBXw=="
     },
     "@sentry/utils": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.7.0.tgz",
-      "integrity": "sha512-fD+ROSFpeJlK7bEvUT2LOW7QqgjBpXJwVISKZ0P2fuzclRC3KoB2pbZgBM4PXMMTiSzRGWhvfRRjBiBvQJBBJQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.8.1.tgz",
+      "integrity": "sha512-isUZjft4HWTOk1Z58KFJ/zzXeFtIJgP82CkYQlW464ZR2WCqPHYlXXXRWZpOHOfMnrf+gWeX9WAGS9rTAdhiSg==",
       "requires": {
-        "@sentry/types": "7.7.0",
+        "@sentry/types": "7.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/vue": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.7.0.tgz",
-      "integrity": "sha512-0gtUJ5ngdEYS2CnlOW76U6sMs5RoALpfhk7QMqPn7nGCMHP2uthwi8/T1HMKjg5JTZqLcfssf059fg3ZnhpGYQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.8.1.tgz",
+      "integrity": "sha512-vFIyqBmg/ldkNr4fmvUNms5r9HaXG645QoUsNtJYJxCXe9bUx+cVara3fKENHXYqHlpE+prx83XVP331TQNr5w==",
       "requires": {
-        "@sentry/browser": "7.7.0",
-        "@sentry/core": "7.7.0",
-        "@sentry/types": "7.7.0",
-        "@sentry/utils": "7.7.0",
+        "@sentry/browser": "7.8.1",
+        "@sentry/core": "7.8.1",
+        "@sentry/types": "7.8.1",
+        "@sentry/utils": "7.8.1",
         "tslib": "^1.9.3"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@holtchesley/vue-nestable": "git://github.com/holtchesley/vue-nestable.git#063a64e67e5a1acbb2b7d7556748a3ce00d1ca52",
-    "@sentry/vue": "^7.7.0",
+    "@sentry/vue": "^7.8.1",
     "@trevoreyre/autocomplete-vue": "^2.2.0",
     "axios": "^0.21.4",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
Upgrade to the current recommended version of the Sentry SDK for JS.