### PR TITLE
Change layout of printable HTML TOC from grid to simple floats; fixes #1788

### DIFF
--- a/web/frontend/pages/as_printable_html.scss
+++ b/web/frontend/pages/as_printable_html.scss
@@ -25,6 +25,10 @@
   /* Show underlining for TOC hyperlinks in the web view only */
   nav.toc a {
     text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 1mm;
+    text-decoration-color: gray;
+
   }
 }
 

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -58,9 +58,11 @@
         </ul>
       </div>
       <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
+      {% if page.number == 1%}
       <div id="toc">
         {% include "export/as_printable_html/toc.html" with toc=toc %}
       </div>
+      {% endif %}
     </div>
 
     {% for child in children %}

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -22,13 +22,13 @@
         <section class="headnote">{{ headnote }}</section>
       {% endif %}
 
-      <a href="{{ node.resource.url }}" target="_blank" data-type="resource">{{ node.resource.url }}</a>
+      <a href="{{ node.resource.url }}" target="_blank" data-type="resource link">{{ node.resource.url }}</a>
 
     {% else %}
 
         <h1 class="{{ node.type }} title">
           <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
-          {{ node.title }}
+          <span>{{ node.title }}</span>
         </h1>
 
         {% if node.subtitle %}

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -9,7 +9,10 @@
 
             <ol>
             {% for child in top_level_node.children %}
-                <li><span class="ordinals">{{ child.ordinal_string }}</span> {{ child.title }}</li>
+                <li>
+                    <span class="ordinals">{{ child.ordinal_string }}</span>
+                    <span class="node-title">{{ child.title }}</span>
+                </li>
             {% endfor %}
             </ol>
         </li>

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -153,20 +153,23 @@
   .node-container > p, section > p {
     text-indent: 2em;
   }
-  .ordinal:not(:empty) {
-    display: inline-block;
-    margin: 0 1em 0 0;
+  .title > .ordinal:not(:empty) {
+    float: left;
+    width: 10mm;
   }
-
+  .title > span:nth-of-type(2) {
+    display: block;
+    margin-left: 10mm;
+  }
   .link-container {
     min-height: var(--link-icon-height);
     width: 100%;
   }
-  .link-container p {
-    margin-left: calc(var(--link-icon-width) + var(--link-icon-margin));
+
+  a[data-type~="link"] {
     word-break: break-all;
-    text-indent: 0;
   }
+
   .link-icon {
     width: var(--link-icon-width);
     height: var(--link-icon-height);

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -2,6 +2,7 @@ nav.toc {
     --toc-column-gap: 2mm;
     --toc-row-gap: 5mm;
     --toc-left-width: 10mm;
+    break-before: right;
 }
 nav.toc h2 {
     margin: calc(var(--toc-row-gap) * 2) 0;

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -10,30 +10,32 @@ nav.toc h3 {
     display: inline;
     margin: 0;
     font-size: 1em;
+    font-weight: bold;
 }
 nav.toc ol {
     padding: 0;
 }
+nav.toc ol > li {
+    padding: var(--toc-row-gap) 0 0 0;
 
-nav.toc > ol > li {
-    display: grid;
-    grid-template-columns: var(--toc-left-width) auto;
-    column-gap: var(--toc-column-gap);
-    row-gap: var(--toc-row-gap);
-    margin:  var(--toc-row-gap) 0 var(--toc-row-gap) 0;
+}
+nav.toc .ordinals {
+    width: calc(var(--toc-left-width) + var(--toc-column-gap));
+    float: left;
 }
 
-nav.toc > ol > li > ol{
-    grid-column: 1 / span 2;
+nav.toc .node-title {
+    display: block;
+    margin-left: calc(var(--toc-left-width) + var(--toc-column-gap));
 }
 
 nav.toc > ol > li > ol li {
-    display: grid;
-    grid-template-columns: var(--toc-left-width) auto;
-    column-gap: var(--toc-column-gap);
     line-height: 2em;
+}
+nav.toc > ol > li > ol li span {
+    display: inline-block;
 }
 
 nav.toc > ol > li > ol > li:last-child {
-    margin: 0 0 var(--toc-row-gap) 0;
+    margin: 0 0 calc(var(--toc-row-gap) * 1.5) 0;
 }


### PR DESCRIPTION
Changes the layout engine of the table of contents in the printable view to use a simple left-float for the ordinal + chapter/section title. 

The previous layout with CSS Grid was subject to an artifact in the PagedJS pagination whereby a long grid row could break across pages, resulting in a new block container (after reflow by PagedJS), in which case CSS would shove the longer section title into the small first column intended for the section number. This changes the layout to a less sophisticated float + span which should behave less weirdly with breaks.

This is a little tough to A/B because any change to the markup like this will reflow everything differently, but on spot-checking about 5 different books, things seem to break as I'd expect.

Here's how it looks:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/19571/193900964-29800f38-156f-4d12-a803-b3673fe26b85.png">

(as before, the underlines are only visible in the screen view as this is the primary way for previewing users to skip ahead in the book)