### PR TITLE
Reader mode improvements

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -162,7 +162,6 @@ function hyperlinkFootnote(node, url, dateCreated) {
 
 const main = document.querySelector("main")
 const tmpl = document.querySelector("#casebook-content");
-const css = tmpl.getAttribute("data-stylesheet");
 const paged = new Previewer();
 
 // For any existing URLs that aren't resources, turn them into footnotes
@@ -280,10 +279,15 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
 
 } else {
 
-
   const left = document.createElement('div');
   const right = document.createElement('div');
   const center = document.createElement('article');
+
+  const tocLink = document.createElement('a');
+  tocLink.innerText = '↑ Table of contents';
+  tocLink.href = "#toc";
+  tocLink.classList.add('toc-link');
+  left.append(tocLink);
 
   left.classList.add('left');
   right.classList.add('right');

--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -250,3 +250,59 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
   main.classList.add("preview-ready");
 
 }
+
+class TocControl extends HTMLElement {
+
+  static get observedAttributes() {
+    return ['open']
+  }
+  constructor() {
+    super();
+  }
+  connectedCallback() {
+
+    this.tocList = this.querySelector('ol');
+
+    this.querySelector('svg').addEventListener('click', () => {
+      if (!this.tocList.getAttribute('data-natural-height')) {
+        const height = parseInt(this.tocList.getBoundingClientRect().height, 10);
+        this.tocList.setAttribute('data-natural-height', height);
+        this.tocList.style.height = `${height}px`;
+      }
+      window.requestAnimationFrame(() => this.toggleAttribute('open'));
+    })
+
+    this.tocList.addEventListener('transitionstart', () => {
+      if (this.tocList.classList.contains('collapsing')) {
+        this.tocList.classList.add('invisible')
+      }
+    });
+    this.tocList.addEventListener('transitionend', () => {
+    if (!this.tocList.classList.contains('collapsing')) {
+        this.tocList.classList.remove('invisible')
+      }
+    });
+
+
+  }
+  attributeChangedCallback(name, previous, value) {
+    switch (name) {
+      case "open": {
+        console.log(value);
+        if (this.tocList) {
+          if (value === null) {
+            this.tocList.classList.add('collapsing');
+            this.tocList.style.height = 0;
+          } else {
+            this.tocList.classList.remove('collapsing');
+            this.tocList.style.height = `${this.tocList.getAttribute('data-natural-height')}.px`;
+
+          }
+        }
+        this.querySelector('svg').classList.toggle('open');
+      }
+    }
+  }
+
+}
+customElements.define('toc-control', TocControl)

--- a/web/frontend/pages/as_printable_html.scss
+++ b/web/frontend/pages/as_printable_html.scss
@@ -2,10 +2,6 @@
 @import 'font-vars-and-mixins';
 @import 'font-faces';
 
