### PR TITLE
Add an indexed ordering field; add casebook display; add filtering by…

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -565,8 +565,6 @@ class AnnotationsAdmin(BaseAdmin, SimpleHistoryAdmin):
     def resource_type(self, obj) -> str:
         return obj.resource.resource_type
 
-    resource_type.admin_order_field = "resource__resource_type"
-
     def casebook(self, obj) -> Casebook:
         return obj.resource.casebook
 

--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -537,29 +537,41 @@ class ResourceAdmin(BaseAdmin, SimpleHistoryAdmin):
 
 
 class AnnotationsAdmin(BaseAdmin, SimpleHistoryAdmin):
-    readonly_fields = ["created_at", "updated_at", "kind"]
+    readonly_fields = ["created_at", "updated_at", "kind", "resource", "casebook"]
     fields = [
         "resource",
+        "casebook",
         ("global_start_offset", "global_end_offset"),
         "kind",
         "content",
         "created_at",
         "updated_at",
     ]
-    list_select_related = ["resource"]
-    list_display = ["id", "resource_type", "resource_id", "kind", "created_at", "updated_at"]
-    list_filter = ["resource__resource_type"]
-    raw_id_fields = ["resource"]
+    list_select_related = ["resource", "resource__casebook"]
+    list_display = [
+        "id",
+        "casebook",
+        "resource",
+        "resource_type",
+        "kind",
+        "created_at",
+        "updated_at",
+    ]
+    list_filter = ["kind", "resource__resource_type"]
 
-    def resource_type(self, obj):
+    # This table isn't ordered on an index by default; use this as a proxy for recency
+    ordering = ("-id",)
+
+    def resource_type(self, obj) -> str:
         return obj.resource.resource_type
 
     resource_type.admin_order_field = "resource__resource_type"
 
-    def resource_id(self, obj):
-        return obj.resource.resource_id
+    def casebook(self, obj) -> Casebook:
+        return obj.resource.casebook
 
-    resource_id.admin_order_field = "resource__resource_id"
+    def resource(self, obj) -> ContentNode:
+        return obj.resource
 
 
 ## Resources


### PR DESCRIPTION
I wanted to find more details on content annotations but the admin was slow (see #1767) and didn't have the filtering and field options necessary to actually track down a specific type of annotation to a specific casebook and resource.

* Explicitly orders on `-id`, an indexed field, which drops the query time for the list page from ~1000ms on my machine to 200ms.
* Adds a filter by "kind", meaning whether the annotation is an elision, note, highlight, etc.
* Adds the casebook title and resource name to the list display
* Adds the casebook title to the detail page

**Before**
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/19571/191333066-9ee8f97b-9597-4d46-9d97-41b27a5ad714.png">

(Takes about 12 seconds to render on prod; TBD how much faster this will be.)

**After**
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/19571/191333093-f2077713-a1cd-4ae3-b728-fa1cb55bfb77.png">
