### PR TITLE
Remove python-docx from main app

### DIFF
--- a/web/requirements.in
+++ b/web/requirements.in
@@ -22,7 +22,6 @@ bleach              # html sanitization
 diff-match-patch    # update annotations when underlying text changes
 django-json-widget  # fancy editor for Case JSON fields in the Django admin
 django-simple-history # history preservation for contents
-python-docx         # experimental method for DOCX export
 
 # Testing
 pytest

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -370,9 +370,7 @@ lxml==4.9.1 \
     --hash=sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad \
     --hash=sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8 \
     --hash=sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f
-    # via
-    #   pyquery
-    #   python-docx
+    # via pyquery
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
@@ -566,9 +564,6 @@ python-dateutil==2.8.1 \
     #   botocore
     #   faker
     #   freezegun
-python-docx==0.8.11 \
-    --hash=sha256:1105d233a0956dd8dd1e710d20b159e2d72ac3c301041b95f4d4ceb3e0ebebc4
-    # via -r requirements.in
 pytz==2021.1 \
     --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da \
     --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798


### PR DESCRIPTION
This library is in use in the python-lambda part of the application, but that has its own `requirements.txt` and  gets installed as part of the function instantiation. The library is not in use in the main part of the application and can be removed.