### PR TITLE
Use user permission check for media only; fixes #1825

### DIFF
--- a/web/frontend/pages/rich_text_editor.js
+++ b/web/frontend/pages/rich_text_editor.js
@@ -12,7 +12,7 @@ import 'tinymce/plugins/media';
 import 'tinymce/plugins/noneditable';
 import {getInitConfig} from '../libs/tinymce_extensions';
 
-const ENHANCED = window.VERIFIED || window.SUP;
+const ENHANCED = window.ENABLE_MEDIA_UPLOAD;
 
 function initRichTextEditor(element, code=false) {
   // Vue rebuilds the whole dom in between the call to init and tinymce actually doing the init

--- a/web/frontend/styles/layout.scss
+++ b/web/frontend/styles/layout.scss
@@ -40,7 +40,7 @@ main > section, main > header {
   }
 }
 
-section#flash {
+section.flash {
   @include transition(height 0.25s linear);
   height: auto;
   overflow: hidden;
@@ -58,6 +58,9 @@ section#flash {
       @extend .alert-info;
     }
     &.flash-error {
+      @extend .alert-danger;
+    }
+    &.flash-admin {
       @extend .alert-danger;
     }
   }

--- a/web/main/templates/base.html
+++ b/web/main/templates/base.html
@@ -10,7 +10,7 @@
     <script>
      {# frontend_urls is set by config.context_processors.frontend_urls #}
      const FRONTEND_URLS = {{ frontend_urls | safe}};
-     window.SUP = {% if super %}true{% else %}false{% endif %};
+     window.ENABLE_MEDIA_UPLOAD =  {% if request.user.is_superuser or request.user.verified_professor %}true{% else %}false{% endif %};
      window.VERIFIED = {% if request.user.verified_professor %}true{% else %}false{% endif %};
      window.sentry = {
        USE_SENTRY: {{ USE_SENTRY|lower }},
@@ -39,16 +39,16 @@
       <main>
         {% block custom_skip_target %}<p id="main" tabindex="-1" class="sr-only">Main Content</p>{% endblock %}
         {% if request.user.is_superuser %}
-          <section id="flash">
+          <section class="flash">
             <div class="content">
-              <div class="flash-error flash-message">
+              <div class="flash-admin flash-message">
                 Admin Mode
               </div>
             </div>
           </section>
         {% endif %}
         {% if messages %}
-          <section id="flash">
+          <section class="flash">
             <div class="content">
               {% for message in messages %}
                 <div class="flash-message flash-{% if message.tags %}{{ message.tags }}{% endif %}">{{ message }}</div>

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2547,7 +2547,6 @@ def edit_resource(request, casebook, resource):
             "form": form,
             "embedded_resource_form": embedded_resource_form,
             "body_json": body_json,
-            "super": request.user.is_superuser,
             "publish_check": json.dumps(
                 {
                     "isVerifiedProfessor": request.user.is_authenticated


### PR DESCRIPTION
Uploading media and embeds is a feature with a light permission gate on verified professors and internal users. This change fixes a bug where the check was being incorrectly unapplied on many pages, and makes it clear the check is to be used only for media uploads. 

Made a few cosmetic changes related to user permissions display while I was here:

* A banner at the top says "Admin Mode" to remind internal users that they have escalated permissions. This was using an 'error' class to generate a red box but isn't actually an error, so I made a new class that applied to this case but re-used the error style. Basically a no-opt that has some less misleading markup.
* Changed the banner selector from an id to a class since both the admin banner and the messages banner can appear.

Looks like it should:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/19571/203089536-c4fe95d9-b74d-4e45-b1e5-dadc8926e8fd.png">
