### PR TITLE
Copyright messaging

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -456,14 +456,10 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
         @include sans-serif($medium, 13px, 13px);
         font-weight: bold;
         display: inline-block;
-        width:fit-content;
-        &.verified::before {
-          @include square(13px);
-          display: inline-block;
-          vertical-align: middle;
-          content: '';
-          background: url('~static/images/ui/verified.png') no-repeat;
-        }
+        width: fit-content;
+
+        @include verified-professor();
+
       }
     }
 
@@ -776,13 +772,7 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
                 &:last-child:after {
                     content: ""
                 }
-            }
-            li.verified::before {
-                @include square(13px);
-                display: inline-block;
-                vertical-align: middle;
-                content: '';
-                background: url('~static/images/ui/verified.png') no-repeat;
+                @include verified-professor();
             }
 
             display: inline;
@@ -1017,4 +1007,8 @@ div.tox-toolbar__group:nth-child(2) button.tox-tbtn.tox-tbtn--select.tox-tbtn--d
       list-style: none;
     }
   }
+}
+
+.casebook-copyright-notice {
+  margin-top: 4rem;
 }

--- a/web/frontend/styles/dashboard.scss
+++ b/web/frontend/styles/dashboard.scss
@@ -207,6 +207,14 @@ div.dashboard-link {
   .content-page:hover{
     box-shadow: 0 3px 40px rgb(0 0 0 / 0.3);
   }
+  .verified {
+    @include square(13px);
+    display: inline-block;
+    vertical-align: middle;
+    content: '';
+    background: url('~static/images/ui/verified.png') no-repeat;
+    margin-left: 3px;
+  }
 }
 
 // casebook-sub info section when there is a cover
@@ -256,14 +264,7 @@ div.dashboard-link {
     @include line-clamp(2, 40px);
   }
 
-  .verified {
-    @include square(13px);
-    display: inline-block;
-    vertical-align: middle;
-    content: '';
-    background: url('~static/images/ui/verified.png') no-repeat;
-    margin-left: 3px;
-  }
+
 
   .root-attribution {
     font-size: 10px;

--- a/web/frontend/styles/mixins.scss
+++ b/web/frontend/styles/mixins.scss
@@ -65,3 +65,15 @@
     max-height: $max-height;
   }
 }
+
+@mixin verified-professor($font-size: 13px, $padding-right: 3px) {
+
+  &.verified::before {
+    height: $font-size;
+    width: calc($font-size + $padding-right);
+    display: inline-block;
+    vertical-align: middle;
+    content: '';
+    background: url('~static/images/ui/verified.png') no-repeat;
+  }
+}

--- a/web/main/templates/casebook_history.html
+++ b/web/main/templates/casebook_history.html
@@ -35,6 +35,8 @@
             </ul>
             {% endif %}
             </div>
+
+            {% include "includes/casebook_copyright_notice.html" %}
         </div>
     </div>
 </section>

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -125,6 +125,15 @@
                 {% else %}
             {% endif %}
         </div>
+
+        <div class="casebook-inner">
+            {% include "includes/casebook_copyright_notice.html" %}
+        </div>
+
     </div>
+
+
 </section>
+
+
 {% endblock %}

--- a/web/main/templates/casebook_page_search.html
+++ b/web/main/templates/casebook_page_search.html
@@ -14,6 +14,8 @@
         <div class="casebook-inner">
             <div class="top-strip"></div>
             {% include 'includes/casebook_search.html' %}
+
+            {% include "includes/casebook_copyright_notice.html" %}
         </div>
     </div>
 </section>

--- a/web/main/templates/casebook_settings.html
+++ b/web/main/templates/casebook_settings.html
@@ -155,6 +155,7 @@
                     </ul>
                 </li>
             </ul>
+            {% include "includes/casebook_copyright_notice.html" %}
         </div>
     </div>
 </section>

--- a/web/main/templates/includes/casebook_copyright_notice.html
+++ b/web/main/templates/includes/casebook_copyright_notice.html
@@ -1,0 +1,10 @@
+<p class="casebook-copyright-notice">
+    This book, and all H2O books, are <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/ ">Creative Commons licensed</a>
+    for sharing and re-use.
+
+
+    {# TODO make this dynamic in response to this casebook's content #}
+    <span class="ali-license">
+        Material included from the American Legal Institute is reproduced with permission and is exempted from the open license.
+    </span>
+</p>

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -56,13 +56,5 @@
         <p class="author-rider">except where otherwise attributed.</p>
         {% endif %}
     </div>
-    <p class="casebook-copyright-notice">
-        This book, and all H2O books, are Creative Commons licensed for sharing and re-use:
-        <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/ ">CC BY-NC-SA</a>.
-
-        {# TODO make this dynamic in response to this casebook's content #}
-        <span class="ali-license">
-            Material included from the American Legal Institute is reproduced with permission and is exempted from the open license.
-        </span>
-    </p>
+    {% include "includes/casebook_copyright_notice.html" %}
 </section>

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -56,4 +56,13 @@
         <p class="author-rider">except where otherwise attributed.</p>
         {% endif %}
     </div>
+    <p class="casebook-copyright-notice">
+        This book, and all H2O books, are Creative Commons licensed for sharing and re-use:
+        <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/ ">CC BY-NC-SA</a>.
+
+        {# TODO make this dynamic in response to this casebook's content #}
+        <span class="ali-license">
+            Material included from the American Legal Institute is reproduced with permission and is exempted from the open license.
+        </span>
+    </p>
 </section>


### PR DESCRIPTION
One main thing and one small thing:

## Copyright messages

<img width="955" alt="image" src="https://user-images.githubusercontent.com/19571/207937615-c8490118-e87d-474f-b3f9-091919110869.png">

The message appears at the bottom of all the casebook pages, except the credits page where it appears inline:
<img width="876" alt="image" src="https://user-images.githubusercontent.com/19571/207937734-6ecf926b-6592-4f26-a20c-44ddca62fec3.png">

otherwise:

<img width="914" alt="image" src="https://user-images.githubusercontent.com/19571/207937810-a425df6d-d25d-4538-94cb-b943e306fd92.png">


Adds the copyright messaging we discussed to the credits page and the footer of the book pages.

## Verified notice

Also while I was there I fixed the display of the verified professor checkbox, which was inconsistent and too close to the name on a few pages.

### Before

<img width="635" alt="image" src="https://user-images.githubusercontent.com/19571/207937433-53179bc9-44c8-40b9-842e-bab0f2f54c45.png">

### After 

<img width="653" alt="image" src="https://user-images.githubusercontent.com/19571/207937483-832ecc61-dbf9-45e9-a17b-635c62d230a1.png">

Finally, one `.verified` class definition seemed to be globally-scoped when it was intended to apply only to the dashboard page. I moved it to the proper scope because it was getting applied in the wrong contexts and colliding with per-page definitions.
