### PR TITLE
Interpolate MATOMO_API values and handle when no data is available

### DIFF
--- a/web/main/templates/includes/analytics.html
+++ b/web/main/templates/includes/analytics.html
@@ -1,6 +1,5 @@
 {% if USE_ANALYTICS %}
 {# Ensure that MATOMO_SITE_ID and MATOMO_SITE_URL are both set for this environment #}
-{% verbatim %}
     <script>
       var _gaq = [];
       var _paq = _paq || [];
@@ -15,5 +14,4 @@
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
-  {% endverbatim %}
 {% endif %}

--- a/web/reporting/matomo.py
+++ b/web/reporting/matomo.py
@@ -104,6 +104,12 @@ def api(
         logger.error(resp.content)
         return web_usage
 
+    if len(data) == 0:
+        web_usage.status = "The Matomo API did not report any data for this period"
+        logger.error(web_usage.status)
+        logger.error(params)
+        return web_usage
+
     if "message" in data:
         web_usage.status = data["message"]
         logger.error(web_usage.status)


### PR DESCRIPTION
Part of enabling the Matomo API reporting feature was templatizing the location and site ID for our Matomo instance, which probably didn't belong hard-coded in the source of the page.

Unfortunately I missed realizing that this was all wrapped in a `{% verbatim %}` template tag, which prevents interpolation (probably originally to guard against javascript syntax and Django template syntax colliding). 

I didn't notice the problem because we were always looking at backwards-facing reporting, which still existed, but data collection did not continue from that point.

This PR removes the template tag and restores interpolation of the site ID and URL. I enabled analytics locally and verified that it looked right, but we only fully have it enabled in prod, so I'll triple-check that it's correct there once this goes live.

Here's what it looks like locally now:

```
    <script>
      var _gaq = [];
      var _paq = _paq || [];
      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
      _paq.push(['trackPageView']);
      _paq.push(['enableLinkTracking']);
      (function() {
      var u="https://analytics.lil.tools/";
      _paq.push(['setTrackerUrl', u+'piwik.php']);
      _paq.push(['setSiteId', '3']);
      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
      })();
    </script>
```
and I verified in the network console that requests were going through:

```
Request URL: https://analytics.lil.tools/piwik.php?action_name=Open%20Casebooks%20%7C%20H2O&idsite=3&rec=1&r=684123&h=9&m=47&s=4&url=http%3A%2F%2Fopencasebook.test%3A8000%2F&_id=52b39d9691ea813d&_idn=0&send_image=0&_refts=0&pdf=1&qt=0&realp=0&wma=0&fla=0&java=0&ag=0&cookie=1&res=1792x1120&pv_id=OZx9c4&pf_net=0&pf_srv=48&pf_tfr=1&pf_dm1=273
Request Method: POST
Status Code: 204 
```

Also in this PR, it will gracefully handle when Matomo has no data to report, so the dashboard page will work again:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/19571/190172073-3d683837-254c-486a-a46a-5813342bfaee.png">



fixes #1755, #1736