### PR TITLE
Tidy up items in the Credits tab; fixes #1813

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -753,7 +753,12 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
     section.credits {
         background-color:$white;
         border-top: 1px solid $light-gray;
-        padding: 2rem 2rem 4rem 2rem;
+        padding: 0 30px 4rem 30px;
+        h3 {
+            @include sans-serif($bold, 20px, 24px);
+            color: $dark-gray;
+
+        }
         .author-rider {
             margin-top: 1rem;
         }
@@ -781,7 +786,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
             }
 
             display: inline;
-            padding-left:4px;
+            padding-left: 0;
 
 
             ul {
@@ -798,7 +803,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
             list-style: none;
             display:flex;
             flex-direction: column;
-            padding: 8px;
+            padding: 0px 0 4rem 0;
             >li {
                 padding-bottom:3rem;
                 border-bottom: 1px solid black;
@@ -810,12 +815,12 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
                 }
             }
             .casebook-credit-header {
-                padding: 1rem 1rem 0 1rem;
+                padding: 1rem 0;
 
             }
             .cloned-content-list {
                 list-style:none;
-                padding-left:16px;
+                padding-left: 0;
                 display:flex;
                 flex-direction:column;
                 flex-wrap: wrap;

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -7,32 +7,34 @@
             <li>
                 <div class="casebook-credit-header">
                     <a href="{{row.casebook.get_absolute_url}}"><h4> {{ row.casebook.title }} </h4></a>
-                    <div class="author-list">
-                        <span>Authors: </span>
-                        <ul class="immediate-author-list">
-                            {% for user in row.immediate_authors %}
-                            <li class="user {% if user.verified_professor %} verified{% endif %}">
-                                <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% if row.incidental_authors %}
-                        <span> with additional contributions by:</span>
-                        <ul class="incidental-author-list">
-                            {% for user in row.incidental_authors %}
-                            <li class="user {% if user.verified_professor %} verified{% endif %}">
-                                <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% endif %}
-                    </div>
+                    {% if row.immediate_authors or row.incidental_authors %}
+                        <div class="author-list">
+                            <span>Authors: </span>
+                            <ul class="immediate-author-list">
+                                {% for user in row.immediate_authors %}
+                                <li class="user {% if user.verified_professor %} verified{% endif %}">
+                                    <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                            {% if row.incidental_authors %}
+                            <span> with additional contributions by:</span>
+                            <ul class="incidental-author-list">
+                                {% for user in row.incidental_authors %}
+                                <li class="user {% if user.verified_professor %} verified{% endif %}">
+                                    <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
                 <div class="casebook-credit-nodes">
                     <ul class="cloned-content-list">
                         {% for node,prior,nesting_depth in row.nodes %}
                         <li class="nesting-depth-{{nesting_depth}}">
-                            <span class="section-title">{{ node.ordinal_string }}: {{ node.title }} </span> <a class="og-node-link" href="{{ prior.get_absolute_url }}">original</a>
+                            <span class="section-title">{{ node.ordinal_string }}{% if node.ordinal_string %}:{% endif %} {{ node.title }} </span> <a class="og-node-link" href="{{ prior.get_absolute_url }}">original</a>
                         </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
Primarily addresses #1813 where books with unnumbered sections looked strange in the credits tab with an orphaned colon. Now the colon is omitted if there's no numbering.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/19571/203100542-32928afe-1faf-45e5-8cbd-1580f72cf82e.png">

Still present if there is numbering:

<img width="727" alt="image" src="https://user-images.githubusercontent.com/19571/203101586-8bfa7f78-97df-4eda-a585-6d295ed98600.png">

While there, did a few purely stylistic changes that I feel tighten up the page:

The header had been largely undefined in its style and inherited whatever the browser default was for `h3`. I set it to match the styling and alignment of the casebook title on the detail page. Now when switching between these tabs the alignment is consistent.

Same with the overall padding and margin of the content area—it should now match the detail page.

Other style changes:

* Don't show the "Authors" heading if there are no authors to attribute (common in early drafts)
* Tightened up some seemingly-arbitrary indenting for the casebook nodes. 

**Before**

<img width="455" alt="image" src="https://user-images.githubusercontent.com/19571/203103087-a8b8bcdc-3ae9-4eea-8f10-357973c4cf66.png">

**After**

<img width="446" alt="image" src="https://user-images.githubusercontent.com/19571/203103133-31c73a1b-8eae-474e-9366-fcc1f0067940.png">
