### PR TITLE
Search inside should check the permissions of the results; fixes #1724

### DIFF
--- a/web/conftest.py
+++ b/web/conftest.py
@@ -587,6 +587,7 @@ def full_casebook_parts_with_prof_only_resource(full_casebook_parts_factory):
     parts: list[ContentNode] = full_casebook_parts_factory(user=prof)
     parts[3].is_instructional_material = True
     parts[3].title = "Instructional material"
+    parts[3].resource.name = "Instructional material"
     parts[3].resource.content = "This is instructional material"
     parts[3].resource.save()
     parts[3].save()

--- a/web/main/test/test_search.py
+++ b/web/main/test/test_search.py
@@ -1,0 +1,69 @@
+from test.test_helpers import check_response
+
+import pytest
+from conftest import UserFactory, VerifiedProfessorFactory
+from django.urls import reverse
+from main.models import ContentNode, FullTextSearchIndex, Link, TextBlock
+
+
+def test_search_inside_default(full_casebook, client):
+    """Search inside should match legal documents by default"""
+    legal_documents = ContentNode.objects.filter(
+        casebook=full_casebook, resource_type="LegalDocument"
+    )
+    FullTextSearchIndex().create_search_index()
+    url = reverse("casebook_search", kwargs={"casebook_param": full_casebook})
+
+    titles = [d.title for d in legal_documents]
+    assert len(titles) > 0
+    check_response(client.get(url), content_includes=titles)
+    check_response(client.get(url, {"type": "legal_doc_fulltext"}), content_includes=titles)
+
+
+@pytest.mark.parametrize("resource_type,resource_class", [["Link", Link], ["TextBlock", TextBlock]])
+def test_search_inside_resource(full_casebook, client, resource_type, resource_class):
+    """Search inside should match resource titles in the correct tab"""
+    resources = resource_class.objects.filter(
+        id__in=ContentNode.objects.filter(
+            casebook=full_casebook, resource_type=resource_type
+        ).values_list("resource_id", flat=True)
+    )
+    FullTextSearchIndex().create_search_index()
+    url = reverse("casebook_search", kwargs={"casebook_param": full_casebook})
+
+    titles = [d.name for d in resources]
+    assert len(titles) > 0
+
+    # Search for all text blocks
+    search_result = client.get(url, {"type": resource_type.lower(), "q": ""})
+    assert len(titles) == len(search_result.context["results"])
+    check_response(search_result, content_includes=titles)
+
+    # Search for a specific text block
+    search_result = client.get(url, {"type": resource_type.lower(), "q": resources[0].name})
+    assert 1 == len(search_result.context["results"])
+    assert resources[0].name in [r.metadata["name"] for r in search_result.context["results"]]
+
+
+@pytest.mark.parametrize(
+    "user_factory_class,results_count",
+    [[VerifiedProfessorFactory, 1], [UserFactory, 0], [lambda: None, 0]],
+)
+def test_search_inside_prof_only(
+    full_casebook, resource_factory, client, user_factory_class, results_count
+):
+    """Full-text search should show results with professor-only content only if the user is a professor"""
+
+    user = user_factory_class()
+    prof_only: ContentNode = resource_factory(
+        casebook=full_casebook,
+        resource_type="TextBlock",
+    )
+    prof_only.is_instructional_material = True
+    prof_only.save()
+    full_casebook.content_tree__repair()  # `reverse` in the results template wants valid ordinals to construct a URL
+
+    FullTextSearchIndex().create_search_index()
+    url = reverse("casebook_search", kwargs={"casebook_param": full_casebook})
+    search_result = client.get(url, {"type": "textblock", "q": prof_only.title}, as_user=user)
+    assert results_count == len(search_result.context["results"])


### PR DESCRIPTION
Adds the `is_instructional_material` flag for textnodes to the full-text search index, and then filters on those if the user is not a verified professor. 

* Centralizes the permission check on the user for whether they can view instructional material. Currently it's just whether they're a verified professor. 
* To make the search API consistent, all content types expose `is_instructional_material` because that is part of the `ContentNode` model, but only `TextBlocks` will actually have the flag set, so we can save having to join on `ContentNode` for legal documents (it vastly increases the search indexing time), and links make no sense in this context. Those two resource types are always `is_instructional_material=False` in the search index.
* I moved the search tests out of doc tests and into their own test module since they were long and duplicative of each other. 

User on the left is a professor; user on the right is not:

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/19571/186473867-defed88a-d387-432f-ad58-cd3fb193c35c.png">

## Deployment note

This requires that `fab create_fts_index` be run at deployment time; until it completes and adds the new field, "search inside" will error. I can't really think of a way around this besides maybe some intermediate step that adds the new field to the index, unpopulated, without actually reindexing the content, but possibly that's more fragile than it's worth?

