### PR TITLE
Ignore more directories during pytest discovery

### DIFF
--- a/web/setup.cfg
+++ b/web/setup.cfg
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE = config.settings.settings_pytest
 addopts = --doctest-modules --nomigrations
 # these options can be used for faster test discovery if necessary:
 # testpaths = main/tests
-norecursedirs = node_modules static
+norecursedirs = node_modules static .mypy_cache frontend config
 
 ## http://flake8.pycqa.org/en/latest/user/configuration.html
 [flake8]


### PR DESCRIPTION
This change speeds up test discovery on local machines quite a lot by excluding the large `.mypy_cache` directory, reducing the run time to a third of the previous. It will probably have no major effect on CI runs unless those end up running `mypy` before tests at some point, though it does exclude a few other directories.