### PR TITLE
Add highlighting support to printable HTML view

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -5,6 +5,89 @@ document.addEventListener("DOMContentLoaded", () => {
     const tmpl = document.querySelector("#casebook-content");
     const css = tmpl.getAttribute("data-stylesheet");
     const paged = new Previewer();
+
+    // Collect groups of ranges for each highlight offset start and end. Note that start/end offset may
+    // cross multiple block-level node boundaries; this will construct one node range for each block-level element.
+    const highlightRanges = Array.from(
+      tmpl.content.querySelectorAll('[data-annotation-type="highlight"]')
+    ).map((el) => {
+      let ranges = [],
+        currentOffset = 0,
+        textNode, // The current textNode we're processing
+        startNode, // The text node we've identified as the start of the highlight
+        endNode; // The text node we've identified that contains the end of the highlight
+
+      // Get the content from the DOM that matches this highlight, and its offset values
+      const resource = tmpl.content.querySelector(
+        `[data-node-id="${el.textContent}"]`
+      );
+      const startOffset = +el.getAttribute("data-start-offset");
+      const endOffset = +el.getAttribute("data-end-offset");
+
+      const iter = document.createNodeIterator(resource, NodeFilter.SHOW_TEXT);
+
+      // Iterate through all the text nodes in the resource, keeping track of the current character offset.
+      // Early exit when we've found the end of the highlight.
+      while ((textNode = iter.nextNode()) && !endNode) {
+        const chars = textNode.textContent?.length;
+
+        // If the highlight start offset lies within this node...
+        if (currentOffset + chars > startOffset && !startNode) {
+          // ...mark the node as the start node
+          startNode = textNode;
+
+          // Create a new Range to express the highlight within this node
+          const range = new Range();
+
+          // Range offsets are relevant to the parent node, so derive a relative offset by dropping
+          // the characters we've skipped over already
+          range.setStart(startNode, startOffset - currentOffset);
+
+          // If the highlight ends naturally inside this text node, set the end offset with
+          // the same relative logic as the start node, and mark this node as the end
+          if (endOffset < currentOffset + chars) {
+            range.setEnd(startNode, endOffset - currentOffset);
+            endNode = startNode;
+          }
+          // Otherwise, the highlight ends in a subsequent node, so end this particular range
+          // at the end of this node's block of characters.
+          else {
+            range.setEnd(startNode, chars);
+          }
+          // Save off this range
+          ranges.push(range);
+        }
+        // If the start of the highlight was found but the end has not been...
+        else if (startNode && !endNode) {
+          // Any intermediate or final range will naturally start at the beginning of this node
+          const range = new Range();
+          range.setStart(textNode, 0);
+
+          // and end either within this node, or in a following one
+          if (endOffset < currentOffset + chars) {
+            endNode = textNode;
+            range.setEnd(endNode, endOffset - currentOffset);
+          } else {
+            range.setEnd(textNode, chars);
+          }
+          ranges.push(range);
+        }
+        currentOffset += chars;
+      }
+
+      console.groupEnd();
+      return ranges;
+    });
+
+    // When all Ranges are ready, start updating the DOM
+    highlightRanges.forEach((rangeGroup) => {
+      rangeGroup.forEach((range) => {
+        const wrap = document.createElement("span");
+        wrap.classList.add("highlighted");
+        range.surroundContents(wrap);
+      });
+    });
+
     paged.preview(tmpl.content, [css], main).then((flow) => {
       console.log("Rendered", flow.total, "pages.");
     });

--- a/web/frontend/pages/as_printable_html.scss
+++ b/web/frontend/pages/as_printable_html.scss
@@ -125,9 +125,9 @@
     box-shadow: 0 0 0 1px inset var(--color-marginBox);
   }
 
-  /* uncomment this part for recto/verso book : ------------------------------------ */
+  /* uncomment this part for one-up layout: ------------------------------------ */
 
-  /*\
+/*
       .pagedjs_pages {
           flex-direction: column;
           width: 100%;
@@ -157,7 +157,7 @@
       .pagedjs_right_page{
           left: 0;
       }
-      */
+*/
 
   /*--------------------------------------------------------------------------------------*/
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2499,6 +2499,10 @@ class ContentNode(
             return reverse("annotate_resource", args=[self.casebook, self])
         raise ValueError("Only Resources (LegalDocument and TextBlock) can be annotated.")
 
+    def highlights(self):
+        """Return all annotations of type highlight for this node"""
+        return self.annotations.filter(kind="highlight")
+
     @property
     def get_preferred_url(self):
         """

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -33,18 +33,22 @@
 
 
     {% if node.is_resource %}
-      <section class="resource">
+     {# Whitespace beteen the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
+      <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
 
-        {% if node.resource.content %}
-          {% call_method node 'annotated_content_for_export' export_options=export_options as contents %}
-        {% endif %}
-
-        {# Strip out any manual whitespace, and mark the output as safe because this operation should not result in broken HTML #}
-        {{ contents|string_strip:"&nbsp;"|safe }}
-
-      </section>
+      {% for annotation in node.highlights %}
+      <li data-annotation-type="highlight"
+          data-start-offset="{{ annotation.global_start_offset }}"
+          data-end-offset="{{ annotation.global_end_offset }}"
+          class="hidden">{{ annotation.resource_id }}</li>
+      {% endfor %}
     {% endif %}
   </div>
-  </section>
 
-<span class="truncated-title">{{ node.ordinal_string }} {{ node.title|truncatechars:50 }}</span>
+
+</section>
+
+<span class="truncated-title hidden">{{ node.ordinal_string }} {{ node.title|truncatechars:50 }}</span>
+
+
+

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -33,7 +33,7 @@
 
 
     {% if node.is_resource %}
-     {# Whitespace beteen the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
+     {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
       <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
 
       {% for annotation in node.highlights %}

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -17,18 +17,17 @@
 
   :root {
     --casebook-font-size: 4mm;
-    --casebook-line-height: 170%;
+    --casebook-line-height: 7mm;
     --casebook-font-family: "LibreCaslon";
+    --link-icon-height: 10mm;
+    --link-icon-width: 10mm;
+    --link-icon-margin: 5mm;
+    --highlight-background-greyscale: #ededed;
+    --highlight-background-color: #fff7b9;
   }
-
 
   a {
     text-decoration: none;
-  }
-
-  .ordinal {
-    display: inline-block;
-    margin: 0 1em 0 0;
   }
 
   /* Always start a top-level section on a new page, even if there's preface matter */
@@ -51,10 +50,6 @@
     font-family: var(--casebook-font-family), serif !important;
   }
 
-  /* Book content (but not metadata or other types) should be indented. */
-  .node-container p {
-    text-indent: 2em;
-  }
 
   h1.casebook.title {
     font-size: 300%;
@@ -114,23 +109,50 @@
   section.link {
     margin-top: 10mm;
   }
+  section.depth-2.legaldocument {
+    break-before: page;
+  }
+  sup {
+    font-size: calc(var(--casebook-font-size) / 2.5);
+  }
+  ol, ul {
+    margin: initial;
+  }
+  li {
+    list-style-type: initial;
+  }
+  /* Book content (but not metadata or other types) should be indented. */
+  .node-container p {
+    text-indent: 2em;
+  }
+  .ordinal {
+    display: inline-block;
+    margin: 0 1em 0 0;
+  }
+
   .link-container {
-    min-height: 10mm;
+    min-height: var(--link-icon-height);
     height: 100%;
     width: 100%;
   }
+  .link-container p {
+    margin-left: calc(var(--link-icon-width) + var(--link-icon-margin));
+    word-break: break-all;
+    text-indent: 0;
+  }
   .link-icon {
-    width: 10mm;
-    height: 10mm;
+    width: var(--link-icon-width);
+    height: var(--link-icon-height);
+    margin-right: var(--link-icon-margin);
     background: url("../images/Link.svg");
     background-size: cover;
     float: left;
-    padding-right: 5mm;
   }
-
 
   .truncated-title {
     string-set: title content(text);
+  }
+  .hidden {
     display: none;
   }
 
@@ -152,16 +174,16 @@
     margin: 0;
     padding: 0;
   }
-
-  section.depth-2.legaldocument {
-    break-before: page;
+  .highlighted {
+    background: var(--highlight-background-color);
+    padding: calc(var(--casebook-line-height) * .2) 0;
   }
-
-  sup {
-    font-size: calc(var(--casebook-font-size) / 2.5);
-
+  /* Support for greyscale-only printing */
+  @media not color {
+    .highlighted {
+      background: var(--highlight-background-greyscale);
+    }
   }
-
   @page:right {
     @top-center {
       content: string(title);


### PR DESCRIPTION
As part of adding support for all annotation types to the printable HTML view, start with highlights. This follows the approach of #1770 which to my surprise seems to work.

Annotations created by the frontend are expressed as start and end "global" offsets—character offsets relative to the book content. One challenge that the current frontend and export code has to deal with is that any change to the markup needed to express elisions, highlights, or corrections is itself likely to alter those character offsets, because they modify the DOM tree. A nice feature of the [Range API](https://developer.mozilla.org/en-US/docs/Web/API/Range) is that it sits alongside the DOM, not within it. 

For each "chapter" and for each highlight in that chapter:

* Find the node containing text that lies within the boundary of the start offset for the highlight. Create a Range with a relative start offset that marks where the user began the highlight.
* If the highlight ends in this same text node, close the Range at the point at which the user ended the highlight. Otherwise, close the range when the node ends.
* If the highlight end hasn't been found yet, keep opening new Ranges as text nodes are consumed until the end is found.

Once all highlights have been turned into one or more ranges, for each range, use the native [range.surroundContent()](https://developer.mozilla.org/en-US/docs/Web/API/Range/surroundContents) method to wrap the text content in a styled span. 

I think all annotation kinds (elisions, corrections) should be safe to handle this way, and by deferring DOM mutations until the end, they shouldn't collide with each other because each Range created is relative to its nearest parent. This also lets us [avoid having to decorate nodes](https://github.com/harvard-lil/h2o/blob/4e0ad9597fb2860296da060195528e8cd79391e7/web/frontend/components/TheAnnotator.vue#L103-L107) just for the purposes of skipping them. However, it's possible this implementation will not be totally resilient to the other annotation types and I'll cross the bridge when I get there.

## Testing

At some point printable HTML will need tests, but H2O doesn't have Playwright yet and that's the logical way to test this. For now, some manual diffs between the website highlight views and the PagedJS view (I put it into single-page rather than two-up view to make it easier to compare.)

<img width="1785" alt="Screen Shot 2022-09-22 at 12 19 50 PM" src="https://user-images.githubusercontent.com/19571/191802221-96967ed7-5bd6-421c-bad2-3592f25c7c90.png">
