### PR TITLE
Search inside should check the permissions of the results; fixes #1724

### DIFF
--- a/web/main/create_fts_index.sql
+++ b/web/main/create_fts_index.sql
@@ -1,7 +1,7 @@
 DROP MATERIALIZED VIEW IF EXISTS tmp_fts_search_view;
 DROP MATERIALIZED VIEW IF EXISTS tmp_fts_internal_search_view;
 CREATE MATERIALIZED VIEW tmp_fts_internal_search_view AS
-    -- seperate category for full-text search
+    -- separate category for full-text search of legal documents
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            c.id AS result_id,
@@ -20,7 +20,7 @@ CREATE MATERIALIZED VIEW tmp_fts_internal_search_view AS
         main_legaldocument c
     GROUP BY c.id
 UNION ALL
-    -- seperate category for full-text search of textblocks
+    -- separate category for full-text search of textblocks
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            t.id AS result_id,
@@ -33,7 +33,8 @@ UNION ALL
                'name', t.name,
                'description', t.description,
                'ordinals', array_to_string(cn.ordinals, '.'),
-               'casebook_id', cn.casebook_id
+               'casebook_id', cn.casebook_id,
+               'is_instructional_material', cn.is_instructional_material
            ) AS metadata,
            'textblock'::text AS category
     FROM
@@ -41,7 +42,7 @@ UNION ALL
         INNER JOIN main_contentnode cn ON cn.resource_id = t.id AND cn.resource_type = 'TextBlock'
     GROUP BY t.id, cn.id
 UNION ALL
-    -- seperate category for searching through links
+    -- separate category for searching through links
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            l.id AS result_id,

--- a/web/main/test/test_search.py
+++ b/web/main/test/test_search.py
@@ -1,0 +1,46 @@
+from cgitb import reset
+from django.urls import reverse
+from test.test_helpers import check_response
+
+from main.models import ContentNode, FullTextSearchIndex, TextBlock
+
+
+def test_search_inside_default(full_casebook, client):
+    """Search inside should match legal documents by default"""
+    legal_documents = ContentNode.objects.filter(
+        casebook=full_casebook, resource_type="LegalDocument"
+    )
+    FullTextSearchIndex().create_search_index()
+    url = reverse("casebook_search", kwargs={"casebook_param": full_casebook})
+
+    titles = [d.title for d in legal_documents]
+    assert len(titles) > 0
+    check_response(client.get(url), content_includes=titles)
+    check_response(client.get(url, kwargs={"type": "legal_doc_fulltext"}), content_includes=titles)
+
+
+def test_search_inside_text_passages(full_casebook, client):
+    """Search inside should match text passages in the correct tab"""
+    text_blocks = TextBlock.objects.filter(
+        id__in=ContentNode.objects.filter(
+            casebook=full_casebook, resource_type="TextBlock"
+        ).values_list("resource_id", flat=True)
+    )
+    text_blocks[0].content = "Unique content"
+    text_blocks[0].save()
+
+    FullTextSearchIndex().create_search_index()
+    url = reverse("casebook_search", kwargs={"casebook_param": full_casebook})
+
+    titles = [d.name for d in text_blocks]
+    assert len(titles) > 0
+
+    # Search for all text blocks
+    search_result = client.get(url, {"type": "textblock", "q": ""})
+    assert len(titles) == len(search_result.context["results"])
+    check_response(search_result, content_includes=titles)
+
+    # Search for a specific text block
+    search_result = client.get(url, {"type": "textblock", "q": text_blocks[0].content})
+    assert 1 == len(search_result.context["results"])
+    assert text_blocks[0].name in [r.metadata["name"] for r in search_result.context["results"]]

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3265,27 +3265,10 @@ casebook_search_categories = set(("legal_doc_fulltext", "textblock", "link"))
 @hydrate_params
 def casebook_search(request, casebook):
     """
-    Search content of a specific casebook. Currently only searches legal docs.
+    Search full-text content of a specific casebook.
 
-        Given:
-        >>> _, legal_document_factory, casebook_factory, content_node_factory = [getfixture(i) for i in ['reset_sequences', 'legal_document_factory', 'casebook_factory', 'content_node_factory']]
-        >>> capapi_mock, client = [getfixture(i) for i in ['capapi_mock', 'client']]
-        >>> casebooks = [casebook_factory() for i in range(3)]
-        >>> nodes = [content_node_factory() for i in range(3)]
-        >>> docs = [legal_document_factory() for i in range(3)]
-        >>> for d, n in zip(docs, nodes):
-        ...     n.resource_type = 'LegalDocument'
-        ...     n.resource_id = d.id
-        ...     n.casebook_id = casebooks[0].id
-        ...     n.ordinals = [1, 1]
-        ...     n.save()
-        >>> FullTextSearchIndex().create_search_index()
-        >>> url = reverse('casebook_search', args=[casebooks[0].id])
-
-    Show all legal documents by default:
-    >>> check_response(client.get(url), content_includes=[d.name for d in docs])
+    See test/test_search.py
     """
-    # read query parameters
     try:
         page = int(request.GET.get("page"))
     except (TypeError, ValueError):
@@ -3300,7 +3283,6 @@ def casebook_search(request, casebook):
         category,
         page=page,
         query_str=query,
-        # order_by=request.GET.get('sort')
     )
     results.from_capapi = False
     return render(


### PR DESCRIPTION
Adds the `is_instructional_material` flag for textnodes to the full-text search index, and then filters on those if the user is not a verified professor. 

* Centralizes the permission check on the user for whether they can view instructional material. Currently it's just whether they're a verified professor. 
* To make the search API consistent, all content types expose `is_instructional_material` because that is part of the `ContentNode` model, but only `TextBlocks` will actually have the flag set, so we can save having to join on `ContentNode` for legal documents (it vastly increases the search indexing time), and links make no sense in this context. Those two resource types are always `is_instructional_material=False` in the search index.
* I moved the search tests out of doc tests and into their own test module since they were long and duplicative of each other. 

## Deployment note

This requires that `fab create_fts_index` be run at deployment time; until it completes and adds the new field, "search inside" will error. I can't really think of a way around this besides maybe some intermediate step that adds the new field to the index, unpopulated, without actually reindexing the content, but possibly that's more fragile than it's worth?

