### PR TITLE
Add missing call to create publish_check object; fixes #1734

### DIFF
--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2656,6 +2656,15 @@ def annotate_resource(request, casebook, resource):
             "editing": True,
             "edit_mode": True,
             "body_json": body_json,
+            "publish_check": json.dumps(
+                {
+                    "isVerifiedProfessor": request.user.is_authenticated
+                    and request.user.verified_professor,
+                    "coverImageFlag": settings.COVER_IMAGES,
+                    "coverImageExists": bool(casebook.cover_image),  # Handling both blank and None
+                    "descriptionExists": bool(casebook.description),
+                }
+            ),
         },
     )
 


### PR DESCRIPTION
The error in the ticket is coming from a complex object being passed down to `action_buttons.html`; though this code is a bit fragile, I think this is the one view that uses that include that wasn't populating `publish_check` in the template context. This eliminates the error for me locally.