### PR TITLE
Iterate through nodes more carefully when discovering offsets

### DIFF
--- a/web/frontend/components/TheAnnotator.vue
+++ b/web/frontend/components/TheAnnotator.vue
@@ -77,7 +77,7 @@ export default {
       const wrapperRect = this.$parent.$el.getBoundingClientRect();
       const viewportTop = window.scrollY - (wrapperRect.top + window.scrollY);
       const targetRect = this.ranges[1].getBoundingClientRect();
-      
+
       return Math.min(Math.max(targetRect.top - wrapperRect.top, viewportTop + 20),
                       targetRect.bottom - wrapperRect.top).toString(10) + "px";
     },
@@ -92,17 +92,18 @@ export default {
     },
     offsets() {
       if(!this.hasValidRanges) return;
-      
+
       const el = document.querySelector(".case-text");
-      
-      const ret = ["start", "end"].map((s, i) =>
-        this.ranges[i][`${s}Offset`] + getOffsetWithinParent(el, this.ranges[i][`${s}Container`], this.contributesToOffsets)
+
+      const ret = ["start", "end"].map((s, i) => {
+        return this.ranges[i][`${s}Offset`] + getOffsetWithinParent(el, this.ranges[i][`${s}Container`], this.contributesToOffsets)
+      }
       );
       const sel_length = this.selection.toString().length;
 
       let sp = (this.ranges[0].startContainer == this.ranges[0].commonAncestorContainer);
       let ep = (this.ranges[1].endContainer == this.ranges[1].commonAncestorContainer);
-      
+
       if (sp ? !ep : ep) {
         // If the edge of a selection lies on an image, the offsets are calculated incorrectly
         if (sp) {
@@ -116,20 +117,23 @@ export default {
   },
   methods: {
     ...mapActions(["create"]),
-    
+
     tempId() {
       return Math.floor(Math.random() * Math.floor(10000000)) * -1;
     },
-    
+
     // returns false if the text or element node is the child of an
-    // element with a special attribute
+    // element with a special attribute, or is not a computable type
     contributesToOffsets(node) {
-      return !getClosestElement(node).closest("[data-exclude-from-offset-calcs='true']")
+      if (node && (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.ELEMENT_NODE)) {
+        return !getClosestElement(node).closest("[data-exclude-from-offset-calcs='true']")
+      }
+      return false;
     },
-    
+
     selectionchange(e, sel) {
       if(sel && !this.contributesToOffsets(sel.anchorNode)) return;
-      
+
       this.ranges =
         (!sel || sel.type != "Range")
         ? null
@@ -137,7 +141,7 @@ export default {
            sel.getRangeAt(sel.rangeCount-1)];
       this.selection = sel;
     },
-    
+
     close() {
       document.getSelection().empty();
       this.ranges = null;

--- a/web/frontend/libs/html_helpers.js
+++ b/web/frontend/libs/html_helpers.js
@@ -64,14 +64,35 @@ export const getAttrsMap = (el) => {
 export const getClosestElement = (node) =>
   isText(node) ? node.parentNode : node;
 
+  /**
+   *
+   * Get the character offset within the case text itself.
+   *
+   * @param {Node} parent The top-level parent, usually the selector `.case-text` that contains the entire case HTML
+   * @param {Node} child The node where the selection took place.
+   * @param {function} accept A filter function to accept or reject a node from inclusion in the treewalker
+   * @returns {number} the offset
+   */
 export const getOffsetWithinParent = (parent, child, accept) => {
   const filter = accept ? {acceptNode: (node) => accept(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT} : null;
-  const walker = document.createTreeWalker(parent, NodeFilter.SHOW_TEXT, filter);
+  const walker = document.createTreeWalker(parent, NodeFilter.SHOW_ALL, filter);
+
+  // Determine when to stop walking through the nodes to find the start position of the selection...
+  const continueCondition = child.nodeType === document.TEXT_NODE ?
+      // If the user started their selection in a text node, stop the iteration at the point when we get to that node
+      (node) => node && node !== child:
+      // If the user started their selection on an element boundary, stop at the containing element
+      (node) => node && !child.contains(node)
+
   let offset = 0;
-  for (let node = walker.nextNode();
-       (isText(child) && node !== child) || !child.contains(node);
-       node = walker.nextNode()) {
-    offset += getLength(node);
+  let node = walker.nextNode();
+
+  while (continueCondition(node)) {
+    if (node.nodeType === document.TEXT_NODE) {
+      offset += getLength(node);
+    }
+    node = walker.nextNode();
   }
+
   return offset;
 };

--- a/web/frontend/test/libs/html_helpers.test.js
+++ b/web/frontend/test/libs/html_helpers.test.js
@@ -81,7 +81,7 @@ describe('getClosestElement', () => {
   });
 });
 
-describe('getOffsetWithinELement', () => {
+describe('getOffsetWithinElement', () => {
   it('returns the correct offset for a child text node within its parent', () => {
     const parent = parseHTML('<div>foo <span>bar <em>buzz</em></span> fizz</div>');
     const child = parent.childNodes[2];
@@ -99,5 +99,12 @@ describe('getOffsetWithinELement', () => {
     const child = parent.childNodes[2];
     const wrapper = mount(TheAnnotator);
     expect(getOffsetWithinParent(parent, child, wrapper.vm.contributesToOffsets)).toBe(8);
+  });
+
+  it('returns the correct offset when the selection moves through an image', () => {
+    const parent = parseHTML('<div>foo <span>bar <em>buzz</em></span><img src="" /> fizz</div>');
+    const child = parent.childNodes[2];
+    const wrapper = mount(TheAnnotator);
+    expect(getOffsetWithinParent(parent, child, wrapper.vm.contributesToOffsets)).toBe(12);
   });
 });


### PR DESCRIPTION
fixes #1771

Addresses a bug mentioned by users and Sentry where highlighting exuberantly across a document can cause the annotation code to throw an uncaught exception and stop processing. The only recourse for users in this scenario is to refresh the page.

This makes a few changes to both make the code easier to follow, and also to fix the bug:

## The bug

The root cause of the actual bug is in a loop that is designed to walk through the HTML tree and count the character offset to the start of the selection range. The tree-walking loop was written such that the iterator could reach the end of its iteration and return `null`, but code in the loop would still attempt to retrieve information about the node. In the JS console this resulted in an uncaught exception trying to get the length of the (null) node's text content.

This was addressed by letting the iteration exit naturally when it completes, or sooner if the loop knows it has exited the relevant part of the DOM. Iterating through all node types, not just text nodes, allows it to capture selections that span image boundaries. 

<img width="200" alt="image" src="https://user-images.githubusercontent.com/19571/193684682-229a3bf3-4afc-4778-b901-1f72dcbaa8f6.png">

This fixes two cases—highlighting across an image boundary and (more commonly) highlighting across an elision boundary. I think it should generalize to any similar cases.

## Testing

I want to do a little more manual testing, but the new automated test case does fail in `develop` and passes here:

```
  1) getOffsetWithinELement
       returns the correct offset when the selection moves through an image:
     TypeError: Cannot read properties of null (reading 'textContent')
      at getLength (static/dist/js/webpack:/frontend/libs/html_helpers.js:51:1)
      at getOffsetWithinParent (static/dist/js/webpack:/frontend/libs/html_helpers.js:74:1)
      at Context.<anonymous> (static/dist/js/webpack:/frontend/test/libs/html_helpers.test.js:108:1)
      at processImmediate (node:internal/timers:466:21)
```
