### PR TITLE
Make section headings searchable in "Search Inside"

### DIFF
--- a/web/main/create_fts_index.sql
+++ b/web/main/create_fts_index.sql
@@ -43,7 +43,7 @@ UNION ALL
         INNER JOIN main_contentnode cn ON cn.resource_id = t.id AND cn.resource_type = 'TextBlock'
     GROUP BY t.id, cn.id
 UNION ALL
-    -- Sections effectively only have titles, so limit populating the index to that fields
+    -- Sections effectively only have titles, so limit populating the index to that field
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            cn.id AS result_id,

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1084,9 +1084,6 @@ class FullTextSearchIndex(models.Model):
         elif category == "textblock":
             query_class = TextBlock
             content_name = "content"
-        elif category == "section":
-            query_class = ContentNode
-            content_name = "name"
         elif category == "link":
             query_class = Link
             content_name = "description"
@@ -4926,4 +4923,4 @@ class LiveSettings(models.Model):
         verbose_name_plural = "Live settings"
 
 
-ResourceType = Union[Type[LegalDocument], Type[Link], Type[TextBlock], Type[ContentNode]]
+ResourceType = Union[Type[LegalDocument], Type[Link], Type[TextBlock]]

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -25,7 +25,7 @@
             {% endif %}
           </div>
         </a>
-      {% elif category == 'textblock' %}
+      {% elif category == 'textblock' or category == 'section' %}
         <a href="{% url 'resource' casebook.id result.metadata.ordinals %}" class="wrapper" data-result-id="{{ result.result_id }}">
           <div class="fts-results-entry">
             <div class="title">
@@ -36,8 +36,9 @@
             <div class="ordinals">
                 {{ result.metadata.ordinals }}
             </div>
+
             {% if result.metadata.headlines|length > 1%}
-              <div class="description">
+            <div class="description">
                  {% autoescape off %}
                  {% for headline in result.metadata.headlines|slice:"0:4" %}
                    ...

--- a/web/main/templates/search/results.html
+++ b/web/main/templates/search/results.html
@@ -25,7 +25,7 @@
             {% endif %}
           </div>
         </a>
-      {% elif category == 'textblock' or category == 'section' %}
+      {% elif category == 'textblock' %}
         <a href="{% url 'resource' casebook.id result.metadata.ordinals %}" class="wrapper" data-result-id="{{ result.result_id }}">
           <div class="fts-results-entry">
             <div class="title">
@@ -36,9 +36,8 @@
             <div class="ordinals">
                 {{ result.metadata.ordinals }}
             </div>
-
             {% if result.metadata.headlines|length > 1%}
-            <div class="description">
+              <div class="description">
                  {% autoescape off %}
                  {% for headline in result.metadata.headlines|slice:"0:4" %}
                    ...


### PR DESCRIPTION
Fixes #1832 

Adds section title content to the "Search Inside" feature.

This was a little less straightforward than I'd assumed at first because a `TextBlock` and a section aren't the same kind of thing. Since the `Section` proxy class is DOA, this code only cares about `ContentNodes` with the right (usually null) resource type.

I assumed we'd want to group section results in with "Text Passages" so it looks like this (the first two results are sections):

<img width="807" alt="image" src="https://user-images.githubusercontent.com/19571/205744755-14ee723c-cda7-4899-a264-567883e45545.png">

I considered labelling the sections as such but it doesn't seem necessary. Clicking on the section title takes you to the section.

Also shortened this function mostly by making some function calls guaranteed to return empty string or empty list results so a number of if/else checks could be eliminated.