### PR TITLE
Fix #1738 by calling method, not method name

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -3281,7 +3281,7 @@ class ContentNode(
 
         This method should be implemented by all children.
         """
-        return self.casebook.get_draft_url
+        return self.casebook.get_draft_url()
 
     def get_edit_or_absolute_url(self, editing=False):
         if self.resource_id:


### PR DESCRIPTION
See #1738 for details.

Without this, the "return to draft" button returns a URL like `opencasebook.org/casebooks/1234/<bound method>`. This fixes the issue.