### PR TITLE
Update collection stats in search to report full list; some type fixes

### DIFF
--- a/web/main/templates/search/show.html
+++ b/web/main/templates/search/show.html
@@ -1,13 +1,15 @@
 {% extends 'base.html' %}
 {% load current_query_string %}
+{% load humanize %}
 
 {% block mainContent %}
   <header class="advanced-search view-searches-show">
     <h1>H2O Casebook Collection</h1>
     {% if counts %}
     <p>
-      Search inside H2O's Collection of {{ counts.casebook|default:"0" }} casebooks, {{ counts.legal_doc|default:"0" }} legal documents, and 
-      {{ counts.user|default:"0" }} authors.
+      Search inside H2O's Collection of {{ full_counts.casebook|intcomma|default:"0" }} casebooks,
+      {{ full_counts.legal_doc|intcomma|default:"0" }} legal documents, and
+      {{ full_counts.user|intcomma|default:"0" }} authors.
     </p>
     {% endif %}
     <form novalidate="novalidate" class="simple_form search" accept-charset="UTF-8">
@@ -32,19 +34,19 @@
 
             <div class="type-tab {% if category == 'casebook' %}active{% endif %}" {% if category == 'casebook' %}aria-current="location"{% endif %}>
               <a href="?{% current_query_string type="casebooks" page=1 %}" class="wrapper">
-                Casebooks ({{ counts.casebook|default:"0" }})
+                Casebooks ({{ counts.casebook|intcomma|default:"0" }})
               </a>
             </div>
 
             <div class="type-tab {% if category == 'legal_doc' %}active{% endif %}" {% if category == 'legal_doc' %}aria-current="location"{% endif %}>
               <a href="?{% current_query_string type="legal_doc" page=1 %}" class="wrapper">
-                Legal Documents ({{ counts.legal_doc|default:"0" }})
+                Legal Documents ({{ counts.legal_doc|intcomma|default:"0" }})
               </a>
             </div>
 
             <div class="type-tab {% if category == 'user' %}active{% endif %}" {% if category == 'user' %}aria-current="location"{% endif %}>
               <a href="?{% current_query_string type="user" page=1 %}" class="wrapper">
-                Authors ({{ counts.user|default:"0" }})
+                Authors ({{ counts.user|intcomma|default:"0" }})
               </a>
             </div>
           </div>
@@ -54,7 +56,7 @@
         {% include 'search/results.html' %}
       {% else %}
         <div class="no-results">
-          <h3>No results found</h3>
+          <h3>No results were found.</h3>
         </div>
       {% endif %}
     </div>

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3233,7 +3233,6 @@ def internal_search(request):
         page = 1
     query = request.GET.get("q")
 
-    # else query postgres:
     filters = {}
     author = request.GET.get("author")
     school = request.GET.get("school")
@@ -3250,13 +3249,17 @@ def internal_search(request):
         facet_fields=["attribution", "affiliation"],
         order_by=request.GET.get("sort"),
     )
+    full_counts = SearchIndex.counts(query=SearchIndex.objects.all())
+
     results.from_capapi = False
+
     return render(
         request,
         "search/show.html",
         {
             "results": results,
             "counts": counts,
+            "full_counts": full_counts,
             "facets": facets,
             "category": category,
         },


### PR DESCRIPTION
Addresses the confusing UI where the messaging at the top reflects the search the user did, which can make it seem like H2O has few documents.

**Before (prod)**

Note: we have more than two authors!

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/19571/191049838-2ea541e8-bdca-4795-84ef-a5dc51b667f8.png">

**After (dev)**

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/19571/191049938-ffc5aa17-3932-4505-bb0d-9b6fffd94006.png">

(The numbers don't match because my local index is behind production by a few weeks.)

While I was there, did some housekeeping on the search method:

* Added types to the parameters
* Removed the default dict and list params ([these aren't safe](https://towardsdatascience.com/python-pitfall-mutable-default-arguments-9385e8265422) though probably wasn't a problem here in practice)
* Added commas to the result numbers 
* Dropped `base_query` as a param; it seemed to have no callers.


fixes ##1759