### PR TITLE
Strip `nbsp;` from content using a template tag; improvements to running heads and other markup

### DIFF
--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -1,5 +1,4 @@
-{% load call_method %}
-
+{% load call_method string_strip %}
 
 
 <section class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
@@ -60,6 +59,7 @@
 
     {% elif node.is_resource %}  {# case or textblock #}
 
+      {# TODO understand what is going on here #}
       {# Duplicated in the link block because headnotes should go below a link but above cases and text blocks #}
       {% if node.headnote %}
         <section class="headnote">{{ node.headnote_for_export }}</section>
@@ -67,19 +67,16 @@
 
       <section class="resource">
 
-        {% if include_annotations %}
-          {% call_method node 'annotated_content_for_export' export_options=export_options as contents %}
+        {# TODO adapt annotation methods for printable HTML #}
+        {% call_method node 'annotated_content_for_export' export_options=export_options as contents %}
 
-          {{ contents }}
+        {# Strip out any manual whitespace, and mark the output as safe because this operation should not result in broken HTML #}
+        {{ contents|string_strip:"&nbsp;"|safe }}
 
-          {% call_method node 'footnote_annotations' export_options=export_options as footnote_contents %}
-          <div class="footnote">{{ footnote_contents }}</div>
-        {% else %}
+        {# TODO adapt footnote methods for printable HTML #}
+        {% call_method node 'footnote_annotations' export_options=export_options as footnote_contents %}
+        <div class="footnote">{{ footnote_contents }}</div>
 
-        {% call_method node 'content_for_export' export_options=export_options as contents %}
-        {{ contents }}
-
-        {% endif %}
       </section>
     {% endif %}
   {% endif %}

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -4,82 +4,47 @@
 <section class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
 
   {% if node.resource_type == 'Link' %}
-  <div class="link-icon"></div>
+    <div class="link-container">
+      <div class="link-icon"></div>
+
+      <h4 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}.
+        Hyperlink to a web resource
+      </h4>
+
+      <p><a href="{{ node.resource.url }}" target="_blank">{{ node.resource.url }}</a></p>
+    </div>
   {% endif %}
 
   <div class="node-container">
 
-    {% if node.type == 'section' %}
+    <h1 class="{{ node.type }} title">
+      <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
+      {{ node.title }}
+    </h1>
 
-      <h1 class="title">
-        <span class="section ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
-        {{ node.title }}
-      </h1>
+    {% if node.subtitle %}
+      <h2 class="subtitle">{{ node.subtitle }}</h2>
+    {% endif %}
 
-      {% if node.subtitle %}
-        <h2 class="subtitle">{{ node.subtitle }}</h2>
-      {% endif %}
-
-      {% if node.headnote %}
-        {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
-        <section class="headnote" data-custom-style="Section Headnote">{{ headnote }}</section>
-      {% endif %}
-
-    {% elif node.type == 'resource' %}
-
-      {% if node.resource_type == 'Link' %}
-        <span class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}.
-          Hyperlink to a web resource
-        </span>
-        <h1 class="resource title" >{{ node.title }}</h1>
-
-      {% else %}
-        <h1 class="title">
-          <span class="resource ordinal non-link" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
-          {{ node.title }}
-        </h1>
-      {% endif %}
+    {% if node.headnote %}
+      {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
+      <section class="headnote">{{ headnote }}</section>
+    {% endif %}
 
 
-
-      {% if node.subtitle %}
-        <h2 class="subtitle">{{ node.subtitle }}</h2>
-      {% endif %}
-
-      {# I think the headnote should go below a link, but above a resource which is why this block prints headnotes#}
-      {% if node.resource_type == 'Link' %}
-
-      <div class="link-container">
-        <a href="{{ node.resource.url }}" target="_blank">{{ node.resource.url }}</a>
-      </div>
-
-      {% if node.headnote %}
-        <section class="headnote">{{ node.headnote_for_export }}</section>
-      {% endif %}
-
-    {% elif node.is_resource %}  {# case or textblock #}
-
-      {# TODO understand what is going on here #}
-      {# Duplicated in the link block because headnotes should go below a link but above cases and text blocks #}
-      {% if node.headnote %}
-        <section class="headnote">{{ node.headnote_for_export }}</section>
-      {% endif %}
-
+    {% if node.is_resource %}
       <section class="resource">
 
-        {# TODO adapt annotation methods for printable HTML #}
-        {% call_method node 'annotated_content_for_export' export_options=export_options as contents %}
+        {% if node.resource.content %}
+          {% call_method node 'annotated_content_for_export' export_options=export_options as contents %}
+        {% endif %}
 
         {# Strip out any manual whitespace, and mark the output as safe because this operation should not result in broken HTML #}
         {{ contents|string_strip:"&nbsp;"|safe }}
 
-        {# TODO adapt footnote methods for printable HTML #}
-        {% call_method node 'footnote_annotations' export_options=export_options as footnote_contents %}
-        <div class="footnote">{{ footnote_contents }}</div>
-
       </section>
     {% endif %}
-  {% endif %}
   </div>
   </section>
 
+<span class="truncated-title">{{ node.ordinal_string }} {{ node.title|truncatechars:50 }}</span>

--- a/web/main/templatetags/string_strip.py
+++ b/web/main/templatetags/string_strip.py
@@ -1,0 +1,9 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def string_strip(content: str, string_from: str) -> str:
+    "Remove a substring."
+    return content.replace(string_from, "")

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -36,16 +36,14 @@
     break-before: right;
   }
 
+  div,
   span,
   p {
     color: unset !important;
     letter-spacing: unset !important;
-    font-size: unset !important;
-    line-height: unset !important;
-
+    font-family: var(--casebook-font-family), serif !important;
   }
 
-  span,
   p,
   div {
     font-size: var(--casebook-font-size) !important;
@@ -70,7 +68,7 @@
   h6 {
     margin: 10mm 0 0.5em 0;
     font-family: var(--casebook-font-family), serif;
-
+    line-height: 140%;
   }
 
   h1 {
@@ -116,21 +114,24 @@
   section.link {
     margin-top: 10mm;
   }
-
+  .link-container {
+    min-height: 10mm;
+    height: 100%;
+    width: 100%;
+  }
   .link-icon {
     width: 10mm;
     height: 10mm;
-    position: absolute;
     background: url("../images/Link.svg");
     background-size: cover;
+    float: left;
+    padding-right: 5mm;
   }
 
-  .link-icon + .node-container {
-    margin-left: 14mm;
-  }
 
-  h1.title {
+  .truncated-title {
     string-set: title content(text);
+    display: none;
   }
 
   h1.casebook.title {
@@ -161,29 +162,21 @@
 
   }
 
-  @page {
-    @bottom-right {
-      content: counter(page);
-    }
-  }
-
   @page:right {
     @top-center {
       content: string(title);
-      max-width: 100mm;
-      height: 9mm;
+    }
+    @bottom-right {
+      content: counter(page);
     }
   }
   @page:left {
     @top-center {
       content: string(casebook-title);
     }
+    @bottom-left {
+      content: counter(page);
+    }
   }
-  .pagedjs_right_page .pagedjs_margin-top-center .pagedjs_margin-content {
-    text-overflow: ellipsis;
-    line-height: 1em;
-    background: green;
-    max-height: 1em;
 
-  }
 }

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -53,6 +53,11 @@
     font-family: var(--casebook-font-family), serif !important;
   }
 
+  /* Book content (but not metadata or other types) should be indented. */
+  .node-container p {
+    text-indent: 2em;
+  }
+
   h1.casebook.title {
     font-size: 300%;
   }
@@ -63,7 +68,6 @@
   h4,
   h5,
   h6 {
-    line-height: 110%;
     margin: 10mm 0 0.5em 0;
     font-family: var(--casebook-font-family), serif;
 
@@ -129,6 +133,10 @@
     string-set: title content(text);
   }
 
+  h1.casebook.title {
+    string-set: casebook-title content(text);
+  }
+
   .casebook-metadata:not([data-paginator-page="1"]) {
     display: none;
   }
@@ -144,16 +152,8 @@
     padding: 0;
   }
 
-  section.depth-1 {
-    padding: 4em;
-  }
-
   section.depth-2.legaldocument {
     break-before: page;
-  }
-
-  section.depth-2 {
-    padding: 2em;
   }
 
   sup {
@@ -165,9 +165,25 @@
     @bottom-right {
       content: counter(page);
     }
+  }
 
+  @page:right {
     @top-center {
       content: string(title);
+      max-width: 100mm;
+      height: 9mm;
     }
+  }
+  @page:left {
+    @top-center {
+      content: string(casebook-title);
+    }
+  }
+  .pagedjs_right_page .pagedjs_margin-top-center .pagedjs_margin-content {
+    text-overflow: ellipsis;
+    line-height: 1em;
+    background: green;
+    max-height: 1em;
+
   }
 }


### PR DESCRIPTION
Kind of a grab bag here:

* Adds a Django template filter to do a simple string replacement process, so far just for stripping `&nbsp;`s from CAP where it's used for paragraph indenting. I might drop this in the future in favor of replacing the `annotated_content_for_export()` method (which is very pandoc-centered) right now.
* Simplifies the template logic which was originally copied from the pandoc export that varies by resource type, to vary less.
* Changes the behavior of the running head: left side is the book title, right side is the node title.
* Handles truncating the running title in Django—ideally this would be done with `text-overflow: ellipses` but that can't be applied to CSS generated content, which is how Pagedjs handles this. 

Other small CSS tweaks, e.g. moving the page numbers to the outer edge of the recto/verso pages rather than always appearing on the lower right in either case.

**Examples**

Running heads:

<img width="1541" alt="image" src="https://user-images.githubusercontent.com/19571/190484500-b04c45b6-24cc-48ca-a47f-dbc8e7d78cf2.png">

Embedded links are the only resource type that varies now:

<img width="686" alt="image" src="https://user-images.githubusercontent.com/19571/190484811-b1322ba5-9daa-42ab-8ad4-791296a299de.png">
