### PR TITLE
Reader mode header and other enhancements

### DIFF
--- a/web/main/templates/base.html
+++ b/web/main/templates/base.html
@@ -12,13 +12,8 @@
      const FRONTEND_URLS = {{ frontend_urls | safe}};
      window.ENABLE_MEDIA_UPLOAD =  {% if request.user.is_superuser or request.user.verified_professor %}true{% else %}false{% endif %};
      window.VERIFIED = {% if request.user.verified_professor %}true{% else %}false{% endif %};
-     window.sentry = {
-       USE_SENTRY: {{ USE_SENTRY|lower }},
-       DSN: "{{ SENTRY_DSN }}",
-       ENVIRONMENT: "{{ SENTRY_ENVIRONMENT }}",
-       TRACES_SAMPLE_RATE: {{ SENTRY_TRACES_SAMPLE_RATE }}
-     }
     </script>
+    {% include "includes/sentry.html" %}
     {% render_bundle 'main' %}
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy"/>
     <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css"/>

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -39,9 +39,9 @@
         {% endif %}
 
         {% if use_pagedjs %}
-          <button onclick="window.location.href='{% url "as_printable_html" casebook page.number %}'">Exit print preview</button>
+          <button class="print-preview" onclick="window.location.href='{% url "as_printable_html" casebook page.number %}'">Exit print preview</button>
         {% else %}
-          <button onclick="window.location.href='{% url "as_printable_html" casebook page.number %}?print-preview=true'">Print preview</button>
+          <button class="print-preview" onclick="window.location.href='{% url "as_printable_html" casebook page.number %}?print-preview=true'">Print preview</button>
         {% endif %}
         <span>{{ page.number }} of {{ paginator.num_pages }} section{{ paginator.num_pages|pluralize}} </span>
 

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -15,6 +15,7 @@
         }
      }
     </style>
+    {% include "includes/sentry.html" %}
   </head>
 
 <body>
@@ -87,5 +88,6 @@
 
   <main id="as-printable-html"></main>
 
+  {% include "includes/analytics.html" %}
 </body>
 </html>

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -1,5 +1,6 @@
 {% load call_method string_strip %}
 
+<span class="node-heading depth-{{ node.ordinals | length }}">{{ node.ordinal_string }} {{ node.title }}</span>
 
 <section
   data-datetime="{{ node.created_at|date:'c' }}"

--- a/web/main/templates/includes/sentry.html
+++ b/web/main/templates/includes/sentry.html
@@ -1,0 +1,8 @@
+<script>
+    window.sentry = {
+      USE_SENTRY: {{ USE_SENTRY|lower }},
+      DSN: "{{ SENTRY_DSN }}",
+      ENVIRONMENT: "{{ SENTRY_ENVIRONMENT }}",
+      TRACES_SAMPLE_RATE: {{ SENTRY_TRACES_SAMPLE_RATE }}
+    }
+</script>

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -278,7 +278,9 @@
     text-underline-offset: 5px;
     background: none;
   }
-
+  a.footnote-generated {
+    display: none;
+  }
 }
 
 /* Styling that only applies to the print preview, or when the screen preview is printed */

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -244,21 +244,20 @@
     grid-template-areas: "left center right";
 
   }
-
   p, div {
     margin: 1rem 0;
   }
-  article {
+  main > article {
     background-color: white;
     padding: 5vh 10vw 10vh 10vw;
     grid-area: "center";
   }
-  .left {
+  main > .left {
     width: 15vw;
     height: auto;
     grid-area: "left";
   }
-  .right {
+  main > .right {
     width: 15vw;
     height: auto;
     grid-area: "right";
@@ -281,7 +280,18 @@
   a.footnote-generated {
     display: none;
   }
+  @media (max-width: 552px) {
+
+    main {
+      margin: 0;
+      grid-template-areas: "center";
+    }
+    footer nav button.print-preview {
+      display: none;
+    }
+  }
 }
+
 
 /* Styling that only applies to the print preview, or when the screen preview is printed */
 @media print {

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -234,6 +234,10 @@
     text-indent: initial;
   }
 
+  /* Usually hidden node title that will be displayed in screen view */
+  .node-heading {
+    display: none;
+  }
 }
 /* Styling that applies only to the screen-based reader view */
 @media screen {
@@ -242,25 +246,23 @@
     margin: 5vh 0;
     display: grid;
     grid-template-areas: "left center right";
-
+    grid-template-columns: 15vw 65vw 15vw;
   }
-  p, div {
+  article p, article div {
     margin: 1rem 0;
   }
   main > article {
     background-color: white;
-    padding: 5vh 10vw 10vh 10vw;
-    grid-area: "center";
+    padding: 5vh 5vw 10vh 5vw;
+    grid-area: center;
   }
   main > .left {
-    width: 15vw;
     height: auto;
-    grid-area: "left";
+    grid-area: left;
   }
   main > .right {
-    width: 15vw;
     height: auto;
-    grid-area: "right";
+    grid-area: right;
   }
   aside.authors-note {
     position: absolute;
@@ -280,11 +282,33 @@
   a.footnote-generated {
     display: none;
   }
+  .node-heading {
+    display: block;
+    /* position: sticky; try this with IntersectionObserver */
+    float: left;
+    font-size: 10px;
+    width: 13vw;
+    margin-left: -20vw;
+    text-align: right;
+  }
+  .node-heading.depth-1 {
+    top: 5vh;
+  }
+  .node-heading.depth-2 {
+    top: 10vh;
+  }
+  .node-heading.depth-3 {
+    top: 15vh;
+  }
+  .node-heading.depth-4 {
+    top: 20vh;
+  }
   @media (max-width: 552px) {
 
     main {
-      margin: 0;
-      grid-template-areas: "center";
+      margin: 0 auto;
+      grid-template-areas: center;
+      grid-template-columns: 1fr;
     }
     footer nav button.print-preview {
       display: none;


### PR DESCRIPTION
## Analytics and tracking 

* Move Sentry code to an include and use it in both the general site header and the reader view
* Ensure that Matomo analytics are capturing the reader view

## Mobile layout

* One-column layout for mobile view
* Don't show print-preview button in mobile view (the two-up view is not useful here)

## Enhancements

Hang the current section title in the left nav. I'd like this to be `sticky` and be present as the user scrolls down, displaying the current section, but that needs some JS. TODO.

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/19571/207425876-2845b204-65b0-4cf8-8527-89e9a1e49b99.png">



