### PR TITLE
Handle elisions in printable HTML as part of #1764

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -6,18 +6,18 @@ document.addEventListener("DOMContentLoaded", () => {
     const css = tmpl.getAttribute("data-stylesheet");
     const paged = new Previewer();
 
-    // Collect groups of ranges for each highlight offset start and end. Note that start/end offset may
+    // Collect groups of ranges for each annotation offset start and end. Note that start/end offset may
     // cross multiple block-level node boundaries; this will construct one node range for each block-level element.
-    const highlightRanges = Array.from(
-      tmpl.content.querySelectorAll('[data-annotation-type="highlight"]')
+    const annotationRanges = Array.from(
+      tmpl.content.querySelectorAll("[data-annotation-type]")
     ).map((el) => {
       let ranges = [],
         currentOffset = 0,
-        textNode, // The current textNode we're processing
-        startNode, // The text node we've identified as the start of the highlight
-        endNode; // The text node we've identified that contains the end of the highlight
+        textNode, // The current text node we're processing
+        startNode, // The text node we've identified as the start of the annotation
+        endNode; // The text node we've identified that contains the end of the annotation
 
-      // Get the content from the DOM that matches this highlight, and its offset values
+      // Get the content from the DOM that matches this annotation, and its offset values
       const resource = tmpl.content.querySelector(
         `[data-node-id="${el.textContent}"]`
       );
@@ -27,29 +27,29 @@ document.addEventListener("DOMContentLoaded", () => {
       const iter = document.createNodeIterator(resource, NodeFilter.SHOW_TEXT);
 
       // Iterate through all the text nodes in the resource, keeping track of the current character offset.
-      // Early exit when we've found the end of the highlight.
+      // Early exit when we've found the end of the annotation.
       while ((textNode = iter.nextNode()) && !endNode) {
         const chars = textNode.textContent?.length;
 
-        // If the highlight start offset lies within this node...
+        // If the annotation's start offset lies within this node...
         if (currentOffset + chars > startOffset && !startNode) {
           // ...mark the node as the start node
           startNode = textNode;
 
-          // Create a new Range to express the highlight within this node
+          // Create a new Range to express the annotation within this node
           const range = new Range();
 
-          // Range offsets are relevant to the parent node, so derive a relative offset by dropping
+          // Range offsets are relative to the parent node, so derive a relative offset by dropping
           // the characters we've skipped over already
           range.setStart(startNode, startOffset - currentOffset);
 
-          // If the highlight ends naturally inside this text node, set the end offset with
+          // If the annotation ends naturally inside this text node, set the end offset with
           // the same relative logic as the start node, and mark this node as the end
-          if (endOffset < currentOffset + chars) {
+          if (endOffset <= currentOffset + chars) {
             range.setEnd(startNode, endOffset - currentOffset);
             endNode = startNode;
           }
-          // Otherwise, the highlight ends in a subsequent node, so end this particular range
+          // Otherwise, the annotation ends in a subsequent node, so end this particular range
           // at the end of this node's block of characters.
           else {
             range.setEnd(startNode, chars);
@@ -57,7 +57,7 @@ document.addEventListener("DOMContentLoaded", () => {
           // Save off this range
           ranges.push(range);
         }
-        // If the start of the highlight was found but the end has not been...
+        // If the start of the annotation was found but the end has not been...
         else if (startNode && !endNode) {
           // Any intermediate or final range will naturally start at the beginning of this node
           const range = new Range();
@@ -75,17 +75,48 @@ document.addEventListener("DOMContentLoaded", () => {
         currentOffset += chars;
       }
 
-      console.groupEnd();
-      return ranges;
+      return {
+        type: el.getAttribute("data-annotation-type"),
+        datetime: el.getAttribute("data-datetime"),
+        ranges,
+      };
     });
-
     // When all Ranges are ready, start updating the DOM
-    highlightRanges.forEach((rangeGroup) => {
-      rangeGroup.forEach((range) => {
-        const wrap = document.createElement("span");
-        wrap.classList.add("highlighted");
-        range.surroundContents(wrap);
-      });
+    annotationRanges.forEach((rg) => {
+      const { type, datetime, ranges } = rg;
+      switch (type) {
+        case "highlight": {
+          ranges.forEach((range) => {
+            const wrap = document.createElement("span");
+            wrap.classList.add("highlighted");
+            range.surroundContents(wrap);
+          });
+          break;
+        }
+        case "elide": {
+          ranges.forEach((range) => {
+            const elision = document.createElement("del");
+            elision.classList.add("elided");
+            elision.setAttribute("datetime", datetime);
+
+            const marker = document.createElement("ins");
+            marker.classList.add("elision-marker");
+            marker.innerText=" […] ";
+            range.surroundContents(elision);
+            elision.insertAdjacentElement("afterend", marker);
+
+            // If the previous sibling is another marker, or if it's an empty text node,
+            // hide the marker
+            if (
+              elision.previousSibling.classList?.contains("elision-marker") ||
+              elision.previousSibling.textContent.trim() === ""
+            ) {
+              marker.classList.add("hidden");
+            }
+          });
+          break;
+        }
+      }
     });
 
     paged.preview(tmpl.content, [css], main).then((flow) => {

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2499,10 +2499,6 @@ class ContentNode(
             return reverse("annotate_resource", args=[self.casebook, self])
         raise ValueError("Only Resources (LegalDocument and TextBlock) can be annotated.")
 
-    def highlights(self):
-        """Return all annotations of type highlight for this node"""
-        return self.annotations.filter(kind="highlight")
-
     @property
     def get_preferred_url(self):
         """

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -36,10 +36,11 @@
      {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
       <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
 
-      {% for annotation in node.highlights %}
-      <li data-annotation-type="highlight"
+      {% for annotation in node.annotations.valid %}
+      <li data-annotation-type="{{ annotation.kind }}"
           data-start-offset="{{ annotation.global_start_offset }}"
           data-end-offset="{{ annotation.global_end_offset }}"
+          data-datetime="{{ annotation.created_at|date:'c' }}"
           class="hidden">{{ annotation.resource_id }}</li>
       {% endfor %}
     {% endif %}

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -174,16 +174,27 @@
     margin: 0;
     padding: 0;
   }
+
   .highlighted {
     background: var(--highlight-background-color);
     padding: calc(var(--casebook-line-height) * .2) 0;
   }
+
+  .elided {
+    display: none;
+  }
+  .elision-marker {
+    text-decoration: none;
+  }
+
   /* Support for greyscale-only printing */
   @media not color {
     .highlighted {
       background: var(--highlight-background-greyscale);
     }
   }
+
+
   @page:right {
     @top-center {
       content: string(title);


### PR DESCRIPTION
Extending from #1772 , this generalizes the previous code to consider all annotation types, and adds a serialization mechanism for elisions.

* Uses `<ins>` / `<del>` to represent these semantically.
* Hides adjacent empty elisions (the [current export doesn't do this](https://github.com/harvard-lil/h2o/issues/1511))

## Testing

<img width="1606" alt="image" src="https://user-images.githubusercontent.com/19571/191844062-e10080dc-8386-4eb5-9965-028749c62467.png">

Compare with Word export:

<img width="772" alt="image" src="https://user-images.githubusercontent.com/19571/191844508-d38f6b03-622e-45d0-84fa-fad9ef441ea1.png">


## Accessibility and æsthetics

(I don't think this is blocking for this PR, but I'm interested in thoughts!)

I was originally going to set the insertion ellipses as `ins::after { content: "…"}` but `<ins>` has special behavior with regards to [screenreaders](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins#accessibility_concerns). Even though screenreaders aren't the target of a print preview page, I figure it's useful to think about using this markup in the website itself, and I saw some old discussion in Slack about using these elements.

I'm not happy with a screenreader reading `[…]` out loud (though at least it's a real ellipses character and not a string of dots). A few legal style guides and a free non-H2O casebook I checked seemed to favor excluding the brackets entirely, which would be my preference in the printed layout. On the other hand, screen readers [may skip over reading this content entirely](https://stackoverflow.com/questions/453189/what-do-screen-readers-do-with-an-ellipsis-unicode-character), which suggests maybe we should have a non-visible `ins::after { content: "elided" }` or similar, even though I know it's usually contraindicated to provide alternate content.
