### PR TITLE
Redirect more views that have POST forms

### DIFF
--- a/web/main/test/test_auth.py
+++ b/web/main/test/test_auth.py
@@ -28,6 +28,7 @@ def test_change_password(user, client):
                 "new_password1": "new_password",
                 "new_password2": "new_password",
             },
+            follow=True,
         ),
         content_includes=["Your old password was entered incorrectly."],
     )

--- a/web/main/test/test_user_profile.py
+++ b/web/main/test/test_user_profile.py
@@ -1,0 +1,48 @@
+import pytest
+from pytest_django.asserts import assertContains
+from django.urls import reverse
+
+from conftest import UserFactory
+
+
+def test_edit_user_profile(user, client):
+    """Users should be able to request professor verification from the profile page"""
+
+    resp = client.get(reverse("edit_user"), as_user=user)
+    assertContains(resp, "Request Professor Verification")
+
+    resp = client.post(
+        reverse("edit_user"),
+        {
+            "professor_verification_requested": "on",
+            "email_address": user.email_address,
+            "affiliation": user.affiliation,
+            "attribution": user.attribution,
+        },
+        as_user=user,
+        follow=True,
+    )
+    assertContains(resp, "Your changes have been saved")
+    assertContains(resp, "Professor Verification Requested")
+
+
+@pytest.mark.parametrize("is_verified_professor,num_messages", [[True, 0], [False, 1]])
+@pytest.mark.django_db
+def test_email_for_verification(is_verified_professor, num_messages, client, mailoutbox):
+    """Only unverified users should trigger a professor verification email"""
+    user = UserFactory(verified_professor=is_verified_professor)
+
+    assert len(mailoutbox) == 0
+
+    client.post(
+        reverse("edit_user"),
+        {
+            "professor_verification_requested": "on",
+            "email_address": user.email_address,
+            "affiliation": user.affiliation,
+            "attribution": user.attribution,
+        },
+        as_user=user,
+        follow=True,
+    )
+    assert len(mailoutbox) == num_messages


### PR DESCRIPTION
Following the pattern in #1820, modify a few more edit forms to do redirect-after-post.

Moves the tests in the user profile page to pytest to allow for cleaner differentiation between professors and non-professors requesting verification. 

Updates the casebook settings page to use the same pattern and adds some post-submit messages to give the user some hint that there was a state change, e.g.:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/19571/202036003-c5533197-1bfb-4b42-bcf4-2d9974789b26.png">


Note that the "leave casebook" option doesn't currently work, see #1822. 
