### PR TITLE
Add highlight annotation styles; part of #1764

### DIFF
--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -19,16 +19,14 @@
     --casebook-font-size: 4mm;
     --casebook-line-height: 170%;
     --casebook-font-family: "LibreCaslon";
+    --link-icon-height: 10mm;
+    --link-icon-width: 10mm;
+    --link-icon-margin: 5mm;
+    --highlight-background-color: #ededed;
   }
-
 
   a {
     text-decoration: none;
-  }
-
-  .ordinal {
-    display: inline-block;
-    margin: 0 1em 0 0;
   }
 
   /* Always start a top-level section on a new page, even if there's preface matter */
@@ -51,10 +49,6 @@
     font-family: var(--casebook-font-family), serif !important;
   }
 
-  /* Book content (but not metadata or other types) should be indented. */
-  .node-container p {
-    text-indent: 2em;
-  }
 
   h1.casebook.title {
     font-size: 300%;
@@ -114,20 +108,40 @@
   section.link {
     margin-top: 10mm;
   }
+  section.depth-2.legaldocument {
+    break-before: page;
+  }
+  sup {
+    font-size: calc(var(--casebook-font-size) / 2.5);
+  }
+
+  /* Book content (but not metadata or other types) should be indented. */
+  .node-container p {
+    text-indent: 2em;
+  }
+  .ordinal {
+    display: inline-block;
+    margin: 0 1em 0 0;
+  }
+
   .link-container {
-    min-height: 10mm;
+    min-height: var(--link-icon-height);
     height: 100%;
     width: 100%;
   }
+  .link-container p {
+    margin-left: calc(var(--link-icon-width) + var(--link-icon-margin));
+    word-break: break-all;
+    text-indent: 0;
+  }
   .link-icon {
-    width: 10mm;
-    height: 10mm;
+    width: var(--link-icon-width);
+    height: var(--link-icon-height);
+    margin-right: var(--link-icon-margin);
     background: url("../images/Link.svg");
     background-size: cover;
     float: left;
-    padding-right: 5mm;
   }
-
 
   .truncated-title {
     string-set: title content(text);
@@ -152,14 +166,13 @@
     margin: 0;
     padding: 0;
   }
-
-  section.depth-2.legaldocument {
-    break-before: page;
+  .highlighted {
+    background:var(--highlight-background-color);
   }
-
-  sup {
-    font-size: calc(var(--casebook-font-size) / 2.5);
-
+  p:has(.highlighted) {
+    background: var(--highlight-background-color);
+    box-shadow: 0 0 0 5mm var(--highlight-background-color);
+    clip-path: inset(-2mm -5mm -2mm -5mm);
   }
 
   @page:right {


### PR DESCRIPTION
Adds a style  for text which had a "highlight" annotation applied to it, as a light gray background behind the highlighted text.

The current serialization for the Word export gives us markup like:

```html

<p>
  <span class="highlighted">The highlighted text.</span>
</p>
```

There are two styles added here: one targeting the highlighted span itself, and an identical one targeting the not-quite-production [`:has()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:has), which lets the developer target parent nodes. `:has()` is in Chrome, Edge, and Safari, but behind a flag in Firefox, so those users get the span fallback. The difference is whether the whole block is highlighted or not:

**Firefox**

<img width="687" alt="image" src="https://user-images.githubusercontent.com/19571/191355180-1c5c1cb2-2041-4c7c-91c5-ed012239630d.png">

**Chrome**
<img width="733" alt="image" src="https://user-images.githubusercontent.com/19571/191355041-5f4914a9-9400-4284-841f-7725776f70bd.png">

When this lands eventually as "export to PDF" the output will probably be driven by some fixed version of Chromium, so I think it's safe to assume any Chrome-supported CSS is in play for the "final" output, as long as the previews look reasonable in Firefox (and it'll support `:has()` soon enough anyway.)

For the block-level version, I used a background plus a variable-sized box-shadow in order to push the highlight outside the paragraph's bounding box; otherwise the whole thing looks like it's inset in a callout. 

I'm open to making this yellow instead and letting the printer deal with transforming it to greyscale; this gives us a little more control over the exact color at the expense of it looking less highlight-y.

Also cleaned up a little bit of the link styling and sorted the styles in a more logical order.

