### PR TITLE
Add first published and last modified dates to casebook page

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -295,14 +295,16 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
     margin-bottom: 2px;
     padding: 20px 20px 20px 30px;
     background-color: $white;
+    display: flex;
+    justify-content: space-between;
+
     .casebook-title {
       @include sans-serif($bold, 20px, 24px);
       color: $dark-gray;
     }
-    .reading-time {
-      float: right;
+    .casebook-date {
       color: $dark-gray;
-      font-size: 16px;
+      font-size: 14px;
       font-weight: 500;
     }
   }

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -4527,8 +4527,11 @@ class Casebook(EditTrackedModel, TimestampedModel, BigPkModel, TrackedCloneable)
     def revising(self):
         return self.draft_of
 
+    # Modification dates
+
     @property
     def grouped_edit_log(self):
+        # TODO document this method
         def change_priority(entry):
             return [
                 CasebookEditLog.ChangeType.ORIGINAL_PUBLISH.value,
@@ -4564,6 +4567,29 @@ class Casebook(EditTrackedModel, TimestampedModel, BigPkModel, TrackedCloneable)
                 )
         results.append(list(log_line.values()))
         return results
+
+    @property
+    def first_published(self) -> Optional[CasebookEditLog]:
+        """Return the edit log record representing the datetime of the first publication date, for user display"""
+        return (
+            self.edit_log.filter(change=CasebookEditLog.ChangeType.ORIGINAL_PUBLISH.value)
+            .order_by("-entry_date")
+            .first()
+        )
+
+    @property
+    def last_updated(self) -> Optional[CasebookEditLog]:
+        """Return the edit log record representing the datetime of the most-recent modification date, for user display"""
+        return (
+            self.edit_log.filter(
+                change__in=(
+                    CasebookEditLog.ChangeType.EDITED.value,
+                    CasebookEditLog.ChangeType.ANNOTATED.value,
+                )
+            )
+            .order_by("-entry_date")
+            .first()
+        )
 
 
 class Link(NullableTimestampedModel):

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -33,6 +33,14 @@
                 <div class="casebook-title">
                     {{ casebook.title }}
                 </div>
+                {% if page == "casebook_page" and casebook.first_published.entry_date %}
+                    <div class="casebook-date">
+                        First published {{ casebook.first_published.entry_date | date:"M j, Y" }}
+                        {% if casebook.last_updated.entry_date > casebook.first_published.entry_date %}
+                        and updated {{ casebook.last_updated.entry_date | date:"M j, Y" }}
+                        {% endif %}
+                    </div>
+                {% endif %}
             </header>
             {% if section %}
             <header class="content">

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -35,9 +35,9 @@
                 </div>
                 {% if page == "casebook_page" and casebook.first_published.entry_date %}
                     <div class="casebook-date">
-                        First published {{ casebook.first_published.entry_date | date:"M, Y" }}
+                        First published {{ casebook.first_published.entry_date | date:"M Y" }}
                         {% if casebook.last_updated.entry_date > casebook.first_published.entry_date %}
-                        and updated {{ casebook.last_updated.entry_date | date:"M, Y" }}
+                        and updated {{ casebook.last_updated.entry_date | date:"M Y" }}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -35,9 +35,9 @@
                 </div>
                 {% if page == "casebook_page" and casebook.first_published.entry_date %}
                     <div class="casebook-date">
-                        First published {{ casebook.first_published.entry_date | date:"M j, Y" }}
+                        First published {{ casebook.first_published.entry_date | date:"M, Y" }}
                         {% if casebook.last_updated.entry_date > casebook.first_published.entry_date %}
-                        and updated {{ casebook.last_updated.entry_date | date:"M j, Y" }}
+                        and updated {{ casebook.last_updated.entry_date | date:"M, Y" }}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1535,6 +1535,7 @@ class CasebookView(View):
                 "tabs": casebook.tabs_for_user(request.user),
                 "casebook_color_class": casebook.casebook_color_indicator,
                 "contents": contents,
+                "page": "casebook_page",  # The name of this page, the main casebook entry page
                 "publish_check": json.dumps(
                     {
                         "isVerifiedProfessor": request.user.is_authenticated


### PR DESCRIPTION
Puts some key dates for the Casebook on the "entry page" for the book (the page you land on from search).


<img width="857" alt="image" src="https://user-images.githubusercontent.com/19571/201724730-c876006b-0920-4127-a2db-5dece36879ac.png">

I put the date info on the right-hand side next to the title.

The history model (`CasebookEditLog`) only tracks "first published", not "most recently re-published", which is a somewhat nebulous concept since republished drafts are new books merged back into old ones. Hopefully this value is good enough here.

Most-recently-modified is the more recent of either when the casebook was edited or when it was annotated.

There weren't good hooks into the edit log model from the Django template side—the History page uses a somewhat complicated function to group changes. So I added two straightforward properties on the `Casebook` model.

## Testing 

I didn't include unit tests here though I could—since these properties are only called by a template (which produces no output if it errors) and are just encapsulated ORM queries, I felt it was safe enough to just manually check.

More screenshots in the linked issue.

Fixes https://github.com/harvard-lil/h2o/issues/1303 

