### PR TITLE
Collapse/expand all button; fixes #1301

### DIFF
--- a/web/frontend/components/TheTableOfContents.vue
+++ b/web/frontend/components/TheTableOfContents.vue
@@ -5,6 +5,15 @@
         <span class="annotation-icon"></span>
         <p>Click on the content below to start Annotation!</p>
      </div>
+     <button
+        :aria-expanded="!tocCollapsed ? 'true' : 'false'"
+        :aria-label="tocCollapsed ? 'expand all' : 'collapse all'"
+        class="action-expand toc-expand"
+        @click="toggleToc"
+      >
+      <collapse-triangle :collapsed="tocCollapsed" />
+      {{ tocCollapsed ? "Expand all" : "Collapse all" }}
+     </button>
      <vue-nestable v-model="toc"
                    :max-depth="100"
                    :hooks="{'beforeMove':canMove}"
@@ -31,6 +40,8 @@ import _ from "lodash";
 import { VueNestable } from "@holtchesley/vue-nestable";
 import Placeholder from "./TableOfContents/PlaceHolder";
 import Entry from "./TableOfContents/Entry";
+import CollapseTriangle from "./CollapseTriangle";
+
 import { createNamespacedHelpers } from "vuex";
 const { mapActions, mapMutations } = createNamespacedHelpers(
   "table_of_contents"
@@ -40,7 +51,8 @@ export default {
   components: {
     VueNestable,
     Placeholder,
-    Entry
+    Entry,
+    CollapseTriangle,
   },
   data: () => ({
     needsDeleteConfirmation: {}
@@ -166,7 +178,28 @@ export default {
         parent,
         index
       });
-    }
+    },
+    collapseToc() {
+      const ids = this.$store.getters["table_of_contents/openNodes"](
+        this.rootNode
+      );
+      this.$store.dispatch("table_of_contents/collapseAll", { ids });
+    },
+    expandToc() {
+      const ids = this.$store.getters["table_of_contents/collapsedNodes"](
+        this.rootNode
+      );
+      this.$store.dispatch("table_of_contents/expandAll", { ids });
+    },
+    toggleToc() {
+      if (this.tocCollapsed) {
+        this.tocCollapsed = false;
+        this.expandToc();
+      } else {
+        this.tocCollapsed = true;
+        this.collapseToc();
+      }
+    },
   },
   props: ["editing", "rootOrdinals","verified_professor"],
   created: function() {
@@ -220,6 +253,20 @@ export default {
         border: 0 solid transparent;
         background: transparent;
         margin: -8px;
+    }
+    button.toc-expand {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 10px 0 10px -5px;
+        padding: 0;
+        font-weight: bold;
+
+        svg polygon {
+          fill: $light-blue;
+          stroke: transparent;
+        }
+
     }
     .no-collapse-padded {
         width: 32px;

--- a/web/frontend/store/modules/table_of_contents.js
+++ b/web/frontend/store/modules/table_of_contents.js
@@ -90,6 +90,15 @@ const helpers = {
         }
         return helpers.flatFilter(toc[casebook], isCollapsed).map(node => node.id);
     },
+    openIDs: (toc, casebook) => {
+        function isOpen(node) {
+          return !node.collapsed;
+        }
+        if (!(casebook in toc)) {
+          return [];
+        }
+        return helpers.flatFilter(toc[casebook], isOpen).map((node) => node.id);
+    },
     augmentNode,
     augmentNodes: (tree, augments) => {
         const base = {};
@@ -105,7 +114,9 @@ const helpers = {
 const getters = {
     getNode: state => (id) => helpers.findNode(state.toc, id),
     auditTargets: state => (casebook) => helpers.auditIDs(state.toc, casebook),
-    collapsedNodes: state => (casebook) => helpers.collapsedIDs(state.toc, casebook)
+    collapsedNodes: state => (casebook) => helpers.collapsedIDs(state.toc, casebook),
+    openNodes: (state) => (casebook) => helpers.openIDs(state.toc, casebook),
+
 };
 
 const collapseNode = (node) => helpers.addCSSClass('collapsed')(helpers.addFlag('collapsed')(node));
@@ -181,6 +192,22 @@ const actions = {
             modifyFn: (node) => _.get(node, 'collapsed', false) ? expandNode(node) : collapseNode(node)
         });
     },
+    collapseAll: ({ commit }, { ids }) => {
+        ids.forEach((id) => {
+          commit("modifyAugment", {
+            id,
+            modifyFn: collapseNode,
+          });
+        });
+      },
+      expandAll: ({ commit }, { ids }) => {
+        ids.forEach((id) => {
+          commit("modifyAugment", {
+            id,
+            modifyFn: expandNode,
+          });
+        });
+      },
     setAudit: ({ commit, state }, { id }) => {
         let currentAudits = _.keys(state.augments).filter(k => _.get(state.augments[k], 'audit', false)).map(parseInt);
         commit('modifyAugment', { ids: currentAudits, modifyFn: removeAudit });


### PR DESCRIPTION
Adds a button to collapse or expand all sections on the page.

https://user-images.githubusercontent.com/19571/185229576-0a5fb173-418d-4d4f-a8f5-0fb70ff8c099.mov

Works with keyboard navigation and looks okay on a small viewport.

