### PR TITLE
Add targetable links to TOS page; fixes #1839

### DIFF
--- a/web/main/templates/pages/terms-of-service.html
+++ b/web/main/templates/pages/terms-of-service.html
@@ -6,17 +6,17 @@
 <div class="pages-content">
 
     <h1>Terms of Service</h1>
-    <h2>1. General</h2>
+    <h2 id="tos-general">1. General</h2>
     <p>The H2O project ("H2O"), including the opencasebook.org website (the "Site") and any related services (collectively, the "H2O Services") are maintained and operated by the Harvard Law School Library ("HLSL").</p>
     <p>These terms and conditions (the "Terms of Service") govern your use of the H2O Services, and by using or accessing any portion of the H2O Services you agree to be bound by these Terms of Service, so please read these terms carefully before using or accessing H2O Services. If you do not agree to and accept these Terms of Service, including the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>, please do not register for an account or use the H2O Services in any manner. All individuals who access or otherwise use the H2O Services, including casual visitors to the Site, are referred to in these Terms of Service as "Users."</p>
 
-    <h2>2. Privacy Policy</h2>
+    <h2 id="tos-privacy-policy">2. Privacy Policy</h2>
     <p>H2O respects your privacy. How H2O uses, collects, and stores data is governed by the H2O <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By using the H2O Services, you indicate that you understand and consent to the collection, use and disclosure of your information as described in H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>. By agreeing to these Terms of Service, you additionally agree to be bound by H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a>.</p>
 
-    <h2>3. Account Creation</h2>
+    <h2 id="tos-account-creation">3. Account Creation</h2>
     <p>In order to use some features of the H2O Services, you will need to register with H2O and create an account. When registering, you will be asked to provide certain personal information, such as your email address. Please see H2O’s <a href="{% url 'privacy-policy' %}">Privacy Policy</a> for H2O’s data-retention and usage policies. You agree not to create an account using false or misleading information or on behalf of someone other than yourself. Accounts created using intentionally misleading information are subject to termination at H2O’s sole discretion. If you have been banned or had your account revoked, you may not register for another account.</p>
 
-    <h2>4. Obligations and Restrictions on Use of the H2O Services</h2>
+    <h2 id="tos-obligations-and-restrictions">4. Obligations and Restrictions on Use of the H2O Services</h2>
     <p>Your use of the H2O Services is subject to the following restrictions and obligations:</p>
     <ul>
         <li>a. You may use H2O only for personal, educational, or other types of noncommercial uses.</li>
@@ -26,10 +26,10 @@
         <li>e. You may not use the H2O Services in any way that interferes with the operation of the H2O Services or impacts any other User, host, or network, or circumvents any of the H2O Services’ security protections.</li>
     </ul>
 
-    <h2>5. Children’s Privacy</h2>
+    <h2 id="tos-childrens-privacy">5. Children’s Privacy</h2>
     <p>The H2O Services are intended only for those over the age of 13, and by using or viewing the H2O Services in any way you represent that you are at least 13 years of age. H2O does not knowingly collect or retain any personal information for individuals under 13 years of age. Parents, if you believe that H2O has unintentionally collected personal information regarding your child, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a> so that H2O can remove it.</p>
 
-    <h2>6. User Content</h2>
+    <h2 id="tos-user-content">6. User Content</h2>
 
     <h3>a. Contributing Content</h3>
     <p>Some portions of the H2O Services allow you to upload and post content (such as text, audio, video, questions, and commentary) to the Site ("User Content"). In addition, subject to Section 7 below, you may include embeddable links to third party material available through Third Party Services ("Embedded Links"). You represent and warrant that you have all rights necessary to upload the User Content, or to post the Embedded Links, to the Site and to grant the rights granted by you to H2O and other Users pursuant to these Terms of Service.</p>
