### PR TITLE
Add correction and replacement annotation types

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -114,6 +114,7 @@ document.addEventListener("DOMContentLoaded", () => {
             elision.setAttribute("datetime", datetime);
 
             const marker = document.createElement("ins");
+            marker.setAttribute("datetime", datetime);
             marker.classList.add("elision-marker");
             marker.innerText = " … ";
             range.surroundContents(elision);
@@ -149,6 +150,22 @@ document.addEventListener("DOMContentLoaded", () => {
           note.innerText = content
           lastRange.insertAdjacentElement("afterend", note);
           break;
+        }
+        case "replace":
+        case "correction": {
+          // Transparently replace the content inside the node
+          ranges.forEach((range) => {
+            const deletion = document.createElement("del");
+            deletion.classList.add(type);
+            deletion.setAttribute("datetime", datetime);
+
+            const replacement = document.createElement("ins");
+            replacement.setAttribute("datetime", datetime);
+            replacement.classList.add(type);
+            replacement.innerText = content;
+            range.surroundContents(deletion);
+            deletion.insertAdjacentElement("afterend", replacement);
+          });
         }
       }
     });

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -198,6 +198,12 @@
   .elision-marker {
     text-decoration: none;
   }
+  del.replace, del.correction {
+    display: none;
+  }
+  ins.replace, ins.correction {
+    text-decoration: none;
+  }
 
   /* Set up a new container that avoids inheriting styles from block parents */
   .authors-note {


### PR DESCRIPTION
Addresses two more types from https://github.com/harvard-lil/h2o/issues/1764

The Word export treats "replacements" and "corrections" separately. The former is intended to express some opinionated change on the part of the author modifying a case or other imported document. The latter is intended to express a typo correction. The front-end doesn't [strongly push this distinction](https://github.com/harvard-lil/h2o/issues/1421). Since this distinction is largely opaque to both authors and readers, I chose to treat them the same way here and hide the original source. However, it's in the injected markup, so treating it differently is just a matter of adjusting the CSS.

## Source text

<img width="439" alt="image" src="https://user-images.githubusercontent.com/19571/192854958-4e5d5f99-d270-4fca-ac6c-791ca71fd950.png">

## Printable view

<img width="424" alt="image" src="https://user-images.githubusercontent.com/19571/192857104-d2e75de4-ad5b-4854-ac1e-8476f5a8037d.png">

Markup:

```html
<p>This line has 
   <del class="replace" datetime="2022-09-28T16:14:09.617686">replacement</del>
   <ins class="replace" datetime="2022-09-28T16:14:09.617686">even better text than was here before</ins>.
</p>
```