### PR TITLE
Don't offset the action buttons outside the bounding box of the casebook inner section

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -109,7 +109,7 @@ main > header.casebook {
     display: block;
     position: absolute;
     right: percentage((-1.5 / $grid-columns));
-    top: 0;
+    top: 8px;
     width: 12.5%;
     margin: 0;
   }

--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -109,7 +109,7 @@ main > header.casebook {
     display: block;
     position: absolute;
     right: percentage((-1.5 / $grid-columns));
-    top: -40px;
+    top: 0;
     width: 12.5%;
     margin: 0;
   }


### PR DESCRIPTION
Drops the negative top offset for the action buttons which pushes them into the top white area of the casebook page. Adds a positive offset of half the distance between the buttons (16px, halved).

**Before**

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/19571/191287639-26034bd8-9b4e-4d97-961d-6592eef59bb5.png">

**After**
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/19571/191288757-150849ca-cf57-4057-b5c7-eab3983dc001.png">


Does anyone know why this was this way? It [predates the most recent change](https://github.com/harvard-lil/h2o/commit/62176c6b91f8e1d7bd5783643f35a00e8242db52) to this layout to accommodate mobile but I didn't dig back further. This change has no effect on the mobile layout, which doesn't use this selector.

If folks recall this is intentional I can just close this.


