### PR TITLE
Ensure that does_display_ordinals must track instructional content; fixes #1725

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -440,6 +440,7 @@ class ContentNodeAdmin(BaseAdmin, SimpleHistoryAdmin):
         "headnote",
         "created_at",
         "updated_at",
+        "does_display_ordinals",
         "is_instructional_material",
     ]
     raw_id_fields = ["casebook"]
@@ -464,6 +465,17 @@ class ContentNodeAdmin(BaseAdmin, SimpleHistoryAdmin):
 
     def annotation_count(self, obj):
         return "n/a" if obj.is_annotated == "Link" else obj.annotations_count
+
+    def save_model(self, request, obj, form, *args, **kwargs):
+        """If either of the node-numbering options have been toggled this session, update the
+        content tree for the whole casebook"""
+        super().save_model(request, obj, form, *args, **kwargs)
+
+        if (
+            "is_instructional_material" in form.cleaned_data
+            or "does_display_ordinals" in form.cleaned_data
+        ):
+            obj.casebook.content_tree__repair()
 
 
 class ResourceAdmin(BaseAdmin, SimpleHistoryAdmin):

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1554,6 +1554,17 @@ class MaterializedPathTreeMixin(models.Model):
         help_text="Whether this node will display its section number",
     )
 
+    def save(self, *args, **kwargs):
+        """If this node is instructional, it cannot display ordinals. Callers should
+        call content_tree__repair() on the casebook any place this can be toggled."""
+        if (
+            hasattr(self, "is_instructional_material")
+            and self.is_instructional_material
+            and self.does_display_ordinals
+        ):
+            self.does_display_ordinals = False
+        super().save(*args, **kwargs)
+
     ##
     # Content tree methods
     ##


### PR DESCRIPTION
Enforces that if `is_instructional_material` is true, the node can never be marked as appearing in the ordinal list. This is to ensure that students and non-professors never see skipped ordinal numbers in TOCs or book content.

This does _not_ always renumber the casebook following such a change. I adopted the convention already in the code that `content_tree__repair()` is not called automatically on model `save()`, presumably because it's expensive, or we may be mid-update? 

I think the only two places users will be able to toggle `is_instructional_material` will be on the frontend edit page for a resource (still TODO) and the Django admin. This PR causes renumbering to happen after such an edit in the admin; when I add the frontend toggle, I'll ensure that repair is called only when necessary.

There are other ways this could be implemented that would be more centralized—for example `ContentNode.save()` could fire off a `post_save()` Django signal and renumber the casebook. But we don't otherwise use signals in this repository and they can be hard to reason about. Open to other options!