### PR TITLE
Add mypy to lints workflow; fixes #1615

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,7 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: flake8
         run: |
           pip install `egrep -o 'flake8==\S+' web/requirements.txt`  # install our version of flake8
@@ -19,3 +21,9 @@ jobs:
         run: |
           pip install `egrep -o 'black==\S+' web/requirements.txt`  # install our version of black
           black --check --diff . # Uses pyproject.toml
+
+      - name: mypy
+        run: |
+          cd web
+          pip install -r requirements.txt  # install a full environment for mypy
+          PYTHONPATH=. mypy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository == 'harvard-lil/h2o'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       ### build docker images locally ###
 


### PR DESCRIPTION
Runs `mypy` as the last step in the lints workflow. It takes the longest because it needs all the dependencies installed, especially with the Django extension.

In this project, `web` is set up as the root of the project and is in the python path; this isn't true automatically in CI or when installing locally. Setting `$PYTHONPATH` is always kind of a smell but I think it's what the environment expects.

The other option was running mypy in CI from the container via the `tests.yml` workflow, but I think logically it belongs here in `lints.yml`, and seems to work.