### PR TITLE
Change behavior of resource edit form

### DIFF
--- a/web/main/forms.py
+++ b/web/main/forms.py
@@ -238,7 +238,7 @@ class LinkForm(ModelForm):
         self.helper.layout = Layout(
             Div(
                 HTML('<h5 id="url-label">URL</h5>'),
-                Field("url", aria_labelledby="url-label"),
+                Field("url", aria_labelledby="url-label", type="url"),
             )
         )
         # Remove the explicit label on the "url" field, since it is

--- a/web/main/test/test_editing.py
+++ b/web/main/test/test_editing.py
@@ -1,0 +1,29 @@
+import pytest
+from test.test_helpers import check_response
+from pytest_django.asserts import assertContains, assertNotContains
+
+
+@pytest.fixture
+def casebook_or_draft(request):
+    """Return a casebook's draft if present, or the casebook itself"""
+    casebook = request.getfixturevalue(request.param)
+    return casebook.draft if casebook.draft else casebook
+
+
+@pytest.mark.parametrize(
+    "casebook_or_draft", ["full_private_casebook", "full_casebook_with_draft"], indirect=True
+)
+def test_edit_resources(casebook_or_draft, client):
+    """Users should be able to edit resource metadata via a web form"""
+    resource = casebook_or_draft.contents.first()
+    orig_title = resource.title
+    new_title = "owner-edited title"
+    check_response(
+        client.get(resource.get_edit_url(), as_user=resource.testing_editor),
+        content_includes=[resource.title, "casebook-draft"],
+    )
+    resp = client.post(
+        resource.get_edit_url(), {"title": new_title}, as_user=resource.testing_editor, follow=True
+    )
+    assertContains(resp, new_title)
+    assertNotContains(resp, orig_title)

--- a/web/main/test/test_editing.py
+++ b/web/main/test/test_editing.py
@@ -1,29 +1,102 @@
 import pytest
 from test.test_helpers import check_response
-from pytest_django.asserts import assertContains, assertNotContains
+from pytest_django.asserts import assertContains, assertNotContains, assertFormError
 
 
 @pytest.fixture
 def casebook_or_draft(request):
-    """Return a casebook's draft if present, or the casebook itself"""
-    casebook = request.getfixturevalue(request.param)
+    """Given a fixture name that corresponds to a casebook, return the casebook's draft if present,
+    or the casebook itself if not"""
+    casebook = request.getfixturevalue(
+        request.param
+    )  # Interpret the indirect parameter as a fixture and then run the fixture function
     return casebook.draft if casebook.draft else casebook
 
 
 @pytest.mark.parametrize(
     "casebook_or_draft", ["full_private_casebook", "full_casebook_with_draft"], indirect=True
 )
-def test_edit_resources(casebook_or_draft, client):
+@pytest.mark.parametrize(
+    "resource_type,edit_field,edit_value",
+    [
+        ["TextBlock", "title", "owner-edited title"],
+        ["LegalDocument", "title", "owner-edited title"],
+    ],
+)
+def test_edit_resources(casebook_or_draft, resource_type, edit_field, edit_value, client):
     """Users should be able to edit resource metadata via a web form"""
-    resource = casebook_or_draft.contents.first()
-    orig_title = resource.title
-    new_title = "owner-edited title"
+    resource = casebook_or_draft.contents.filter(resource_type=resource_type).first()
+    orig_value = getattr(resource, edit_field)
     check_response(
         client.get(resource.get_edit_url(), as_user=resource.testing_editor),
-        content_includes=[resource.title, "casebook-draft"],
+        content_includes=[orig_value],
     )
     resp = client.post(
-        resource.get_edit_url(), {"title": new_title}, as_user=resource.testing_editor, follow=True
+        resource.get_edit_url(),
+        {edit_field: edit_value},
+        as_user=resource.testing_editor,
+        follow=True,
     )
