### PR TITLE
Removing Button Focus Outline on Mouse Click

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -65,7 +65,7 @@ main > header.casebook {
       &.disabled {
         background-color: $light-gray;
       }
-      &:focus {
+      &:focus-visible {
         @include generic-focus-styles;
         z-index: 999;
       }
@@ -142,7 +142,7 @@ main > header.casebook {
       text-decoration: underline !important;
       color: $light-blue;
     }
-    &:focus {
+    &:focus-visible {
       @include generic-focus-styles;
     }
     &:hover {
@@ -225,11 +225,11 @@ main > header.casebook {
       height: 50px;
     }
 
-    &:hover, &:focus-visible {
+    &:hover, &:focus {
       transform: scale(1.2);
     }
 
-    &:focus-visible {
+    &:focus {
       outline: none;
     }
   }
@@ -349,7 +349,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
         &:first-child {
           margin-left: 0;
         }
-        &:focus {
+        &:focus-visible {
           @include generic-focus-styles;
         }
         &.active {
@@ -446,7 +446,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
       font-size: 13px;
       display: inline-block;
 
-      a:focus {
+      a:focus-visible {
         @include generic-focus-styles;
       }
     }

--- a/web/frontend/styles/content/modals.scss
+++ b/web/frontend/styles/content/modals.scss
@@ -32,7 +32,7 @@
   z-index: 2;
 }
 
-.modal .close:focus {
+.modal .close:focus-visible {
   @include generic-focus-styles;
 }
 
@@ -55,7 +55,7 @@
 .modal-button {
   @extend .btn;
   @extend .btn-default;
-  &:focus {
+  &:focus-visible {
     @include generic-focus-styles;
   }
 }

--- a/web/frontend/styles/header.scss
+++ b/web/frontend/styles/header.scss
@@ -13,7 +13,7 @@ body {
   #main-header > nav {
     @extend .container;
     margin-top: 24px;
-    *:focus {
+    *:focus-visible {
       @include generic-focus-styles;
     }
     > .content {

--- a/web/frontend/styles/searches.scss
+++ b/web/frontend/styles/searches.scss
@@ -87,14 +87,14 @@ header.advanced-search {
       border-bottom: 2px solid $gray;
     }
 
-    a:focus {
+    a:focus-visible {
       @include generic-focus-styles;
     }
   }
 }
 
 .results-list {
-    .wrapper:focus {
+    .wrapper:focus-visible {
         outline:none;
         .results-entry {
             @include generic-focus-styles;


### PR DESCRIPTION
Removing button focus gray outline on mouse click and only enabling it for keyboard focus
`focus-visible` will only create focus effects for keyboard focus

<img width="139" alt="Screen Shot 2022-08-09 at 10 34 01 AM" src="https://user-images.githubusercontent.com/59305253/183676512-93a11670-f3cf-4a20-bb63-3f8425dca7c8.png">
<img width="123" alt="Screen Shot 2022-08-09 at 10 34 21 AM" src="https://user-images.githubusercontent.com/59305253/183676582-edc8a0c0-00fa-484b-947c-14e1f393f462.png">

Before 


https://user-images.githubusercontent.com/59305253/183676372-2809a020-7695-428e-b922-4b725d9244e7.mov




After

https://user-images.githubusercontent.com/59305253/183676363-17c28c4b-959b-4596-be6f-abd4d72c8351.mov

