### PR TITLE
Add some styles from CAP css and adapt it for print layout

### DIFF
--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -5,12 +5,13 @@
 
   @font-face {
     font-family: 'LibreCaslon';
-    src:  url('../fonts/LibreCaslonText-Regular.woff2') format('woff2');
+    src: url('../fonts/LibreCaslonText-Regular.woff2') format('woff2');
     font-weight: normal;
   }
+
   @font-face {
     font-family: 'LibreCaslon';
-    src:  url('../fonts/LibreCaslonText-Italic.woff2') format('woff2');
+    src: url('../fonts/LibreCaslonText-Italic.woff2') format('woff2');
     font-style: italic;
   }
 
@@ -44,7 +45,9 @@
 
   }
 
-  span, p, div {
+  span,
+  p,
+  div {
     font-size: var(--casebook-font-size) !important;
     line-height: var(--casebook-line-height) !important;
     font-family: var(--casebook-font-family), serif !important;
@@ -118,7 +121,7 @@
     background-size: cover;
   }
 
-  .link-icon+.node-container {
+  .link-icon + .node-container {
     margin-left: 14mm;
   }
 
@@ -141,13 +144,23 @@
     padding: 0;
   }
 
-  section.depth-1 p:first-child {
-    margin-top: 4em !important;
+  section.depth-1 {
+    padding: 4em;
   }
+
+  section.depth-2.legaldocument {
+    break-before: page;
+  }
+
+  section.depth-2 {
+    padding: 2em;
+  }
+
   sup {
     font-size: calc(var(--casebook-font-size) / 2.5);
 
   }
+
   @page {
     @bottom-right {
       content: counter(page);

--- a/web/static/as_printable_html/cap.css
+++ b/web/static/as_printable_html/cap.css
@@ -1,13 +1,79 @@
+/* Cap-specific style */
 
-  /* Cap-specific style */
+.legaldocument sup {
+  font-size: calc(var(--casebook-font-size) * .75);
+}
 
-  /* TODO something about footnotes */
-  .footnote p,
-  .footnote blockquote {
-    margin-left: 13px;
-  }
+/* Add some breathing room after internal footnotes */
+.legaldocument a[href^="#"] {
+  margin-right: .25em;
+}
 
-  .footnotemark {
-    font-size: calc(var(--casebook-font-size) / 2);
-    vertical-align: super;
-  }
+.footnote p,
+.footnote blockquote {
+  margin-left: 13px;
+}
+
+.footnotemark {
+  font-size: calc(var(--casebook-font-size) / 2);
+  vertical-align: super;
+}
+
+
+header.case-header .title,
+header.case-header .citation,
+header.case-header .decisiondate,
+header.case-header .docketnumber,
+header.case-header .court {
+  text-align: center;
+}
+
+header.case-header .citation,
+header.case-header .decisiondate,
+header.case-header .docketnumber,
+header.case-header .court {
+  letter-spacing: 1px;
+  padding: 4px;
+}
+
+header.case-header .court {
+  font-size: 24px;
+}
+
+header.case-header .citation,
+header.case-header .decisiondate,
+header.case-header .docketnumber {
+  font-size: 18px;
+}
+
+header.case-header .title {
+  font-weight: bold;
+  font-size: calc(var(--casebook-font-size) * 1.5) !important;
+  line-height: 1.4em !important;
+  padding: 20px 4px 10px 4px;
+
+}
+
+.case-text .parties,
+.case-text .decisiondate,
+.case-text .docketnumber,
+.case-text .citations,
+.case-text .syllabus,
+.case-text .synopsis,
+.case-text .court {
+  display: none;
+}
+
+.case-text .page-label {
+  display: none;
+}
+
+.case-text aside.footnote > a {
+  float: left;
+}
+
+.case-text img {
+  max-width: 100%;
+  width: auto;
+  height: auto;
+}


### PR DESCRIPTION
Port over some of the SCSS from the website used for CAP to the plain CSS used in the printable HTML view (it's plain CSS because it doesn't go through the bundling process).

Generally this is an easier problem for the print CSS than for the Word layout because the styles are either just re-expressions of what's on the website, or expressions of the native markup in the CAP HTML. 

For example, in the Word doc, footnote text is the same size as the body text, but it's `<small>` in the HTML, and so the website and the printable view both display footnote-sized content:

**Word**

<img width="596" alt="image" src="https://user-images.githubusercontent.com/19571/189992777-391cf848-c565-47f8-ab42-bfe87863e8b4.png" >

**Printable HTML**

<img width="635" alt="image" src="https://user-images.githubusercontent.com/19571/189992922-bd216855-6e57-40ea-9e97-771c2548ada5.png">

Similarly the text-indent seen here is from repeated `&nbsp;`s in the source; we filter that out in the Word export but not on the website. I think I'll want to filter it and then just replace it with CSS indent, because the indent is expected in print layout but we'd want to apply it consistently across all content.

Finally, I made an editorial call here to start all cases on new pages (unlike the Word version).