### PR TITLE
Some type corrections and mypy config

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -3591,7 +3591,7 @@ class Casebook(EditTrackedModel, TimestampedModel, BigPkModel, TrackedCloneable)
     def get_slug(self):
         return slugify(self.title)
 
-    def viewable_by(self, user: User):
+    def viewable_by(self, user: Union[User, AnonymousUser]):
         if (not (self.is_archived or self.is_previous_save)) and (
             self.is_public or user.is_superuser
         ):

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -64,6 +64,7 @@ from .models import (
     ContentAnnotation,
     ContentCollaborator,
     ContentNode,
+    ContentNodeQuerySet,
     LegalDocument,
     LegalDocumentSource,
     Link,
@@ -1775,7 +1776,7 @@ def edit_casebook(request, casebook: Casebook):
         form = form_class(instance=casebook)
 
     casebook.contents.prefetch_resources()
-    search_sources = LegalDocumentSource.objects
+    search_sources = LegalDocumentSource.objects.all()
     if not (request.user and request.user.is_superuser):
         search_sources = search_sources.filter(active=True)
     doc_sources = list(search_sources.order_by("priority").all())
@@ -2894,7 +2895,7 @@ def as_printable_html(request: HttpRequest, casebook: Casebook, page=1):
     if not LiveSettings.load().enable_printable_html_export:
         return HttpResponseForbidden("This feature is not currently enabled")
 
-    children: ContentNode = casebook.children
+    children: ContentNodeQuerySet = casebook.children
 
     logger.info(f"Exporting Casebook {casebook.id}, starting from page {page}: serializing to HTML")
 

--- a/web/setup.cfg
+++ b/web/setup.cfg
@@ -25,6 +25,8 @@ builtins = getfixture
 
 ## https://mypy.readthedocs.io/en/stable/config_file.html
 [mypy]
+mypy_path = web
+files = .
 ignore_missing_imports = true
 allow_untyped_globals = true
 # (2022-07-18) lots of work needs to be done before this works


### PR DESCRIPTION
Fix up some types (`mypy` now passes 100% for me) and add some config that makes it easier for local editors to discover the right files (a lot of default configurations don't work with the source code in a subdirectory like this).

I tried to upgrade `mypy` here per #1701 but `django-stubs` isn't yet compatible, so that should wait.