### PR TITLE
Fix "remove myself from casebook" and inviting duplicate collaborators

### DIFF
--- a/web/main/forms.py
+++ b/web/main/forms.py
@@ -509,4 +509,3 @@ class InviteCollaboratorForm(forms.Form):
                 has_attribution=False, can_edit=False, user=user, casebook=casebook
             )
             send_invitation_email(request, user, casebook)
-

--- a/web/main/forms.py
+++ b/web/main/forms.py
@@ -492,20 +492,21 @@ class InviteCollaboratorForm(forms.Form):
         [email_user, email_domain] = self.cleaned_data["email"].split("@")
         return f"{email_user}@{email_domain.lower()}"
 
-    def save(self, request, commit=True):
+    def save(self, request, commit=True) -> None:
         email_address = self.cleaned_data["email"]
         casebook = Casebook.objects.get(id=self.cleaned_data["casebook"])
 
         if user := User.objects.filter(email_address__iexact=email_address).first():
-            collaborator = ContentCollaborator.objects.create(
-                has_attribution=False, can_edit=False, user=user, casebook=casebook
-            )
-            send_collaboration_email(request, user, casebook)
+            # If this user exists and is not yet a collaborator, create them and notify them via email
+            if ContentCollaborator.objects.filter(user=user, casebook=casebook).count() == 0:
+                ContentCollaborator.objects.create(
+                    has_attribution=False, can_edit=False, user=user, casebook=casebook
+                )
+                send_collaboration_email(request, user, casebook)
         else:
             user = User.objects.create(email_address=email_address)
-            collaborator = ContentCollaborator.objects.create(
+            ContentCollaborator.objects.create(
                 has_attribution=False, can_edit=False, user=user, casebook=casebook
             )
             send_invitation_email(request, user, casebook)
 
-        return collaborator

--- a/web/main/templates/casebook_settings.html
+++ b/web/main/templates/casebook_settings.html
@@ -91,6 +91,7 @@
                     <br />
                     <h4>Leave Collaboration</h4>
                     <form action="{% url 'casebook_settings' casebook %}" method="POST" class="form-control-group" >
+                        {% csrf_token %}
                         <button type="submit"
                                 class="btn btn-danger"
                                 name="submission_type"

--- a/web/main/test/test_forms.py
+++ b/web/main/test/test_forms.py
@@ -42,6 +42,7 @@ def test_collaborator_invite_existing(casebook_factory, faker, mailoutbox):
 
     form = InviteCollaboratorForm(data={"casebook": casebook.id, "email": email})
     assert form.is_valid()
+    form.save(Mock())
     assert len(mailoutbox) == 1  # Unchanged
 
 

--- a/web/main/test/test_forms.py
+++ b/web/main/test/test_forms.py
@@ -30,6 +30,21 @@ def test_collaborator_invite(casebook_factory, faker):
     assert User.objects.filter(email_address__iexact=email).count() == 1
 
 
+def test_collaborator_invite_existing(casebook_factory, faker, mailoutbox):
+    """Don't try to create duplicate collaborators if they already exist"""
+    email = faker.email()
+
+    casebook = casebook_factory()
+    form = InviteCollaboratorForm(data={"casebook": casebook.id, "email": email})
+    assert form.is_valid()
+    form.save(Mock())
+    assert len(mailoutbox) == 1
+
+    form = InviteCollaboratorForm(data={"casebook": casebook.id, "email": email})
+    assert form.is_valid()
+    assert len(mailoutbox) == 1  # Unchanged
+
+
 def test_resourceform_user(full_private_casebook, client):
     """The resource form should only render the instructional toggle if the user is a verified professor"""
     user = full_private_casebook.testing_editor


### PR DESCRIPTION
Two unrelated bug fixes on the casebook settings page:

* Provide a CSRF token for the "remove myself" flow.
* Check whether a collaborator exists for a given user/casebook combination before trying to create a new one.

This message added in #1823 now works, as does the feature:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/19571/202224394-34de849a-9c95-4fe2-9720-631ddf1dac87.png">