-    assertContains(resp, new_title)
-    assertNotContains(resp, orig_title)
+    assertContains(resp, edit_value)
+    assertNotContains(resp, orig_value)
+
+
+@pytest.mark.parametrize(
+    "casebook_or_draft", ["full_private_casebook", "full_casebook_with_draft"], indirect=True
+)
+@pytest.mark.parametrize(
+    "resource_type,edit_field,edit_value",
+    [
+        ["TextBlock", "content", "owner-edited content"],
+        ["Link", "url", "http://new.example.com"],
+    ],
+)
+def test_edit_subresource(casebook_or_draft, resource_type, edit_field, edit_value, client):
+    """Users should be able to edit Link or TextBlock data"""
+    resource = casebook_or_draft.contents.filter(resource_type=resource_type).first()
+    orig_value = getattr(resource.resource, edit_field)
+    edit_value = edit_value
+    check_response(
+        client.get(resource.get_edit_url(), as_user=resource.testing_editor),
+        content_includes=[orig_value],
+    )
+    post_body = {"title": "Title"}
+    post_body[edit_field] = edit_value
+    resp = client.post(
+        resource.get_edit_url(),
+        post_body,
+        as_user=resource.testing_editor,
+        follow=True,
+    )
+    assertContains(resp, edit_value)
+    assertNotContains(resp, orig_value)
+
+
+def test_subresource_validation(full_private_casebook, client):
+    """Passing invalid data to the subresource form should return a user-visible error"""
+    resource = full_private_casebook.contents.filter(resource_type="Link").first()
+    new_title = "New title"
+    new_url = "http://new.example.com"
+
+    # Ensure that the parent resource isn't modified if the subresource had a validation error
+    resp = client.post(
+        resource.get_edit_url(),
+        {"url": "invalid", "title": new_title},
+        as_user=resource.testing_editor,
+        follow=True,
+    )
+    resource.refresh_from_db()
+    assert resource.title != new_title
+    assertFormError(resp, "embedded_resource_form", "url", "Enter a valid URL.")
+
+    # Both forms must validate before any part of the resource can be saved
+    resp = client.post(
+        resource.get_edit_url(),
+        {"url": new_url, "title": new_title},
+        as_user=resource.testing_editor,
+        follow=True,
+    )
+    resource.refresh_from_db()
+    assert resource.title == new_title
+    resource.resource.refresh_from_db()
+    assert resource.resource.url == new_url

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2565,18 +2565,14 @@ def edit_resource(request, casebook, resource):
             if form.is_valid() and embedded_resource_form.is_valid():
                 embedded_resource_form.save()
                 form.save()
-                resource.resource.refresh_from_db()
-                resource.refresh_from_db()
-                form = ResourceForm(
-                    instance=resource, request=request
-                )  # workaround for no redirect-after-post
+                return redirect("edit_resource", casebook, resource)
             else:
                 return server_error(request)
         else:
             if form.is_valid():
                 form.save()
-                resource.resource.refresh_from_db()
-                resource.refresh_from_db()
+                return redirect("edit_resource", casebook, resource)
+
             else:
                 return server_error(request)
     if resource.resource_type == "TextBlock":

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -30,7 +30,6 @@ from django.http import (
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.html import escape
 from django.utils.text import Truncator
 from django.views import View
 from django.views.decorators.cache import never_cache


### PR DESCRIPTION
A few changes we've discussed to make the edit pages' behavior less surprising:

* When the form is successfully edited on POST, redirect back to the canonical edit page rather than reinitializing all the forms and letting the request fall through.
* If the page has a validation error, let Django display it rather than raising a server error.


I modified the Link form to use `type="url"` which should let the browser stop users from submitting non-URL values, but client-side validation is never triggered because the Save button is not a real form submit. However, Django does the right thing on POST and a new test asserts as much:

<img width="258" alt="image" src="https://user-images.githubusercontent.com/19571/202002269-d245e2de-3b8c-4d29-837f-61601010c577.png">

I moved the tests for this view out of doctests and into pytest functions to allow test parametrization.

Part of #1819 and #1050 (there are more views to be adjusted).