### PR TITLE
Change casebook URL to canonical in featured page

### DIFF
--- a/web/main/templates/includes/featured_casebook.html
+++ b/web/main/templates/includes/featured_casebook.html
@@ -1,7 +1,7 @@
 {% if casebook %}
 <section class="featured-casebook">
     <span class="title">
-        <a href="{% url 'casebook_info' casebook %}"
+        <a href="{{ casebook.get_absolute_url }}"
            data-track-content
            data-content-name="{{ title }} ({{ casebook.id }})"
            data-content-piece="Featured casebooks"


### PR DESCRIPTION
Small but important change; I hadn't realized the other link was to the API.

This instead links to the user-facing main page for a casebook.
