### PR TITLE
Use a different webpack file in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ python-shell.sh
 *.iml
 .vscode
 .mypy_cache
+
+# Dev-only webpack stats
+web/.webpack-stats-dev.json

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -40,3 +40,10 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 ADMINS = [("John", "john@example.com"), ("Mary", "mary@example.com")]
 
 LOGGING["loggers"]["main"] = {"level": "DEBUG", "handlers": ["console", "file"]}
+
+WEBPACK_LOADER = {
+    "DEFAULT": {
+        "BUNDLE_DIR_NAME": "dist/",
+        "STATS_FILE": os.path.join(BASE_DIR, ".webpack-stats-dev.json"),
+    }
+}

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -59,7 +59,7 @@ let vueConfig = {
         : [
             new RelativeBundleTracker({
               // output location of bundles so they can be found by django
-              filename: "./webpack-stats.json",
+              filename: devMode ? "./.webpack-stats-dev.json" : "./webpack-stats.json",
             }),
           ]
     ),


### PR DESCRIPTION
It's annoying to have to deal with conflicts or upstream changes in `webpack-stats.json`, or to have to stash it every time you pull from upstream.

This change switches to using a different file in dev mode, which is added to `.gitignore`.

Works locally, though I'm not otherwise sure how to test other than to try it in CI/staging.