### PR TITLE
Handle when some legal doc metadata fields might be present but None

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1115,10 +1115,12 @@ class FullTextSearchIndex(models.Model):
 
             if category == "legal_doc_fulltext":
                 r.metadata["ordinals"] = ".".join(ids_ordinals[r.result_id])
-                r.metadata["citations"] = r.metadata.get("citations", "").split(";;")
-                r.metadata["year"] = (
-                    r.metadata.get("effective_date_formatted", "").split(",")[-1].strip()
-                )
+                if citations := r.metadata.get("citations"):
+                    r.metadata["citations"] = citations.split(";;")
+                if effective_date := r.metadata.get("effective_date_formatted"):
+                    r.metadata["year"] = (
+                        effective_date.split(",")[-1].strip()
+                    )
 
         return results_page
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1118,9 +1118,7 @@ class FullTextSearchIndex(models.Model):
                 if citations := r.metadata.get("citations"):
                     r.metadata["citations"] = citations.split(";;")
                 if effective_date := r.metadata.get("effective_date_formatted"):
-                    r.metadata["year"] = (
-                        effective_date.split(",")[-1].strip()
-                    )
+                    r.metadata["year"] = effective_date.split(",")[-1].strip()
 
         return results_page
 


### PR DESCRIPTION
fixes #1836

I tested this locally using the same casebook that Sentry flagged (it was just a bot crawling the site so it was deep on page 10 of an older casebook).

I assume it was the middle item here: 

<img width="536" alt="image" src="https://user-images.githubusercontent.com/19571/206303806-6451a5bd-0043-4cf9-a8f8-ffa627a0a256.png">
