### PR TITLE
Add front-end button for marking a resource as instructional material

### DIFF
--- a/web/main/forms.py
+++ b/web/main/forms.py
@@ -209,9 +209,6 @@ class ResourceForm(ContentNodeForm):
         )
         self.helper.form_class = "edit_content_resource"
 
-    def clean(self):
-        pass
-
     def save(self, commit=True):
         cn = self.instance
         # null reading_length so it can be recalculated later

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2551,7 +2551,7 @@ def edit_resource(request, casebook, resource):
     """
     if not (resource.is_resource or resource.is_temporary):
         return HttpResponseRedirect(reverse("edit_section", args=[casebook, resource]))
-    form = ResourceForm(request.POST or None, instance=resource)
+    form = ResourceForm(request.POST or None, instance=resource, request=request)
 
     # Let users edit Link and TextBlock resources directly from this page
     embedded_resource_form = None
@@ -2568,6 +2568,9 @@ def edit_resource(request, casebook, resource):
                 form.save()
                 resource.resource.refresh_from_db()
                 resource.refresh_from_db()
+                form = ResourceForm(
+                    instance=resource, request=request
+                )  # workaround for no redirect-after-post
             else:
                 return server_error(request)
         else:


### PR DESCRIPTION

Adds a front-end button to mark instructional material.

The toggle effectively applies only to TextBlock resources, but is on the parent `ContentNode` model, so there's some extra checking here before showing the toggle. The toggle is only rendered to verified professors.

There's a very simple `onclick` handler to indicate to users that instructional material will not be numbered; this is enforced on the backend on save from a prior PR.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/19571/186486861-cb42f879-134f-4153-9c4c-64c50a49ecf4.png">