@@ -38,10 +38,10 @@
     <p>By submitting your User Content to the H2O Services, you grant H2O a perpetual, irrevocable, world-wide, non-exclusive, fully paid-up, royalty-free, sublicenseable, and transferable license to use, reproduce, reformat, distribute, prepare derivative works of, display, and perform your User Content in connection with the H2O Services.</p>
     <p>By submitting your User Content to the H2O Services, you also agree to allow H2O to license your Content under the Creative Commons Attribution-Noncommercial-Share Alike 3.0 License, the terms of which are available at <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">http://creativecommons.org/licenses/by-nc-sa/3.0/</a>, to allow others to freely re-use and adapt your Content with proper attribution.</p>
 
-    <h2>7. Third-Party Services and Content</h2>
+    <h2 id="tos-third-party-services">7. Third-Party Services and Content</h2>
     <p>Certain functions of the Services may link you to or provide you access to functions, content, sites, or services operated by third parties (collectively, "Third-Party Services"). Those Third-Party Services are subject to the terms and conditions and privacy policies of the third parties that provide them, and H2O is not responsible for the privacy practices, content, or functionality of the Third-Party Services. You are solely responsible for reading and complying with any licenses, restrictions, privacy policies or other terms and conditions that govern the use of any Third-Party Services you choose to access, visit or link to through your use of the Services, and are solely liable for any violations of those terms and conditions that arise out of or relate to your use of the Third-Party Services.</p>
 
-    <h2>8. Intellectual Property</h2>
+    <h2 id="tos-intellectual-property">8. Intellectual Property</h2>
 
     <h3>a. Intellectual Property Rights</h3>
     <p>Except for any User Content, H2O owns and retains all right, title, and interest in and to the H2O Services, including, but not limited to, the design and architecture of the H2O Services, as well as any software, logos, or content provided through H2O, including any intellectual property or other proprietary rights contained therein (collectively, "H2O IP"). You must seek permission from H2O if you desire to use the H2O Services in a way that is not outlined in these Terms of Service. Except for any rights explicitly granted in writing by H2O under these Terms of Service or otherwise, you are not granted any rights in and to any H2O IP.</p>
@@ -68,19 +68,19 @@
         <li>4. Your name, address, and telephone number, and a signed statement that you consent to the jurisdiction of state and federal courts in Suffolk County, Massachusetts, and that you will accept service of process from the party who made the initial infringement claim (or their authorized agent) if they choose to pursue legal action.</li>
     </ul>
 
-    <h2>9. Content Removal and Account Termination</h2>
+    <h2 id="tos-content-removal-and-account-termination">9. Content Removal and Account Termination</h2>
     <p>You are entirely responsible for all activities that occur on or through your account. H2O retains the right (but not the obligation) to limit, suspend, terminate, modify, or delete your account; to limit your access to the H2O Services or portions thereof; to remove links in your User Content to other Content on the H2O Services; to remove Embedded Links to Third-Party Services; and to delete your User Content at H2O’s discretion, with or without notice to you. H2O may at any time remove other Users’ Content that you have chosen to incorporate into your own User Content, causing it to be removed from your User Content as well. H2O is under no obligation to provide compensation for any such losses or results, which may occur due to your failure to comply with the these Terms of Service or those of a third party, for repeated violations of third-party rights, for actual or suspected illegal or improper use of the H2O Services, for offensive User Content or conduct, or for technical reasons.</p>
 
