### PR TITLE
Update certifi

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -64,9 +64,9 @@ botocore==1.20.98 \
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30 \
-    --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee \
-    --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
This version of certifi removes TrustCor's root certificate. I haven't found release notes, but here's the diff from the previous version to this:

https://github.com/certifi/python-certifi/compare/2022.09.24...2022.12.07

(We're running an older package -- here's the [longer diff](https://github.com/certifi/python-certifi/compare/2021.05.30...2022.12.07).)