### PR TITLE
Collapse sections in casebook TOC more efficiently

### DIFF
--- a/web/frontend/components/TheTableOfContents.vue
+++ b/web/frontend/components/TheTableOfContents.vue
@@ -55,7 +55,8 @@ export default {
     CollapseTriangle,
   },
   data: () => ({
-    needsDeleteConfirmation: {}
+    needsDeleteConfirmation: {},
+    tocCollapsed: false
   }),
   directives: {
     focus: {
@@ -180,13 +181,13 @@ export default {
       });
     },
     collapseToc() {
-      const ids = this.$store.getters["table_of_contents/openNodes"](
+      const ids = this.$store.getters["table_of_contents/topLevelNodes"](
         this.rootNode
       );
       this.$store.dispatch("table_of_contents/collapseAll", { ids });
     },
     expandToc() {
-      const ids = this.$store.getters["table_of_contents/collapsedNodes"](
+      const ids = this.$store.getters["table_of_contents/topLevelNodes"](
         this.rootNode
       );
       this.$store.dispatch("table_of_contents/expandAll", { ids });

--- a/web/frontend/store/modules/table_of_contents.js
+++ b/web/frontend/store/modules/table_of_contents.js
@@ -99,6 +99,12 @@ const helpers = {
         }
         return helpers.flatFilter(toc[casebook], isOpen).map((node) => node.id);
     },
+    topLevelIDs: (toc, casebook) => {
+        if (!(casebook in toc)) {
+          return [];
+        }
+        return toc[casebook].children.map((node) => node.id);
+    },
     augmentNode,
     augmentNodes: (tree, augments) => {
         const base = {};
@@ -116,12 +122,12 @@ const getters = {
     auditTargets: state => (casebook) => helpers.auditIDs(state.toc, casebook),
     collapsedNodes: state => (casebook) => helpers.collapsedIDs(state.toc, casebook),
     openNodes: (state) => (casebook) => helpers.openIDs(state.toc, casebook),
+    topLevelNodes: (state) => (casebook) => helpers.topLevelIDs(state.toc, casebook),
 
 };
 
 const collapseNode = (node) => helpers.addCSSClass('collapsed')(helpers.addFlag('collapsed')(node));
 const expandNode = (node) => helpers.removeCSSClass('collapsed')(helpers.removeFlag('collapsed')(node));
-//const setLoading = helpers.addFlag('loading');
 const setLoaded = (node) => helpers.removeCSSClass('loading')(helpers.addCSSClass('loaded')(node));
 const setAudit = helpers.addFlag('audit');
 const removeAudit = helpers.removeFlag('audit');
@@ -193,21 +199,17 @@ const actions = {
         });
     },
     collapseAll: ({ commit }, { ids }) => {
-        ids.forEach((id) => {
-          commit("modifyAugment", {
-            id,
+        commit("modifyAugment", {
+            ids,
             modifyFn: collapseNode,
-          });
         });
-      },
-      expandAll: ({ commit }, { ids }) => {
-        ids.forEach((id) => {
-          commit("modifyAugment", {
-            id,
+    },
+    expandAll: ({ commit }, { ids }) => {
+        commit("modifyAugment", {
+            ids,
             modifyFn: expandNode,
-          });
         });
-      },
+    },
     setAudit: ({ commit, state }, { id }) => {
         let currentAudits = _.keys(state.augments).filter(k => _.get(state.augments[k], 'audit', false)).map(parseInt);
         commit('modifyAugment', { ids: currentAudits, modifyFn: removeAudit });


### PR DESCRIPTION
Two optimizations to speed up the expand/collapse toggle for large casebooks or slower machines:

* Only selects top-level nodes rather than all descendant nodes
* Performs the mutation in a single transaction batch rather than one-by-one

Tested with Chrome dev tools on CPU mode "6X slower"—it's faster for sure.

If users really want all nodes collapsed it's easy to switch out to the earlier behavior, but top-level nodes will always be more performant, so starting from there.

(Also corrects a dropped property, probably a merge victim.)

fixes #1721

https://user-images.githubusercontent.com/19571/185490372-a5eb6f57-a81e-4a6c-8a68-855b8c0861fb.mov