-    <h2>10. Warranty Disclaimer</h2>
+    <h2 id="tos-warranty-disclaimer">10. Warranty Disclaimer</h2>
     <p>H2O AND HLSL EXPRESSLY DISCLAIM ANY AND ALL WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND NON-INFRINGEMENT. THE H2O SERVICES ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE BASIS," AND YOU USE THEM AT YOUR SOLE RISK. YOU ASSUME ALL RESPONSIBILITY TO PROTECT YOUR COMPUTER SYSTEMS OR ANY OTHER DEVICES YOU USE TO ACCESS THE H2O SERVICES FROM DAMAGE CAUSED BY BUGS, VIRUSES, TROJANS, OR THE LIKE WHICH MAY BE TRANSMITTED FROM H2O’S SERVERS. H2O AND HLSL ASSUME NO LIABILITY FOR THE ACCURACY, SUITABILITY, OR COMPLETENESS OF ANY CONTENT OR INFORMATION THAT MAY BE ACCESSED THROUGH THE H2O SERVICES, WHETHER OR NOT PROVIDED BY H2O OR ITS PARTNERS. H2O DOES NOT GUARANTEE THAT THE H2O SERVICES WILL BE AVAILABLE AT A GIVEN TIME. H2O AND HLSL ARE NOT RESPONSIBLE FOR ANY OFFENSIVE OR ILLEGAL CONTENT INCLUDED IN PICTURES, PHOTOGRAPHS, OR OTHER KINDS OF MEDIA INCORPORATED INTO USER CONTENT BY THIRD PARTIES. YOU ACKNOWLEDGE THAT THE VIEWPOINTS EXPRESSED IN USER CONTENT OR ON THIRD-PARTY SERVICES REPRESENT THE OPINIONS OF THOSE USERS AND THIRD-PARTY SERVICE PROVIDERS, AND ARE NOT ENDORSED BY H2O OR HLSL IN ANY WAY.</p>
 
-    <h2>11. Limitations of Liability</h2>
+    <h2 id="tos-limitations-of-liability">11. Limitations of Liability</h2>
     <p>IN NO EVENT IS H2O OR HLSL, THEIR OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS LIABLE FOR ANY DAMAGES OR LOSSES, WHETHER DIRECT OR INDIRECT, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, CONSEQUENTIAL, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE, OR OTHER DAMAGES OF ANY KIND ARISING FROM OR RELATED TO THE H2O SERVICES, INCLUDING, BUT NOT LIMITED TO, LOSSES RESULTING FROM LOSS OF DATA, PROPERTY DAMAGE, PERSONAL INJURY, LOSS OF GOODWILL, INABILITY TO USE OR ACCESS THE H2O SERVICES, THIRD-PARTY CONDUCT ON THE H2O SERVICES, OR ANY OTHER ACTIONS ASSOCIATED WITH THE USE OF THE H2O SERVICES.</p>
 
-    <h2>12. Indemnification</h2>
+    <h2 id="tos-indemnification">12. Indemnification</h2>
     <p>You agree at your own expense to indemnify, defend, save, and hold harmless HLSL and H2O, their employees, affiliates, officers, directors, contributors, and other representatives from and against any and all judgments, losses, damages, liabilities, costs, or expenses (including, but not limited to, reasonable attorneys’ fees and legal expenses) arising from or related to your use of the H2O Services, or your violation of these Terms of Service.</p>
 
-    <h2>13. General Terms</h2>
+    <h2 id="tos-general-terms">13. General Terms</h2>
 
     <h3>a. Updates and Changes to These Terms of Service</h3>
     <p>H2O reserves the right to modify these Terms of Service at anytime at its discretion. If H2O does make changes to Terms of Service, H2O will update this page accordingly. Please check this page periodically for any changes. Your continued use of the H2O Services after this page is updated with the new terms signifies your acceptance of the amended Terms of Service. No amendment to these Terms of Service or Privacy Policy shall apply to any dispute of which H2O had actual notice before the date of the amendment. Other additional terms may apply to other functions or components of the H2O Services. If there is a conflict between these Terms of Service and the other additional terms, the other additional terms will govern.</p>
@@ -106,7 +106,7 @@
     <h3>h. No Waiver</h3>
     <p>No waiver of any term of these Terms of Service shall be deemed a further or continuing waiver of such term or any other term, and H2O’s failure to assert any right or provision under these Terms of Service shall not constitute a waiver of such right or provision.</p>
 
-    <h2>14. Questions?</h2>
+    <h2 id="tos-questions">14. Questions?</h2>
     <p>If you have questions about these Terms of Service, please contact H2O at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</p>
 
     <p>Last modified on April 24, 2019.</p>


### PR DESCRIPTION
Adds link targets for all the major (H2) headings, so we can direct people to e.g. `/pages/terms-of-service/#tos-user-content` to go directly to "User Content" (and the CC licensing language).

I kept the targets unnumbered so they don't need to be revised if the order of items on this page changes.