### PR TITLE
Handle different link types in the printable view; fixes #1783

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -109,8 +109,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const css = tmpl.getAttribute("data-stylesheet");
     const paged = new Previewer();
 
-    // For any existing URLs, turn them into footnotes
-    tmpl.content.querySelectorAll('a[href^="http"]').forEach((el) => {
+    // For any existing URLs that aren't resources, turn them into footnotes
+    tmpl.content.querySelectorAll('a[href^="http"]:not([data-type])').forEach((el) => {
       hyperlinkFootnote(el, el['href'],
       new Date(tmpl.content.querySelector('section[data-datetime]').getAttribute('data-datetime')))
     });
@@ -131,7 +131,7 @@ document.addEventListener("DOMContentLoaded", () => {
       switch (type) {
         case "highlight": {
           ranges.forEach((range) => {
-            const wrap = document.createElement("span");
+            const wrap = document.createElement("mark");
             wrap.classList.add("highlighted");
             range.surroundContents(wrap);
           });
@@ -166,7 +166,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
           // Wrap the specific text the author highlighted to allow for downstream styling
           ranges.forEach((range) => {
-            const wrap = document.createElement("span");
+            const wrap = document.createElement("mark");
             range.surroundContents(wrap);
             lastRange = wrap;
           });

--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -1,7 +1,9 @@
-import { Previewer } from "pagedjs";
+import {
+  Previewer
+} from "pagedjs";
 
 /**
- *  Collect groups of ranges for each annotation offset start and end. Note that start/end offset may
+ * Collect groups of ranges for each annotation offset start and end. Note that start/end offset may
  * cross multiple block-level node boundaries; this will construct one node range for each block-level element.
  * @param  {NodeList} annotations The list of annotation elements in the parent DOM injected by Django.
  * @param {DocumentFragment} content The DOM content of the page
@@ -84,11 +86,34 @@ function annotationsToRanges(annotations, content) {
   return annotationRanges;
 }
 
+/**
+ * Create a footnote element in PagedJS containing the provided URL.
+ * @param {Node} node
+ * @param {string} url
+ * @param {Date} dateCreated
+ */
+function hyperlinkFootnote(node, url, dateCreated) {
+  const footnote = document.createElement("a");
+  footnote.setAttribute("href", url)
+  const displayDate = dateCreated.toLocaleString('en-US', {day: 'numeric', month: 'short', year: 'numeric'})
+  footnote.innerHTML = `${url}
+    <span class="citation">(link created ${displayDate})</span>`
+  // Ask PagedJS to render it as a footnote on the current page
+  footnote.classList.add("footnote-generated");
+  node.insertAdjacentElement("afterend", footnote);
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll("main").forEach((main) => {
     const tmpl = document.querySelector("#casebook-content");
     const css = tmpl.getAttribute("data-stylesheet");
     const paged = new Previewer();
+
+    // For any existing URLs, turn them into footnotes
+    tmpl.content.querySelectorAll('a[href^="http"]').forEach((el) => {
+      hyperlinkFootnote(el, el['href'],
+      new Date(tmpl.content.querySelector('section[data-datetime]').getAttribute('data-datetime')))
+    });
 
     const annotationRanges = annotationsToRanges(
       Array.from(tmpl.content.querySelectorAll("[data-annotation-type]")),
@@ -97,7 +122,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // When all Ranges are ready, start updating the DOM
     annotationRanges.forEach((rg) => {
-      const { type, datetime, ranges, content } = rg;
+      const {
+        type,
+        datetime,
+        ranges,
+        content
+      } = rg;
       switch (type) {
         case "highlight": {
           ranges.forEach((range) => {
@@ -166,7 +196,18 @@ document.addEventListener("DOMContentLoaded", () => {
             range.surroundContents(deletion);
             deletion.insertAdjacentElement("afterend", replacement);
           });
+          break;
+
         }
+        case "link":
+          // Inject a hyperlink which in print will be styled as a footnote
+          ranges.forEach((range) => {
+            const anchor = document.createElement("a");
+            anchor.setAttribute("href", content);
+            range.surroundContents(anchor);
+            hyperlinkFootnote(anchor, content, new Date(datetime))
+          });
+          break
       }
     });
 

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -44,6 +44,7 @@
     <div class="casebook-metadata" data-paginator-page="{{ page.number }}">
       <h1 class="casebook title">{{ casebook.title }}</h1>
       <h2 class="casebook subtitle">{{ casebook.subtitle|default_if_none:""}}</h2>
+      <span class="truncated-title hidden">{{ casebook.title }}</span>
       <div class="author-list">
         <ul>
         {% for user in casebook.primary_authors %}
@@ -69,9 +70,6 @@
   </template>
 
   <main id="as-printable-html"></main>
-
-
-
 
 </body>
 </html>

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -1,7 +1,9 @@
 {% load call_method string_strip %}
 
 
-<section class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
+<section
+  data-datetime="{{ node.created_at|date:'c' }}"
+  class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
 
   {% if node.resource_type == 'Link' %}
     <div class="link-container">

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -5,48 +5,58 @@
   data-datetime="{{ node.created_at|date:'c' }}"
   class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
 
-  {% if node.resource_type == 'Link' %}
-    <div class="link-container">
-      <div class="link-icon"></div>
 
-      <h4 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}.
-        Hyperlink to a web resource
-      </h4>
-
-      <p><a href="{{ node.resource.url }}" target="_blank">{{ node.resource.url }}</a></p>
-    </div>
-  {% endif %}
 
   <div class="node-container">
 
-    <h1 class="{{ node.type }} title">
-      <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
-      {{ node.title }}
-    </h1>
+    {% if node.resource_type == 'Link' %}
+      <div class="link-container">
+        <div class="link-icon"></div>
 
-    {% if node.subtitle %}
-      <h2 class="subtitle">{{ node.subtitle }}</h2>
+        <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}.
+          Hyperlink to a web resource
+        </h4>
+        <h2 class="subtitle">{{ node.subtitle }}</h2>
+
+        {% if node.headnote %}
+          {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
+          <section class="headnote">{{ headnote }}</section>
+        {% endif %}
+
+        <a href="{{ node.resource.url }}" target="_blank" data-type="resource">{{ node.resource.url }}</a>
+      </div>
+
+    {% else %}
+
+        <h1 class="{{ node.type }} title">
+          <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
+          {{ node.title }}
+        </h1>
+
+        {% if node.subtitle %}
+          <h2 class="subtitle">{{ node.subtitle }}</h2>
+        {% endif %}
+
+        {% if node.headnote %}
+          {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
+          <section class="headnote">{{ headnote }}</section>
+        {% endif %}
+
+        {% if node.is_resource %}
+        {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
+          <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
+
+          {% for annotation in node.annotations.valid %}
+          <li data-annotation-type="{{ annotation.kind }}"
+              data-node-id="{{ annotation.resource_id }}"
+              data-start-offset="{{ annotation.global_start_offset }}"
+              data-end-offset="{{ annotation.global_end_offset }}"
+              data-datetime="{{ annotation.created_at|date:'c' }}"
+              class="hidden">{{ annotation.content }}</li>
+          {% endfor %}
+        {% endif %}
     {% endif %}
 
-    {% if node.headnote %}
-      {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
-      <section class="headnote">{{ headnote }}</section>
-    {% endif %}
-
-
-    {% if node.is_resource %}
-     {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
-      <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
-
-      {% for annotation in node.annotations.valid %}
-      <li data-annotation-type="{{ annotation.kind }}"
-          data-node-id="{{ annotation.resource_id }}"
-          data-start-offset="{{ annotation.global_start_offset }}"
-          data-end-offset="{{ annotation.global_end_offset }}"
-          data-datetime="{{ annotation.created_at|date:'c' }}"
-          class="hidden">{{ annotation.content }}</li>
-      {% endfor %}
-    {% endif %}
   </div>
 
 

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -5,8 +5,6 @@
   data-datetime="{{ node.created_at|date:'c' }}"
   class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
 
-
-
   <div class="node-container">
 
     {% if node.resource_type == 'Link' %}
@@ -16,15 +14,15 @@
         <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}.
           Hyperlink to a web resource
         </h4>
-        <h2 class="subtitle">{{ node.subtitle }}</h2>
-
-        {% if node.headnote %}
-          {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
-          <section class="headnote">{{ headnote }}</section>
-        {% endif %}
-
-        <a href="{{ node.resource.url }}" target="_blank" data-type="resource">{{ node.resource.url }}</a>
       </div>
+      <h2 class="subtitle">{{ node.subtitle|default_if_none:"" }}</h2>
+
+      {% if node.headnote %}
+        {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
+        <section class="headnote">{{ headnote }}</section>
+      {% endif %}
+
+      <a href="{{ node.resource.url }}" target="_blank" data-type="resource">{{ node.resource.url }}</a>
 
     {% else %}
 
@@ -62,7 +60,8 @@
 
 </section>
 
-<span class="truncated-title hidden">{{ node.ordinal_string }} {{ node.title|truncatechars:50 }}</span>
+<span class="truncated-title hidden">{{ section.title|truncatechars:75 }}</span>
+
 
 
 

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -130,7 +130,6 @@
   /* Headnotes don't have indentation */
   section.headnote p {
     text-indent: initial;
-    margin: 0;
   }
 
   section.link {
@@ -161,7 +160,6 @@
 
   .link-container {
     min-height: var(--link-icon-height);
-    height: 100%;
     width: 100%;
   }
   .link-container p {

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -229,12 +229,23 @@
     text-indent: initial;
   }
 
-  /* PageJS handling of footnotes */
+  /* Style footnotes, allowing the URLs to break midway. PagedJS will put these in the bottom margin */
   .footnote-generated {
     float: footnote;
+    word-wrap: break-word;
   }
+  /* Add some spacing to the superscript indicating a footnote. */
   ::footnote-call {
     margin-left: .5mm;
+  }
+  /* Generate the corresponding footnote reference in the footer as e.g. "2. <footnote-text>"
+   Don't allow long URLs to break on the space in this marker. */
+  [data-footnote-marker]::marker {
+    content: counter(footnote-marker) ". ";
+    white-space: nowrap;
+  }
+  [data-footnote-marker]::after {
+    content: " ";
   }
 
   /* Support for greyscale-only printing */

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -34,6 +34,7 @@
 
   a {
     text-decoration: none;
+    color: inherit;
   }
 
   /* Always start a top-level section on a new page, even if there's preface matter */

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -117,6 +117,22 @@
     font-weight: bold;
   }
 
+  /* Headers for links are much smaller */
+  h1.link {
+    font-size: 110%;
+    font-weight: bold;
+  }
+  h2.subtitle {
+    font-size: 100%;
+    font-style: italic;
+  }
+
+  /* Headnotes don't have indentation */
+  section.headnote p {
+    text-indent: initial;
+    margin: 0;
+  }
+
   section.link {
     margin-top: 10mm;
   }

--- a/web/static/as_printable_html/cap.css
+++ b/web/static/as_printable_html/cap.css
@@ -4,75 +4,69 @@
   font-size: calc(var(--casebook-font-size) * .75);
 }
 
-/* Add some breathing room after internal footnotes */
 .legaldocument a[href^="#"] {
-  margin-right: .25em;
+  margin: 0;
+  padding: 0;
 }
 
-.footnote p,
-.footnote blockquote {
-  margin-left: 13px;
-}
-
-.footnotemark {
+.legaldocument .footnotemark {
   font-size: calc(var(--casebook-font-size) / 2);
   vertical-align: super;
 }
 
 
-header.case-header .title,
-header.case-header .citation,
-header.case-header .decisiondate,
-header.case-header .docketnumber,
-header.case-header .court {
+.legaldocument header.case-header .title,
+.legaldocument header.case-header .citation,
+.legaldocument header.case-header .decisiondate,
+.legaldocument header.case-header .docketnumber,
+.legaldocument header.case-header .court {
   text-align: center;
 }
 
-header.case-header .citation,
-header.case-header .decisiondate,
-header.case-header .docketnumber,
-header.case-header .court {
+.legaldocument header.case-header .citation,
+.legaldocument header.case-header .decisiondate,
+.legaldocument header.case-header .docketnumber,
+.legaldocument header.case-header .court {
   letter-spacing: 1px;
   padding: 4px;
 }
 
-header.case-header .court {
+.legaldocument header.case-header .court {
   font-size: 24px;
 }
 
-header.case-header .citation,
-header.case-header .decisiondate,
-header.case-header .docketnumber {
+.legaldocument header.case-header .citation,
+.legaldocument header.case-header .decisiondate,
+.legaldocument header.case-header .docketnumber {
   font-size: 18px;
 }
 
-header.case-header .title {
+.legaldocument header.case-header .title {
   font-weight: bold;
   font-size: calc(var(--casebook-font-size) * 1.5) !important;
   line-height: 1.4em !important;
   padding: 20px 4px 10px 4px;
-
 }
 
-.case-text .parties,
-.case-text .decisiondate,
-.case-text .docketnumber,
-.case-text .citations,
-.case-text .syllabus,
-.case-text .synopsis,
-.case-text .court {
+.legaldocument .parties,
+.legaldocument .decisiondate,
+.legaldocument .docketnumber,
+.legaldocument .citations,
+.legaldocument .syllabus,
+.legaldocument .synopsis,
+.legaldocument .court {
   display: none;
 }
 
-.case-text .page-label {
+.legaldocument .page-label {
   display: none;
 }
 
-.case-text aside.footnote > a {
+.legaldocument aside.footnote > a {
   float: left;
 }
 
-.case-text img {
+.legaldocument img {
   max-width: 100%;
   width: auto;
   height: auto;


### PR DESCRIPTION
Follow the link format we arrived at in #1783.

## Source data

<img width="609" alt="image" src="https://user-images.githubusercontent.com/19571/193071081-65ef97c9-5993-4397-8ed6-7f6c3e6b1fca.png">

## Word export 
<img width="609" alt="image" src="https://user-images.githubusercontent.com/19571/193071188-391b5ab0-3afc-4e0e-bb62-7db69aa14d01.png">

## Printable export 

* All link types look the same, except internal links which aren't rendered.
* The markup here is anchor tags in both the body text and the footnote, if the previewing user wants to click on them. 
* The footnote date is either derived from the annotation date (if created that way) or from the creation date of the document (which may or may not uniquely correspond with the link itself, but it's a decent proxy).

<img width="559" alt="image" src="https://user-images.githubusercontent.com/19571/193071302-18cb0b5e-7118-4b0c-b51f-094310b0cd5b.png">

