### PR TITLE
Add discovery/featured books page; fixes #1838

### DIFF
--- a/web/frontend/styles/header.scss
+++ b/web/frontend/styles/header.scss
@@ -37,7 +37,7 @@ body {
         // The text is hidden and is replaced visually by an image
         background-image: url('~static/images/logo.svg');
         background-position: 10px center;
-    background-repeat: no-repeat;
+        background-repeat: no-repeat;
         background-size: initial;
         color: transparent;
 

--- a/web/frontend/styles/pages.scss
+++ b/web/frontend/styles/pages.scss
@@ -1,10 +1,24 @@
 
 .pages-content {
-  padding: 20px 20px;
-  width: 80%;
+
+  padding: 5vh 15px 10vh 15px;
+
   margin: 0px auto;
   font-family: $font-family-sans-serif;
 
+  @media (min-width: 768px) {
+    width: 750px;
+  }
+  @media (min-width: 992px) {
+    width: 869px;
+  }
+  @media (min-width: 1200px) {
+      width: 1170px;
+  }
+
+  h1 {
+    margin: 0 0 4rem 0;
+  }
   h2 {
     @include sans-serif($bold, 24px, 36px);
   }
@@ -26,5 +40,27 @@
   }
   a {
     text-decoration: underline !important;
+  }
+  &.featured-casebooks {
+    h1 {
+      padding: 0 0 2rem 0;
+    }
+
+    h3 {
+      padding: 0;
+    }
+    .verified-prof {
+      background: none;
+    }
+    @include sans-serif($regular, 18px, 24px);
+
+    .courses-grid {
+      display: grid;
+
+      gap: 2vw;
+      @media (min-width: 768px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
   }
 }

--- a/web/frontend/styles/pages.scss
+++ b/web/frontend/styles/pages.scss
@@ -45,7 +45,12 @@
     h1 {
       padding: 0 0 2rem 0;
     }
-
+    h2 {
+      margin-top: 4rem;
+    }
+    h2:last-of-type {
+      margin-bottom: 4rem;
+    }
     h3 {
       padding: 0;
     }

--- a/web/main/templates/includes/analytics.html
+++ b/web/main/templates/includes/analytics.html
@@ -6,6 +6,7 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
+      _paq.push(['trackVisibleContentImpressions']);
       (function() {
       var u="{{ MATOMO_SITE_URL }}";
       _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/web/main/templates/includes/featured_casebook.html
+++ b/web/main/templates/includes/featured_casebook.html
@@ -1,0 +1,26 @@
+{% if casebook %}
+<section class="featured-casebook">
+    <span class="title">
+        <a href="{% url 'casebook_info' casebook %}"
+           data-track-content
+           data-content-name="{{ title }} ({{ casebook.id }})"
+           data-content-piece="Featured casebooks"
+        >{{ title }}</a></span>
+    {% if authors %}
+        by
+        <span class="authors">
+            {% for author in authors %}
+            <span {% if author.verified_professor %}class="verified-prof" {% endif %}>
+                {% if authors|length > 1 and forloop.last %}
+                  and
+                {% endif %}
+                {{ author.display_name }}
+            </span>
+            {% endfor %}
+    </span>
+    {% endif %}
+</section>
+{% else %}
+    <!-- Error: {{ error }}-->
+{% endif %}
+

--- a/web/main/templates/pages/about.html
+++ b/web/main/templates/pages/about.html
@@ -2,9 +2,8 @@
 {% block page_title %}About{% endblock %}
 
 {% block mainContent %}
-<div class="content">
-  <div class="pages-content">
-    
+ <div class="pages-content">
+
  <h1>About H2O Open Casebook</h1>
 
   <h2>What is H2O?</h2>
@@ -16,15 +15,15 @@
   <h2>How does H2O work?</h2>
   <p>H2O allows professors to develop, remix, and collaborate on digital course materials under a Creative Commons Attribution-Noncommercial-Share Alike 3.0 License (per the Terms of Service). This open licensing means that everything in H2O is free to share and re-use for non-commercial purposes as long as proper attribution is applied (which we take care of in the platform).</p>
   <p>Powered by a database of 6.5M+ court opinions and an integration with Federal U.S. Code, H2O allows authors to seamlessly integrate these primary legal documents alongside other digital content. Materials faculty can create with H2O include casebooks, syllabi, reading lists, and modules. Final casebooks are available freely online to be easily accessed by students and colleagues, and can be printed from anywhere.</p>
-  
+
   <h2>Who can use H2O?</h2>
-  <p>While our focus right now is supporting law school faculty and students, H2O is a free and open platform. Anybody associated with an educational organization or government entity can sign up and create their own resource or adapt an existing one. An account is not required to read H2O casebooks, which are available to anybody with an internet connection</p>  
+  <p>While our focus right now is supporting law school faculty and students, H2O is a free and open platform. Anybody associated with an educational organization or government entity can sign up and create their own resource or adapt an existing one. An account is not required to read H2O casebooks, which are available to anybody with an internet connection</p>
   <p>Over 100 faculty authors have published H2O casebooks to use in their courses. About a third of them are from Harvard Law School - the remaining authors are from institutions across the country and around the world.</p>
-   
+
   <hr>
-    
+
   <p><i>H2O is built on top of the <a href="https://case.law">Caselaw Access Project</a> - a database of 6.5M+ court opinions freely available online and hosted by the Harvard Law School Library. If you’re including links in your casebook, consider creating a <a href="https://perma.cc">perma.cc</a> link to protect your materials from linkrot.</i></p>
-  </div>
+
 </div>
 
 {% endblock %}

--- a/web/main/templates/pages/featured_casebooks.html
+++ b/web/main/templates/pages/featured_casebooks.html
@@ -1,0 +1,125 @@
+{% extends 'base.html' %}
+{% load featured_casebook  %}
+{% block page_title %}Featured Casebooks{% endblock %}
+
+{% block mainContent %}
+<div class="pages-content featured-casebooks">
+
+    <h1>Featured Casebooks</h1>
+
+    <h2>1L Courses</h2>
+
+    <div class="courses-grid">
+
+        <section>
+            <h3 class="topic">Civil Procedure</h3>
+
+            {% featured_casebook 5196 title="Civil Procedure" authors="Glenn Cohen" %}
+            {% featured_casebook 1245 %}
+            {% featured_casebook 4444 title="U.S. Civil Procedure for International Students"%}
+        </section>
+
+        <section>
+
+            <h3 class="topic">Constitutional Law</h3>
+
+            {% featured_casebook 5182 %}
+            {% featured_casebook 531 %}
+            {% featured_casebook 6029 authors="Natalie Gomez-Velez" %}
+        </section>
+
+        <section>
+            <h3 class="topic">Contracts</h3>
+            {% featured_casebook 4201 title="Contracts" authors="John Coates" %}
+            {% featured_casebook 477 title="Contracts Casebook" %}
+            {% featured_casebook 3665 title="Contracts: Happiness and Heartbreak" authors="Randall Kennedy" %}
+        </section>
+
+        <section>
+        <h3 class="topic">Criminal Law</h3>
+            {% featured_casebook 3553 title="Crim Law" %}
+            {% featured_casebook 5587 title="Criminal Law" %}
+            {% featured_casebook 6083 title="Federal Criminal Law" %}
+            {% featured_casebook 5713 %}
+            {% featured_casebook 2459 title="Criminal Law" %}
+            {% featured_casebook 6003 %}
+        </section>
+
+        <section>
+            <h3 class="topic">Property</h3>
+            {% featured_casebook 2202 title="Property Law" %}
+        </section>
+
+        <section>
+            <h3 class="topic">Torts</h3>
+            {% featured_casebook 379 title="Torts" %}
+            {% featured_casebook 2566 %}
+            {% featured_casebook 187 %}
+        </section>
+    </div>
+
+    <h2>Upper Level Courses</h2>
+
+    <div class="courses-grid">
+        <section>
+            <h3 class="topic">Corporations</h3>
+            {% featured_casebook 237 title="An Introduction to the Law of Corporations" %}
+            {% featured_casebook 261 %}
+        </section>
+
+        <section>
+            <h3 class="topic">Employment Law</h3>
+            {% featured_casebook 3728 authors="Erin Buzuvis" %}
+            {% featured_casebook 5444 %}
+        </section>
+
+        <section>
+            <h3 class="topic">Evidence</h3>
+            {% featured_casebook 5959 title="Advanced Evidence" authors="Nina Chernoff" %}
+            {% featured_casebook 6094 title="Evidence" authors="Nina Chernoff" %}
+            {% featured_casebook 230 %}
+        </section>
+
+        <section>
+            <h3 class="topic">Lawyering</h3>
+            {% featured_casebook 762 %}
+            {% featured_casebook 6195 title="Lawyering Seminar" authors="Sarah Lamdan" %}
+        </section>
+
+        <section>
+            <h3 class="topic">Technology and the Law</h3>
+            {% featured_casebook 2554 %}
+            {% featured_casebook 4395 title="Music and Digital Media" %}
+            {% featured_casebook 6714 title="Technology, Human Rights, and Cybersecurity" authors="Vivek Krishnamurthy" %}
+        </section>
+
+        <section>
+            <h3 class="topic">Other Topics</h3>
+            {% featured_casebook 3648 title="Advanced Legislation" %}
+            {% featured_casebook 4746 title="Asian Americans and U.S. Law" %}
+            {% featured_casebook 2953 title="Cambio Climático, Protección del Medio Ambiente y Recursos Naturales" %}
+            {% featured_casebook 2806 %}
+            {% featured_casebook 588 title="Family Law" %}
+            {% featured_casebook 5386 %}
+            {% featured_casebook 5485 title="Immigration Law" %}
+            {% featured_casebook 1045 title="Public Institutions: Administrative Law Cases and Material"%}
+            {% featured_casebook 109 %}
+            {% featured_casebook 29 title="The Role of State Attorneys General" %}
+        </section>
+
+    </div>
+
+    <h2>Graduate and Undergraduate Courses</h2>
+
+    <div class="courses-grid">
+        <section>
+        {% featured_casebook 2175 authors="Mary Lou Coilfi" %}
+        {% featured_casebook 882 %}
+        {% featured_casebook 960 %}
+        {% featured_casebook 4082 %}
+        {% featured_casebook 4477 title="Law & Society" %}
+        </section>
+    </div>
+
+</div>
+{% endblock %}

--- a/web/main/templates/pages/privacy-policy.html
+++ b/web/main/templates/pages/privacy-policy.html
@@ -2,8 +2,8 @@
 
 {% block page_title %}Privacy Policy{% endblock %}
 {% block mainContent %}
-<div class="content">
-  <div class="pages-content">
+
+<div class="pages-content">
 
     <h1>Privacy Policy</h1>
 
@@ -43,6 +43,6 @@
 
     <p>If you have questions about this privacy policy, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</p>
     <p>Last modified on April 24, 2019.</p>
-  </div>
+
 </div>
 {% endblock %}

--- a/web/main/templates/pages/terms-of-service.html
+++ b/web/main/templates/pages/terms-of-service.html
@@ -3,114 +3,113 @@
 {% block page_title %}Terms of Service{% endblock %}
 {% block mainContent %}
 
-<div class="content">
-    <div class="pages-content">
+<div class="pages-content">
 
-        <h1>Terms of Service</h1>
-        <h2>1. General</h2>
-        <p>The H2O project ("H2O"), including the opencasebook.org website (the "Site") and any related services (collectively, the "H2O Services") are maintained and operated by the Harvard Law School Library ("HLSL").</p>
-        <p>These terms and conditions (the "Terms of Service") govern your use of the H2O Services, and by using or accessing any portion of the H2O Services you agree to be bound by these Terms of Service, so please read these terms carefully before using or accessing H2O Services. If you do not agree to and accept these Terms of Service, including the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>, please do not register for an account or use the H2O Services in any manner. All individuals who access or otherwise use the H2O Services, including casual visitors to the Site, are referred to in these Terms of Service as "Users."</p>
+    <h1>Terms of Service</h1>
+    <h2>1. General</h2>
+    <p>The H2O project ("H2O"), including the opencasebook.org website (the "Site") and any related services (collectively, the "H2O Services") are maintained and operated by the Harvard Law School Library ("HLSL").</p>
+    <p>These terms and conditions (the "Terms of Service") govern your use of the H2O Services, and by using or accessing any portion of the H2O Services you agree to be bound by these Terms of Service, so please read these terms carefully before using or accessing H2O Services. If you do not agree to and accept these Terms of Service, including the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>, please do not register for an account or use the H2O Services in any manner. All individuals who access or otherwise use the H2O Services, including casual visitors to the Site, are referred to in these Terms of Service as "Users."</p>
 
-        <h2>2. Privacy Policy</h2>
-        <p>H2O respects your privacy. How H2O uses, collects, and stores data is governed by the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By using the H2O Services, you indicate that you understand and consent to the collection, use and disclosure of your information as described in H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By agreeing to these Terms of Service, you additionally agree to be bound by H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>.</p>
+    <h2>2. Privacy Policy</h2>
+    <p>H2O respects your privacy. How H2O uses, collects, and stores data is governed by the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By using the H2O Services, you indicate that you understand and consent to the collection, use and disclosure of your information as described in H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By agreeing to these Terms of Service, you additionally agree to be bound by H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>.</p>
 
-        <h2>3. Account Creation</h2>
-        <p>In order to use some features of the H2O Services, you will need to register with H2O and create an account. When registering, you will be asked to provide certain personal information, such as your email address. Please see H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a> for H2O’s data-retention and usage policies. You agree not to create an account using false or misleading information or on behalf of someone other than yourself. Accounts created using intentionally misleading information are subject to termination at H2O’s sole discretion. If you have been banned or had your account revoked, you may not register for another account.</p>
+    <h2>3. Account Creation</h2>
+    <p>In order to use some features of the H2O Services, you will need to register with H2O and create an account. When registering, you will be asked to provide certain personal information, such as your email address. Please see H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a> for H2O’s data-retention and usage policies. You agree not to create an account using false or misleading information or on behalf of someone other than yourself. Accounts created using intentionally misleading information are subject to termination at H2O’s sole discretion. If you have been banned or had your account revoked, you may not register for another account.</p>
 
-        <h2>4. Obligations and Restrictions on Use of the H2O Services</h2>
-        <p>Your use of the H2O Services is subject to the following restrictions and obligations:</p>
-        <ul>
-            <li>a. You may use H2O only for personal, educational, or other types of noncommercial uses.</li>
-            <li>b. You may not sell, rent, or otherwise offer the H2O Services to third parties, without H2O’s prior written consent.</li>
-            <li>c. Use of the H2O Services in any way that is unlawful, fraudulent, defamatory, obscene, or otherwise harmful, including, but not limited to, displaying content in a manner that violates any applicable laws, statutes, or regulations, or that H2O, in its sole discretion, finds to be obscene or defamatory is prohibited.</li>
-            <li>d. You agree to comply with all applicable laws, including, but not limited to, any privacy laws, as well as H2O’s policies when you use the H2O Services.</li>
-            <li>e. You may not use the H2O Services in any way that interferes with the operation of the H2O Services or impacts any other User, host, or network, or circumvents any of the H2O Services’ security protections.</li>
-        </ul>
+    <h2>4. Obligations and Restrictions on Use of the H2O Services</h2>
+    <p>Your use of the H2O Services is subject to the following restrictions and obligations:</p>
+    <ul>
+        <li>a. You may use H2O only for personal, educational, or other types of noncommercial uses.</li>
+        <li>b. You may not sell, rent, or otherwise offer the H2O Services to third parties, without H2O’s prior written consent.</li>
+        <li>c. Use of the H2O Services in any way that is unlawful, fraudulent, defamatory, obscene, or otherwise harmful, including, but not limited to, displaying content in a manner that violates any applicable laws, statutes, or regulations, or that H2O, in its sole discretion, finds to be obscene or defamatory is prohibited.</li>
+        <li>d. You agree to comply with all applicable laws, including, but not limited to, any privacy laws, as well as H2O’s policies when you use the H2O Services.</li>
+        <li>e. You may not use the H2O Services in any way that interferes with the operation of the H2O Services or impacts any other User, host, or network, or circumvents any of the H2O Services’ security protections.</li>
+    </ul>
 
-        <h2>5. Children’s Privacy</h2>
-        <p>The H2O Services are intended only for those over the age of 13, and by using or viewing the H2O Services in any way you represent that you are at least 13 years of age. H2O does not knowingly collect or retain any personal information for individuals under 13 years of age. Parents, if you believe that H2O has unintentionally collected personal information regarding your child, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a> so that H2O can remove it.</p>
+    <h2>5. Children’s Privacy</h2>
+    <p>The H2O Services are intended only for those over the age of 13, and by using or viewing the H2O Services in any way you represent that you are at least 13 years of age. H2O does not knowingly collect or retain any personal information for individuals under 13 years of age. Parents, if you believe that H2O has unintentionally collected personal information regarding your child, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a> so that H2O can remove it.</p>
 
-        <h2>6. User Content</h2>
+    <h2>6. User Content</h2>
 
-        <h3>a. Contributing Content</h3>
-        <p>Some portions of the H2O Services allow you to upload and post content (such as text, audio, video, questions, and commentary) to the Site ("User Content"). In addition, subject to Section 7 below, you may include embeddable links to third party material available through Third Party Services ("Embedded Links"). You represent and warrant that you have all rights necessary to upload the User Content, or to post the Embedded Links, to the Site and to grant the rights granted by you to H2O and other Users pursuant to these Terms of Service.</p>
+    <h3>a. Contributing Content</h3>
+    <p>Some portions of the H2O Services allow you to upload and post content (such as text, audio, video, questions, and commentary) to the Site ("User Content"). In addition, subject to Section 7 below, you may include embeddable links to third party material available through Third Party Services ("Embedded Links"). You represent and warrant that you have all rights necessary to upload the User Content, or to post the Embedded Links, to the Site and to grant the rights granted by you to H2O and other Users pursuant to these Terms of Service.</p>
 
-        <h3>b. License to User Content</h3>
-        <p>By submitting your User Content to the H2O Services, you grant H2O a perpetual, irrevocable, world-wide, non-exclusive, fully paid-up, royalty-free, sublicenseable, and transferable license to use, reproduce, reformat, distribute, prepare derivative works of, display, and perform your User Content in connection with the H2O Services.</p>
-        <p>By submitting your User Content to the H2O Services, you also agree to allow H2O to license your Content under the Creative Commons Attribution-Noncommercial-Share Alike 3.0 License, the terms of which are available at <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">http://creativecommons.org/licenses/by-nc-sa/3.0/</a>, to allow others to freely re-use and adapt your Content with proper attribution.</p>
+    <h3>b. License to User Content</h3>
+    <p>By submitting your User Content to the H2O Services, you grant H2O a perpetual, irrevocable, world-wide, non-exclusive, fully paid-up, royalty-free, sublicenseable, and transferable license to use, reproduce, reformat, distribute, prepare derivative works of, display, and perform your User Content in connection with the H2O Services.</p>
+    <p>By submitting your User Content to the H2O Services, you also agree to allow H2O to license your Content under the Creative Commons Attribution-Noncommercial-Share Alike 3.0 License, the terms of which are available at <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">http://creativecommons.org/licenses/by-nc-sa/3.0/</a>, to allow others to freely re-use and adapt your Content with proper attribution.</p>
 
-        <h2>7. Third-Party Services and Content</h2>
-        <p>Certain functions of the Services may link you to or provide you access to functions, content, sites, or services operated by third parties (collectively, "Third-Party Services"). Those Third-Party Services are subject to the terms and conditions and privacy policies of the third parties that provide them, and H2O is not responsible for the privacy practices, content, or functionality of the Third-Party Services. You are solely responsible for reading and complying with any licenses, restrictions, privacy policies or other terms and conditions that govern the use of any Third-Party Services you choose to access, visit or link to through your use of the Services, and are solely liable for any violations of those terms and conditions that arise out of or relate to your use of the Third-Party Services.</p>
+    <h2>7. Third-Party Services and Content</h2>
+    <p>Certain functions of the Services may link you to or provide you access to functions, content, sites, or services operated by third parties (collectively, "Third-Party Services"). Those Third-Party Services are subject to the terms and conditions and privacy policies of the third parties that provide them, and H2O is not responsible for the privacy practices, content, or functionality of the Third-Party Services. You are solely responsible for reading and complying with any licenses, restrictions, privacy policies or other terms and conditions that govern the use of any Third-Party Services you choose to access, visit or link to through your use of the Services, and are solely liable for any violations of those terms and conditions that arise out of or relate to your use of the Third-Party Services.</p>
 
-        <h2>8. Intellectual Property</h2>
+    <h2>8. Intellectual Property</h2>
 
-        <h3>a. Intellectual Property Rights</h3>
-        <p>Except for any User Content, H2O owns and retains all right, title, and interest in and to the H2O Services, including, but not limited to, the design and architecture of the H2O Services, as well as any software, logos, or content provided through H2O, including any intellectual property or other proprietary rights contained therein (collectively, "H2O IP"). You must seek permission from H2O if you desire to use the H2O Services in a way that is not outlined in these Terms of Service. Except for any rights explicitly granted in writing by H2O under these Terms of Service or otherwise, you are not granted any rights in and to any H2O IP.</p>
+    <h3>a. Intellectual Property Rights</h3>
+    <p>Except for any User Content, H2O owns and retains all right, title, and interest in and to the H2O Services, including, but not limited to, the design and architecture of the H2O Services, as well as any software, logos, or content provided through H2O, including any intellectual property or other proprietary rights contained therein (collectively, "H2O IP"). You must seek permission from H2O if you desire to use the H2O Services in a way that is not outlined in these Terms of Service. Except for any rights explicitly granted in writing by H2O under these Terms of Service or otherwise, you are not granted any rights in and to any H2O IP.</p>
 
-        <h3>b. Digital Millennium Copyright Act Policy</h3>
-        <p>H2O respects the intellectual property rights of others and asks that Users do the same. If you are a rights-holder and believe that your rights have been violated in connection with User Content that is made available through the H2O Services, in accordance with the Digital Millennium Copyright Act ("DMCA", see 17 U.S.C. § 512(c)(3) for more information) please send an email or written notice to H2O’s designated agent for infringement claims with the following information:</p>
-        <ul>
-            <li>1. An electronic or physical signature of a person authorized to act on behalf of the rights-holder.</li>
-            <li>2. A description of the work that you claim has been infringed.</li>
-            <li>3. A URL indicating where the claimed infringing material is located on the H2O Services.</li>
-            <li>4. Your address, telephone number, and email address.</li>
-            <li>5. A statement by you declaring a good-faith belief that the content use is not authorized by the rights-holder or its agent and is prohibited by law.</li>
-            <li>6. A statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or an agent authorized to act on the copyright owner's behalf.</li>
-        </ul>
+    <h3>b. Digital Millennium Copyright Act Policy</h3>
+    <p>H2O respects the intellectual property rights of others and asks that Users do the same. If you are a rights-holder and believe that your rights have been violated in connection with User Content that is made available through the H2O Services, in accordance with the Digital Millennium Copyright Act ("DMCA", see 17 U.S.C. § 512(c)(3) for more information) please send an email or written notice to H2O’s designated agent for infringement claims with the following information:</p>
+    <ul>
+        <li>1. An electronic or physical signature of a person authorized to act on behalf of the rights-holder.</li>
+        <li>2. A description of the work that you claim has been infringed.</li>
+        <li>3. A URL indicating where the claimed infringing material is located on the H2O Services.</li>
+        <li>4. Your address, telephone number, and email address.</li>
+        <li>5. A statement by you declaring a good-faith belief that the content use is not authorized by the rights-holder or its agent and is prohibited by law.</li>
+        <li>6. A statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or an agent authorized to act on the copyright owner's behalf.</li>
+    </ul>
 
-        <p>H2O’s designated agent for notice for claims of infringement can be reached as follows: Tracy Walden, Harvard University Information Technology, IT Security | Policy, Risk and Compliance, +1.617.496.8515, 1414 Massachusetts Avenue, Room 346, Cambridge, MA 02138, Email: dmca@harvard.edu</p>
+    <p>H2O’s designated agent for notice for claims of infringement can be reached as follows: Tracy Walden, Harvard University Information Technology, IT Security | Policy, Risk and Compliance, +1.617.496.8515, 1414 Massachusetts Avenue, Room 346, Cambridge, MA 02138, Email: dmca@harvard.edu</p>
 
-        <h3>c. Counter-Notice</h3>
-        <p>If you receive notification that your User Content has been removed from the H2O Services, you have an opportunity to appeal this removal if you believe that your User Content was removed in error. If you believe that the removed User Content does not violate any third-party rights, or you have authorization from the rights-holder or the rights-holder’s authorized agent to use the material in question, you may appeal the removal by sending an email or written notice to H2O’s designated agent with the following information:</p>
-        <ul>
-            <li>1. Your physical or electronic signature.</li>
-            <li>2. Identification of the material that has been removed or to which access has been disabled, and the location at which the material appeared before it was removed or access to it was disabled.</li>
-            <li>3. A statement under penalty of perjury that you have a good-faith belief that the material was removed or disabled as a result of mistake or misidentification of the material to be removed or disabled.</li>
-            <li>4. Your name, address, and telephone number, and a signed statement that you consent to the jurisdiction of state and federal courts in Suffolk County, Massachusetts, and that you will accept service of process from the party who made the initial infringement claim (or their authorized agent) if they choose to pursue legal action.</li>
-        </ul>
+    <h3>c. Counter-Notice</h3>
+    <p>If you receive notification that your User Content has been removed from the H2O Services, you have an opportunity to appeal this removal if you believe that your User Content was removed in error. If you believe that the removed User Content does not violate any third-party rights, or you have authorization from the rights-holder or the rights-holder’s authorized agent to use the material in question, you may appeal the removal by sending an email or written notice to H2O’s designated agent with the following information:</p>
+    <ul>
+        <li>1. Your physical or electronic signature.</li>
+        <li>2. Identification of the material that has been removed or to which access has been disabled, and the location at which the material appeared before it was removed or access to it was disabled.</li>
+        <li>3. A statement under penalty of perjury that you have a good-faith belief that the material was removed or disabled as a result of mistake or misidentification of the material to be removed or disabled.</li>
+        <li>4. Your name, address, and telephone number, and a signed statement that you consent to the jurisdiction of state and federal courts in Suffolk County, Massachusetts, and that you will accept service of process from the party who made the initial infringement claim (or their authorized agent) if they choose to pursue legal action.</li>
+    </ul>
 
-        <h2>9. Content Removal and Account Termination</h2>
-        <p>You are entirely responsible for all activities that occur on or through your account. H2O retains the right (but not the obligation) to limit, suspend, terminate, modify, or delete your account; to limit your access to the H2O Services or portions thereof; to remove links in your User Content to other Content on the H2O Services; to remove Embedded Links to Third-Party Services; and to delete your User Content at H2O’s discretion, with or without notice to you. H2O may at any time remove other Users’ Content that you have chosen to incorporate into your own User Content, causing it to be removed from your User Content as well. H2O is under no obligation to provide compensation for any such losses or results, which may occur due to your failure to comply with the these Terms of Service or those of a third party, for repeated violations of third-party rights, for actual or suspected illegal or improper use of the H2O Services, for offensive User Content or conduct, or for technical reasons.</p>
+    <h2>9. Content Removal and Account Termination</h2>
+    <p>You are entirely responsible for all activities that occur on or through your account. H2O retains the right (but not the obligation) to limit, suspend, terminate, modify, or delete your account; to limit your access to the H2O Services or portions thereof; to remove links in your User Content to other Content on the H2O Services; to remove Embedded Links to Third-Party Services; and to delete your User Content at H2O’s discretion, with or without notice to you. H2O may at any time remove other Users’ Content that you have chosen to incorporate into your own User Content, causing it to be removed from your User Content as well. H2O is under no obligation to provide compensation for any such losses or results, which may occur due to your failure to comply with the these Terms of Service or those of a third party, for repeated violations of third-party rights, for actual or suspected illegal or improper use of the H2O Services, for offensive User Content or conduct, or for technical reasons.</p>
 
-        <h2>10. Warranty Disclaimer</h2>
-        <p>H2O AND HLSL EXPRESSLY DISCLAIM ANY AND ALL WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND NON-INFRINGEMENT. THE H2O SERVICES ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE BASIS," AND YOU USE THEM AT YOUR SOLE RISK. YOU ASSUME ALL RESPONSIBILITY TO PROTECT YOUR COMPUTER SYSTEMS OR ANY OTHER DEVICES YOU USE TO ACCESS THE H2O SERVICES FROM DAMAGE CAUSED BY BUGS, VIRUSES, TROJANS, OR THE LIKE WHICH MAY BE TRANSMITTED FROM H2O’S SERVERS. H2O AND HLSL ASSUME NO LIABILITY FOR THE ACCURACY, SUITABILITY, OR COMPLETENESS OF ANY CONTENT OR INFORMATION THAT MAY BE ACCESSED THROUGH THE H2O SERVICES, WHETHER OR NOT PROVIDED BY H2O OR ITS PARTNERS. H2O DOES NOT GUARANTEE THAT THE H2O SERVICES WILL BE AVAILABLE AT A GIVEN TIME. H2O AND HLSL ARE NOT RESPONSIBLE FOR ANY OFFENSIVE OR ILLEGAL CONTENT INCLUDED IN PICTURES, PHOTOGRAPHS, OR OTHER KINDS OF MEDIA INCORPORATED INTO USER CONTENT BY THIRD PARTIES. YOU ACKNOWLEDGE THAT THE VIEWPOINTS EXPRESSED IN USER CONTENT OR ON THIRD-PARTY SERVICES REPRESENT THE OPINIONS OF THOSE USERS AND THIRD-PARTY SERVICE PROVIDERS, AND ARE NOT ENDORSED BY H2O OR HLSL IN ANY WAY.</p>
+    <h2>10. Warranty Disclaimer</h2>
+    <p>H2O AND HLSL EXPRESSLY DISCLAIM ANY AND ALL WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND NON-INFRINGEMENT. THE H2O SERVICES ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE BASIS," AND YOU USE THEM AT YOUR SOLE RISK. YOU ASSUME ALL RESPONSIBILITY TO PROTECT YOUR COMPUTER SYSTEMS OR ANY OTHER DEVICES YOU USE TO ACCESS THE H2O SERVICES FROM DAMAGE CAUSED BY BUGS, VIRUSES, TROJANS, OR THE LIKE WHICH MAY BE TRANSMITTED FROM H2O’S SERVERS. H2O AND HLSL ASSUME NO LIABILITY FOR THE ACCURACY, SUITABILITY, OR COMPLETENESS OF ANY CONTENT OR INFORMATION THAT MAY BE ACCESSED THROUGH THE H2O SERVICES, WHETHER OR NOT PROVIDED BY H2O OR ITS PARTNERS. H2O DOES NOT GUARANTEE THAT THE H2O SERVICES WILL BE AVAILABLE AT A GIVEN TIME. H2O AND HLSL ARE NOT RESPONSIBLE FOR ANY OFFENSIVE OR ILLEGAL CONTENT INCLUDED IN PICTURES, PHOTOGRAPHS, OR OTHER KINDS OF MEDIA INCORPORATED INTO USER CONTENT BY THIRD PARTIES. YOU ACKNOWLEDGE THAT THE VIEWPOINTS EXPRESSED IN USER CONTENT OR ON THIRD-PARTY SERVICES REPRESENT THE OPINIONS OF THOSE USERS AND THIRD-PARTY SERVICE PROVIDERS, AND ARE NOT ENDORSED BY H2O OR HLSL IN ANY WAY.</p>
 
-        <h2>11. Limitations of Liability</h2>
-        <p>IN NO EVENT IS H2O OR HLSL, THEIR OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS LIABLE FOR ANY DAMAGES OR LOSSES, WHETHER DIRECT OR INDIRECT, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, CONSEQUENTIAL, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE, OR OTHER DAMAGES OF ANY KIND ARISING FROM OR RELATED TO THE H2O SERVICES, INCLUDING, BUT NOT LIMITED TO, LOSSES RESULTING FROM LOSS OF DATA, PROPERTY DAMAGE, PERSONAL INJURY, LOSS OF GOODWILL, INABILITY TO USE OR ACCESS THE H2O SERVICES, THIRD-PARTY CONDUCT ON THE H2O SERVICES, OR ANY OTHER ACTIONS ASSOCIATED WITH THE USE OF THE H2O SERVICES.</p>
+    <h2>11. Limitations of Liability</h2>
+    <p>IN NO EVENT IS H2O OR HLSL, THEIR OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS LIABLE FOR ANY DAMAGES OR LOSSES, WHETHER DIRECT OR INDIRECT, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, CONSEQUENTIAL, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE, OR OTHER DAMAGES OF ANY KIND ARISING FROM OR RELATED TO THE H2O SERVICES, INCLUDING, BUT NOT LIMITED TO, LOSSES RESULTING FROM LOSS OF DATA, PROPERTY DAMAGE, PERSONAL INJURY, LOSS OF GOODWILL, INABILITY TO USE OR ACCESS THE H2O SERVICES, THIRD-PARTY CONDUCT ON THE H2O SERVICES, OR ANY OTHER ACTIONS ASSOCIATED WITH THE USE OF THE H2O SERVICES.</p>
 
-        <h2>12. Indemnification</h2>
-        <p>You agree at your own expense to indemnify, defend, save, and hold harmless HLSL and H2O, their employees, affiliates, officers, directors, contributors, and other representatives from and against any and all judgments, losses, damages, liabilities, costs, or expenses (including, but not limited to, reasonable attorneys’ fees and legal expenses) arising from or related to your use of the H2O Services, or your violation of these Terms of Service.</p>
+    <h2>12. Indemnification</h2>
+    <p>You agree at your own expense to indemnify, defend, save, and hold harmless HLSL and H2O, their employees, affiliates, officers, directors, contributors, and other representatives from and against any and all judgments, losses, damages, liabilities, costs, or expenses (including, but not limited to, reasonable attorneys’ fees and legal expenses) arising from or related to your use of the H2O Services, or your violation of these Terms of Service.</p>
 
-        <h2>13. General Terms</h2>
+    <h2>13. General Terms</h2>
 
-        <h3>a. Updates and Changes to These Terms of Service</h3>
-        <p>H2O reserves the right to modify these Terms of Service at anytime at its discretion. If H2O does make changes to Terms of Service, H2O will update this page accordingly. Please check this page periodically for any changes. Your continued use of the H2O Services after this page is updated with the new terms signifies your acceptance of the amended Terms of Service. No amendment to these Terms of Service or Privacy Policy shall apply to any dispute of which H2O had actual notice before the date of the amendment. Other additional terms may apply to other functions or components of the H2O Services. If there is a conflict between these Terms of Service and the other additional terms, the other additional terms will govern.</p>
+    <h3>a. Updates and Changes to These Terms of Service</h3>
+    <p>H2O reserves the right to modify these Terms of Service at anytime at its discretion. If H2O does make changes to Terms of Service, H2O will update this page accordingly. Please check this page periodically for any changes. Your continued use of the H2O Services after this page is updated with the new terms signifies your acceptance of the amended Terms of Service. No amendment to these Terms of Service or Privacy Policy shall apply to any dispute of which H2O had actual notice before the date of the amendment. Other additional terms may apply to other functions or components of the H2O Services. If there is a conflict between these Terms of Service and the other additional terms, the other additional terms will govern.</p>
 
-        <h3>b. Entire Agreement</h3>
-        <p>These Terms of Service constitute the entire agreement between the parties, and supersede all previous agreements relating to the use of the H2O Services.</p>
+    <h3>b. Entire Agreement</h3>
+    <p>These Terms of Service constitute the entire agreement between the parties, and supersede all previous agreements relating to the use of the H2O Services.</p>
 
-        <h3>c. Applicable Law and Forum</h3>
-        <p>These Terms of Service and any referenced policies or guidelines are governed by and construed in accordance with the laws of the Commonwealth of Massachusetts, without regard to principles of conflict of law. If you bring a suit against H2O or HLSL, you hereby consent to the exclusive jurisdiction of state and federal courts in Suffolk County, Massachusetts, and hereby consent to the personal jurisdiction of said courts.</p>
+    <h3>c. Applicable Law and Forum</h3>
+    <p>These Terms of Service and any referenced policies or guidelines are governed by and construed in accordance with the laws of the Commonwealth of Massachusetts, without regard to principles of conflict of law. If you bring a suit against H2O or HLSL, you hereby consent to the exclusive jurisdiction of state and federal courts in Suffolk County, Massachusetts, and hereby consent to the personal jurisdiction of said courts.</p>
 
-        <h3>d. Location of Services</h3>
-        <p>The H2O Services are controlled and offered by HLSL from its facilities in the United States. H2O makes no representations that the H2O Services are appropriate or available for use in other locations. Those who access or use the H2O Services from other jurisdictions do so at their own volition and are responsible for complying with local law.</p>
+    <h3>d. Location of Services</h3>
+    <p>The H2O Services are controlled and offered by HLSL from its facilities in the United States. H2O makes no representations that the H2O Services are appropriate or available for use in other locations. Those who access or use the H2O Services from other jurisdictions do so at their own volition and are responsible for complying with local law.</p>
 
-        <h3>e. Severability</h3>
-        <p>If any provision of these Terms of Service is deemed to be unenforceable for any reason by any court, the invalidity of this provision does not affect the validity of any other provisions in these Terms of Service, which remain in full effect.</p>
+    <h3>e. Severability</h3>
+    <p>If any provision of these Terms of Service is deemed to be unenforceable for any reason by any court, the invalidity of this provision does not affect the validity of any other provisions in these Terms of Service, which remain in full effect.</p>
 
-        <h3>f. Language of the Terms of Service</h3>
-        <p>If H2O provides you with a translation of the English version of these Terms of Service, the Privacy Policy, or any other policy, then you agree that the translation is provided for informational purposes only and does not modify the English-language version. In the event of a conflict between a translation and the English version, the English version will govern.</p>
+    <h3>f. Language of the Terms of Service</h3>
+    <p>If H2O provides you with a translation of the English version of these Terms of Service, the Privacy Policy, or any other policy, then you agree that the translation is provided for informational purposes only and does not modify the English-language version. In the event of a conflict between a translation and the English version, the English version will govern.</p>
 
-        <h3>g. Site Source Code</h3>
-        <p>H2O makes some of its source code related to the H2O Services available under the GNU Affero General Public License. You can obtain the source code that H2O makes available as open source software at <a href="https://github.com/harvard-lil/h2o">https://github.com/harvard-lil/h2o</a>.</p>
+    <h3>g. Site Source Code</h3>
+    <p>H2O makes some of its source code related to the H2O Services available under the GNU Affero General Public License. You can obtain the source code that H2O makes available as open source software at <a href="https://github.com/harvard-lil/h2o">https://github.com/harvard-lil/h2o</a>.</p>
 
-        <h3>h. No Waiver</h3>
-        <p>No waiver of any term of these Terms of Service shall be deemed a further or continuing waiver of such term or any other term, and H2O’s failure to assert any right or provision under these Terms of Service shall not constitute a waiver of such right or provision.</p>
+    <h3>h. No Waiver</h3>
+    <p>No waiver of any term of these Terms of Service shall be deemed a further or continuing waiver of such term or any other term, and H2O’s failure to assert any right or provision under these Terms of Service shall not constitute a waiver of such right or provision.</p>
 
-        <h2>14. Questions?</h2>
-        <p>If you have questions about these Terms of Service, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</p>
+    <h2>14. Questions?</h2>
+    <p>If you have questions about these Terms of Service, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</p>
 
-        <p>Last modified on April 24, 2019.</p>
-    </div>
+    <p>Last modified on April 24, 2019.</p>
+
 </div>
 {% endblock %}

--- a/web/main/templatetags/featured_casebook.py
+++ b/web/main/templatetags/featured_casebook.py
@@ -1,0 +1,34 @@
+from typing import Optional
+from django import template
+from main.models import Casebook
+
+register = template.Library()
+
+
+@register.inclusion_tag("includes/featured_casebook.html")
+def featured_casebook(
+    id: int,
+    title: Optional[str] = None,
+    authors: Optional[str] = None,
+    cover_image: Optional[str] = None,
+):
+    """
+    Render a casebook on the Featured Casebooks page, optionally overriding metadata on the casebook object itself
+    """
+    casebook = Casebook.objects.filter(id=id).first()
+
+    if not casebook:
+        return {"error": f"Casebook ID {id} was not found in this environment"}
+
+    if not casebook.is_public:
+        return {"error": f"Casebook ID {id} is not publicly viewable"}
+
+    return {
+        "casebook": casebook,
+        "title": title or casebook.title,
+        "authors": [{"display_name": authors}]
+        if authors
+        else [author for author in casebook.primary_authors if author.verified_professor],
+        "cover_image": cover_image,
+        "error": None,
+    }

--- a/web/main/test/test_templatetags.py
+++ b/web/main/test/test_templatetags.py
@@ -1,0 +1,21 @@
+import pytest
+
+from main.templatetags.featured_casebook import featured_casebook
+
+
+def test_featured_casebook(full_casebook):
+    """Featuring a casebook should return information about it, unless overridden"""
+    assert featured_casebook(full_casebook.id)["title"] == full_casebook.title
+    assert featured_casebook(full_casebook.id, title="Fake title")["title"] == "Fake title"
+    assert featured_casebook(full_casebook.id)["error"] is None
+
+
+def test_featured_casebook_private(private_casebook):
+    """A private casebook should return only an error message"""
+    assert "not publicly viewable" in featured_casebook(private_casebook.id)["error"]
+
+
+@pytest.mark.django_db
+def test_featured_casebook_missing():
+    """Attempting to retrieve a non-existent casebook should return a friendly error message"""
+    assert "not found" in featured_casebook(-1)["error"]

--- a/web/main/test/test_templatetags.py
+++ b/web/main/test/test_templatetags.py
@@ -7,6 +7,10 @@ def test_featured_casebook(full_casebook):
     """Featuring a casebook should return information about it, unless overridden"""
     assert featured_casebook(full_casebook.id)["title"] == full_casebook.title
     assert featured_casebook(full_casebook.id, title="Fake title")["title"] == "Fake title"
+    assert (
+        featured_casebook(full_casebook.id, authors="Fake authors")["authors"][0]["display_name"]
+        == "Fake authors"
+    )
     assert featured_casebook(full_casebook.id)["error"] is None
 
 

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -239,6 +239,11 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path("image/", no_perms_test(views.upload_image), name="upload_image"),
     path("image/<image_uuid>", no_perms_test(views.view_image), name="image_url"),
     # canonical paths for static pages
+    path(
+        "pages/featured/",
+        TemplateView.as_view(template_name="pages/featured_casebooks.html"),
+        name="featured",
+    ),
     path("pages/about/", TemplateView.as_view(template_name="pages/about.html"), name="about"),
     path(
         "pages/privacy-policy/",


### PR DESCRIPTION
Adds a featured casebooks page to be linked from the home page and other places. Currently it's not linked from anywhere.


<img width="991" alt="image" src="https://user-images.githubusercontent.com/19571/207151435-7e47ad9e-7786-40fe-bf8b-adfb2b5a30f0.png">

This is implemented as a template tag which accepts a casebook ID as input, and any of the displayable fields as optional parameters. If those are provided, they'll be used as-is instead of the default values from the casebook itself.

A few casebooks look missing here because my local database doesn't have them; this is a good test of what happens if they aren't available. In view source you'd see:

```html
    <!-- Error: Casebook ID 6195 was not found in this environment-->
```

For casebooks which exist but aren't publicly viewable, they are also omitted but show something different in view source:

```html
<!-- Error: Casebook ID 6094 is not publicly viewable--> 
```

If we want to keep this information private I could remove it from the template output, but I think it's safe enough—we already use auto-incrementing IDs which are easily discoverable.

## Analytics

Adds the analytics doodads based on the Matomo documentation, but that's not testable locally.

## Mobile

Two columns become one:

<img width="585" alt="image" src="https://user-images.githubusercontent.com/19571/207152792-8f36d6f4-8f19-4d8e-9abe-6ee7e7f0de44.png">

## Testing

Added a few unit tests for the template tag, which is the one moving part here.

# Additional styling 

Also rationalizes the widths of all the static pages because this was depressing me:

## Before

<img width="1749" alt="image" src="https://user-images.githubusercontent.com/19571/207150826-d99d0368-80d9-4105-9f6e-e1aef2872509.png">

## After

<img width="1811" alt="image" src="https://user-images.githubusercontent.com/19571/207150882-2ac86561-26e6-4fe5-97d9-835f3bcffe80.png">

Lastly, I removed a wrapper div `content` which was in all the static pages but didn't actually do anything and had no references in the relevant SCSS.

