### PR TITLE
Stop "npm run serve" overwriting webpack-stats.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ python-shell.sh
 *.iml
 .vscode
 .mypy_cache
+
+# Dev-only webpack stats
+web/webpack-stats-serve.json

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Run the development server with hot-reloading vue-cli pipeline:
     or, with [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/index.html#) enabled,
     # fab run_frontend:debug_toolbar=True
 
-After making changes to frontend/, compile new assets:
+After making changes to frontend/, compile new assets if you want to see them from plain `fab run`:
 
     # npm run build
 
-(Or if you run_frontend and don't end up changing anything, then instead of running `npm run build` afterward
-you can just revert the changes to `webpack-stats.json`)
+`npm run build` will be automatically run by Github Actions as well, so it is unnecessary (but harmless) to build and
+commit the new assets locally, unless you want to use them immediately.
 
 ### Stop
 

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -224,7 +224,12 @@ WHITENOISE_USE_FINDERS = True
 WEBPACK_LOADER = {
     "DEFAULT": {
         "BUNDLE_DIR_NAME": "dist/",
-        "STATS_FILE": os.path.join(BASE_DIR, "webpack-stats.json"),
+        "STATS_FILE": os.path.join(
+            BASE_DIR,
+            "webpack-stats-serve.json"
+            if os.environ.get("LIVE_JS_ASSETS")
+            else "webpack-stats.json",
+        ),
     }
 }
 

--- a/web/fabfile.py
+++ b/web/fabfile.py
@@ -38,8 +38,8 @@ def setup_django(func):
 
 
 @task(alias="run")
-def run_django(port=None, debug_toolbar=""):
-    with shell_env(DEBUG_TOOLBAR=debug_toolbar):
+def run_django(port=None, debug_toolbar="", live_js_assets=""):
+    with shell_env(DEBUG_TOOLBAR=debug_toolbar, LIVE_JS_ASSETS=live_js_assets):
         if port is None:
             port = "0.0.0.0:8000" if os.environ.get("DOCKERIZED") else "127.0.0.1:8000"
         local(f"python manage.py runserver {port}")
@@ -49,7 +49,7 @@ def run_django(port=None, debug_toolbar=""):
 def run_frontend(port=None, debug_toolbar=""):
     node_proc = subprocess.Popen("npm run serve", shell=True, stdout=sys.stdout, stderr=sys.stderr)
     try:
-        run_django(port, debug_toolbar)
+        run_django(port, debug_toolbar=debug_toolbar, live_js_assets="1")
     finally:
         os.kill(node_proc.pid, signal.SIGKILL)
 

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -59,7 +59,7 @@ let vueConfig = {
         : [
             new RelativeBundleTracker({
               // output location of bundles so they can be found by django
-              filename: "./webpack-stats.json",
+              filename: devMode ? "./webpack-stats-serve.json" : "./webpack-stats.json",
             }),
           ]
     ),


### PR DESCRIPTION
Friday funday coding project! A small quality of life improvement to stop `fab run_frontend` from overwriting `webpack-stats.json`. This is a second attempt at #1732. I called the new stats file `webpack-stats-serve.json` to emphasize that it's the file created by running `npm run serve` instead of `npm run build`, and added a `LIVE_JS_ASSETS` environment variable (set by `fab run_frontend`) to tell Django that it should look for live assets from `npm run serve` instead of built assets from `npm run build`.

Note, I think it might be considerably clearer to call this file `vue-bundle-paths.json` (and `vue-bundle-paths-serve.json`) instead of `webpack-stats.json`. But that seemed confusing to mix in here, so, eh, something to consider.