-.preview-loading {
-  visibility: hidden;
-}
-
 /* Customized for navigation component at the top */
 @media screen, pagedjs-ignore {
   header.screen-only {
@@ -19,6 +15,25 @@
     }
     img {
       max-height: 50px;
+    }
+  }
+  .left {
+    a.toc-link {
+      font-family: $preferred-sans-serif !important;
+      text-align: center;
+      bottom: 8vh;
+      display: block;
+      position: fixed;
+      left: 3vw;
+      text-decoration: none;
+      background: white;
+      border: lightgray 1px solid;
+      padding: 5px;
+    }
+  }
+  @media (max-width: 552px) {
+    .left a {
+      left: 40vw;
     }
   }
   .screen-only {

--- a/web/frontend/pages/as_printable_html.scss
+++ b/web/frontend/pages/as_printable_html.scss
@@ -2,6 +2,10 @@
 @import 'font-vars-and-mixins';
 @import 'font-faces';
 
+.preview-loading {
+  visibility: hidden;
+}
+
 /* Customized for navigation component at the top */
 @media screen, pagedjs-ignore {
   header.screen-only {

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -3,6 +3,7 @@
 {% load render_bundle from webpack_loader %}
 <html lang="en">
   <head>
+    <title>{{ casebook.title }} | H2O </title>
     <link href="{% static 'images/favicon.ico' %}" rel="shortcut icon" type="image/vnd.microsoft.icon" />
     <meta name="viewport" content="width=device-width">
     <meta content="width=device-width, initial-scale=1" name="viewport"/>
@@ -76,10 +77,12 @@
         </ul>
       </div>
       <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
-      {% if page.number == 1%}
-      <div id="toc">
-        {% include "export/as_printable_html/toc.html" with toc=toc %}
-      </div>
+
+      {# Always show the TOC in screen mode; otherwise only show it on the first page in print preview #}
+      {% if not use_pagedjs or use_pagedjs and page.number == 1 %}
+        <div id="toc">
+          {% include "export/as_printable_html/toc.html" with toc=toc %}
+        </div>
       {% endif %}
     </div>
 

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -1,9 +1,12 @@
 {% load call_method %}
 {% load static %}
 {% load render_bundle from webpack_loader %}
-<html>
+<html lang="en">
   <head>
     <link href="{% static 'images/favicon.ico' %}" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+    <meta name="viewport" content="width=device-width">
+    <meta content="width=device-width, initial-scale=1" name="viewport"/>
+    <meta charset="utf-8"/>
 
     {% render_bundle 'as_printable_html_styles' %}
     {% render_bundle 'as_printable_html' attrs="defer" %}

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -12,6 +12,12 @@
     {% render_bundle 'as_printable_html_styles' %}
     {% render_bundle 'as_printable_html' attrs="defer" %}
     {% render_bundle 'chunk-common' attrs="defer" %}
+
+    <link href="{% static 'as_printable_html/book.css' %}" type="text/css" rel="stylesheet">
+
+    {% if not use_pagedjs %}
+      <link href="{% static 'as_printable_html/reader-view.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
     <style>
       @media print {
         .screen-only {
@@ -37,7 +43,7 @@
 
       {% else %}
         {% if page.has_previous %}
-          <span><a href="{% url 'as_printable_html' casebook page.previous_page_number %}">Previous</a></span>
+          <span><a href="{% url 'as_printable_html' casebook page.previous_page_number %}{% if use_pagedjs %}?print-preview=true{% endif %}">Previous</a></span>
         {% else %}
           <span>Previous</span>
         {% endif %}
@@ -51,7 +57,7 @@
 
         <button onclick="window.location.href='{% url 'casebook' casebook %}'">Exit reader mode</button>
       {% if page.has_next %}
-        <span><a href="{% url 'as_printable_html' casebook page.next_page_number %}">Next</a></span>
+        <span><a href="{% url 'as_printable_html' casebook page.next_page_number %}{% if use_pagedjs %}?print-preview=true{% endif %}">Next</a></span>
       {% else %}
           <span>Next</span>
       {% endif %}
@@ -78,12 +84,10 @@
       </div>
       <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
 
-      {# Always show the TOC in screen mode; otherwise only show it on the first page in print preview #}
-      {% if not use_pagedjs or use_pagedjs and page.number == 1 %}
-        <div id="toc">
-          {% include "export/as_printable_html/toc.html" with toc=toc %}
-        </div>
-      {% endif %}
+      <div id="toc">
+        {% include "export/as_printable_html/toc.html" with toc=toc %}
+      </div>
+
     </div>
 
     {% for child in children %}

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -1,21 +1,30 @@
 
 <nav class="toc">
-    <h2>Table of contents</h2>
-    <ol>
-    {% for top_level_node in toc %}
-        <li>
-            <span class="ordinals">{{ top_level_node.ordinal_string }}</span>
-            <h3><a href="{% url 'as_printable_html' casebook forloop.counter %}">{{ top_level_node.title }}</a></h3>
+    <toc-control open>
+        <h2>
+            <svg class="screen-only collapse-triangle open" height="25" width="25">
+            <polygon points="6,6 20,16 6,24" />
+        </svg>
+        Table of contents
+        </h2>
 
-            <ol>
-            {% for child in top_level_node.children %}
-                <li>
-                    <span class="ordinals">{{ child.ordinal_string }}</span>
-                    <span class="node-title">{{ child.title }}</span>
-                </li>
-            {% endfor %}
-            </ol>
-        </li>
-    {% endfor %}
-    </ol>
+
+        <ol class="toc-items">
+        {% for top_level_node in toc %}
+            <li>
+                <span class="ordinals">{{ top_level_node.ordinal_string }}</span>
+                <h3><a href="{% url 'as_printable_html' casebook forloop.counter %}">{{ top_level_node.title }}</a></h3>
+
+                <ol>
+                {% for child in top_level_node.children %}
+                    <li>
+                        <span class="ordinals">{{ child.ordinal_string }}</span>
+                        <span class="node-title">{{ child.title }}</span>
+                    </li>
+                {% endfor %}
+                </ol>
+            </li>
+        {% endfor %}
+        </ol>
+    </toc-control>
 </nav>

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -1,13 +1,16 @@
 
 <nav class="toc">
     <toc-control open>
-        <h2>
-            <svg class="screen-only collapse-triangle open" height="25" width="25">
-            <polygon points="6,6 20,16 6,24" />
-        </svg>
-        Table of contents
-        </h2>
-
+        {% if use_pagedjs %}
+            <h2>Table of contents</h2>
+        {% else %}
+            <button class="toc-opener" role="button">
+                <svg class="screen-only collapse-triangle open" height="25" width="25">
+                    <polygon points="6,6 20,16 6,24" />
+                </svg>
+                <h2>Table of contents</h2>
+            </button>
+        {% endif %}
 
         <ol class="toc-items">
         {% for top_level_node in toc %}

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -156,10 +156,7 @@
   .node-container > p, section > p, article.opinion > p {
     text-indent: 2em;
   }
-  .title > .ordinal:not(:empty) {
-    float: left;
-    width: 10mm;
-  }
+
   .title > span:nth-of-type(2) {
     display: block;
   }
@@ -284,8 +281,6 @@
   }
   .node-heading {
     display: block;
-    /* position: sticky; try this with IntersectionObserver */
-    float: left;
     font-size: 10px;
     width: 13vw;
     margin-left: -20vw;

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -310,6 +310,12 @@
       grid-template-areas: center;
       grid-template-columns: 1fr;
     }
+    header.screen-only {
+      margin-bottom: 2rem;
+    }
+    header.screen-only p {
+      margin: 0 0 0 1rem;
+    }
     footer nav button.print-preview {
       display: none;
     }

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -53,8 +53,6 @@
     margin: 0;
   }
 
-
-
   h1.casebook.title {
     font-size: 300%;
   }
@@ -189,7 +187,8 @@
     string-set: casebook-title content(text);
   }
 
-  .casebook-metadata:not([data-paginator-page="1"]) {
+  /* Only in pagedjs mode, hide the TOC except from the first page */
+  .pagedjs_page .casebook-metadata:not([data-paginator-page="1"]) {
     display: none;
   }
 
@@ -235,88 +234,13 @@
   .node-heading {
     display: none;
   }
-}
-/* Styling that applies only to the screen-based reader view */
-@media screen {
 
-  main {
-    margin: 5vh 0;
-    display: grid;
-    grid-template-areas: "left center right";
-    grid-template-columns: 15vw 65vw 15vw;
-  }
-  article p, article div {
-    margin: 1rem 0;
-  }
-  main > article {
-    background-color: white;
-    padding: 5vh 5vw 10vh 5vw;
-    grid-area: center;
-  }
-  main > .left {
-    height: auto;
-    grid-area: left;
-  }
-  main > .right {
-    height: auto;
-    grid-area: right;
-  }
-  aside.authors-note {
-    position: absolute;
-    right: 2vw;
-    background: white;
-    border: 1px solid lightgray;
-    padding: 1rem;
-    width: 15vw;
-  }
-  mark.note-mark {
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: lightgrey;
-    text-underline-offset: 5px;
-    background: none;
-  }
-  a.footnote-generated {
+  /* Collapse line breaks from cases that are adjacent to deletions/insertions */
+  ins + br {
     display: none;
   }
-  .node-heading {
-    display: block;
-    font-size: 10px;
-    width: 13vw;
-    margin-left: -20vw;
-    text-align: right;
-  }
-  .node-heading.depth-1 {
-    top: 5vh;
-  }
-  .node-heading.depth-2 {
-    top: 10vh;
-  }
-  .node-heading.depth-3 {
-    top: 15vh;
-  }
-  .node-heading.depth-4 {
-    top: 20vh;
-  }
-  @media (max-width: 552px) {
 
-    main {
-      margin: 0 auto;
-      grid-template-areas: center;
-      grid-template-columns: 1fr;
-    }
-    header.screen-only {
-      margin-bottom: 2rem;
-    }
-    header.screen-only p {
-      margin: 0 0 0 1rem;
-    }
-    footer nav button.print-preview {
-      display: none;
-    }
-  }
 }
-
 
 /* Styling that only applies to the print preview, or when the screen preview is printed */
 @media print {

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -1,6 +1,6 @@
 
 /* Styling that applies only to the screen-based reader view */
-@media screen {
+@media screen, pagedjs-ignore {
 
     main {
       margin: 5vh 0;

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -1,0 +1,82 @@
+
+/* Styling that applies only to the screen-based reader view */
+@media screen {
+
+    main {
+      margin: 5vh 0;
+      display: grid;
+      grid-template-areas: "left center right";
+      grid-template-columns: 15vw 65vw 15vw;
+    }
+    article p, article div {
+      margin: 1rem 0;
+    }
+    main > article {
+      background-color: white;
+      padding: 5vh 5vw 10vh 5vw;
+      grid-area: center;
+    }
+    main > .left {
+      height: auto;
+      grid-area: left;
+    }
+    main > .right {
+      height: auto;
+      grid-area: right;
+    }
+    aside.authors-note {
+      position: absolute;
+      right: 2vw;
+      background: white;
+      border: 1px solid lightgray;
+      padding: 1rem;
+      width: 15vw;
+    }
+    mark.note-mark {
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-decoration-color: lightgrey;
+      text-underline-offset: 5px;
+      background: none;
+    }
+    a.footnote-generated {
+      display: none;
+    }
+    .node-heading {
+      display: block;
+      font-size: 10px;
+      width: 13vw;
+      margin-left: -20vw;
+      margin-top: -2rem;
+      text-align: right;
+    }
+    .node-heading.depth-1 {
+      top: 5vh;
+    }
+    .node-heading.depth-2 {
+      top: 10vh;
+    }
+    .node-heading.depth-3 {
+      top: 15vh;
+    }
+    .node-heading.depth-4 {
+      top: 20vh;
+    }
+    @media (max-width: 552px) {
+
+      main {
+        margin: 0 auto;
+        grid-template-areas: center;
+        grid-template-columns: 1fr;
+      }
+      header.screen-only {
+        margin-bottom: 2rem;
+      }
+      header.screen-only p {
+        margin: 0 0 0 1rem;
+      }
+      footer nav button.print-preview {
+        display: none;
+      }
+    }
+  }

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -54,25 +54,20 @@ nav.toc .toc-opener h2 {
 }
 nav.toc .collapse-triangle {
     scale: 0.75;
+    transition: transform 0.25s;
+    transform: rotate(0deg);
+    transform-origin: 30% 50%;
 }
 nav.toc .collapse-triangle polygon {
     fill: lightgray;
     stroke: black;
     stroke-width: 1;
 }
-
 nav.toc .collapse-triangle polygon:hover {
     stroke-width: 2;
 }
-nav.toc .collapse-triangle.open {
-    transition: transform 0.25s;
-    transform: rotate(90deg);
-    transform-origin: 30% 50%;
-}
 nav.toc .collapse-triangle:not(.open) {
-    transition: transform 0.25s;
-    transform: rotate(0deg);
-    transform-origin: 30% 50%;
+    transform: rotate(90deg);
 }
 nav.toc ol {
     transition: height 0.25s;

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -7,6 +7,10 @@ nav.toc {
 nav.toc h2 {
     margin: calc(var(--toc-row-gap) * 2) 0;
 }
+nav.toc toc-control:not([open]) h2 {
+    margin-bottom: 0;
+}
+
 nav.toc h3 {
     display: inline;
     margin: 0;
@@ -40,7 +44,17 @@ nav.toc > ol > li > ol li span {
 nav.toc > ol > li > ol > li:last-child {
     margin: 0 0 calc(var(--toc-row-gap) * 1.5) 0;
 }
-
+nav.toc .toc-opener {
+    cursor: pointer;
+    background: none;
+    border: 0;
+}
+nav.toc .toc-opener h2 {
+    display: inline-block;
+}
+nav.toc .collapse-triangle {
+    scale: 0.75;
+}
 nav.toc .collapse-triangle polygon {
     fill: lightgray;
     stroke: black;
@@ -65,6 +79,10 @@ nav.toc ol {
     height: auto;
     opacity: 1;
 }
+nav.toc toc-control:not([open]) h2::after {
+    content: " (click to expand)";
+    font-size: 12px;
+}
 nav.toc ol.invisible li {
-    opacity: 0;
+    display: none;
 }

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -40,3 +40,31 @@ nav.toc > ol > li > ol li span {
 nav.toc > ol > li > ol > li:last-child {
     margin: 0 0 calc(var(--toc-row-gap) * 1.5) 0;
 }
+
+nav.toc .collapse-triangle polygon {
+    fill: lightgray;
+    stroke: black;
+    stroke-width: 1;
+}
+
+nav.toc .collapse-triangle polygon:hover {
+    stroke-width: 2;
+}
+nav.toc .collapse-triangle.open {
+    transition: transform 0.25s;
+    transform: rotate(90deg);
+    transform-origin: 30% 50%;
+}
+nav.toc .collapse-triangle:not(.open) {
+    transition: transform 0.25s;
+    transform: rotate(0deg);
+    transform-origin: 30% 50%;
+}
+nav.toc ol {
+    transition: height 0.25s;
+    height: auto;
+    opacity: 1;
+}
+nav.toc ol.invisible li {
+    opacity: 0;
+}


### PR DESCRIPTION
* Streamlines the CSS rendering so there's less loading jank.
* Improves the mobile view (I was missing some of the viewport boilerplate).
* Adds an over-engineered TOC accordion animation (see video).
* Adds a floating "back to TOC" element.
* Displays the TOC on all pages in reader view.


## TOC view

https://user-images.githubusercontent.com/19571/207698081-b105e999-ec59-45cd-9434-c1e2183e9046.mov


