### PR TITLE
Fix some type errors

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -4961,6 +4961,7 @@ class User(NullableTimestampedModel, PermissionsMixin, AbstractBaseUser):
     def user_can_view_instructional_material(user: Union[AnonymousUser, User]) -> bool:
         return user.is_authenticated and (user.verified_professor or user.is_staff)
 
+
 def update_user_login_fields(sender, request, user, **kwargs):
     """
     Register signal to record user login details on successful login, following the behavior of the Rails authlogic gem.


### PR DESCRIPTION
Addresses some minor gripes from the type checker that snuck in, since types aren't currently checked in CI (#1615).

Dropped one unused function which mypy correctly flagged isn't callable that way without some hanky-panky.