### PR TITLE
Redirect-after-POST for edit_casebook; reduce duplicate code in sources check

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1164,7 +1164,7 @@ class LegalDocumentSource(models.Model):
             cls.source_apis[api.details["name"]] = api
 
     @classmethod
-    def active_sources(cls, user: Optional[AnonymousUser | User]) -> QuerySet[LegalDocumentSource]:
+    def active_sources(cls, user: Union[AnonymousUser, User]) -> QuerySet[LegalDocumentSource]:
         """Return the queryset of active sources based on the user's current permissions"""
         search_sources = LegalDocumentSource.objects.order_by("priority")
         if user.is_anonymous or not user.is_superuser:

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1163,6 +1163,14 @@ class LegalDocumentSource(models.Model):
         if api.details["name"] not in cls.source_apis:
             cls.source_apis[api.details["name"]] = api
 
+    @classmethod
+    def active_sources(cls, user: Optional[AnonymousUser | User]) -> QuerySet[LegalDocumentSource]:
+        """Return the queryset of active sources based on the user's current permissions"""
+        search_sources = LegalDocumentSource.objects.order_by("priority")
+        if user.is_anonymous or not user.is_superuser:
+            search_sources = search_sources.filter(active=True)
+        return search_sources
+
     def api_model(self):
         # short_description, long_description, bulk_process, search(long_citation_json), import(id)
         if self.search_class in self.source_apis:


### PR DESCRIPTION
The main thing here is continuing #1050 work to make Django view pages redirect as normal, this time for the casebook edit page.

This also reduces a bunch of repeated code to draw from the list of possible sources for searching using the quick add. I suspect that this code could actually be excised ultimately—if we want to add beta search sources going forward I think we should use a more traditional feature flag approach rather than custom permission checks. All I did here was package up the repetition into a class function that should have the same logic.