### PR TITLE
Disambiguate headnotes from other text in reading mode

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -268,7 +268,8 @@ annotationRanges.forEach((rg) => {
 });
 
 function renderAsPagedJS() {
-  paged.preview(tmpl.content, [], main).then((flow) => {
+  const css = tmpl.getAttribute("data-stylesheet");
+  paged.preview(tmpl.content, [css], main).then((flow) => {
     console.log("Rendered", flow.total, "pages.");
     main.classList.add("preview-ready");
   });

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -42,12 +42,13 @@
         {% endif %}
 
         {% if node.is_resource %}
-          {% if node.resource_type.lower == 'legaldocument' %}
 
-            <section class="legal_doc_header">
-              {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
-            </section>
+        <section class="{{ node.resource_type.lower }}-container">
+
+          {% if node.resource_type.lower == 'legaldocument' %}
+            {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
           {% endif %}
+
           {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
           <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
 
@@ -60,6 +61,7 @@
               class="hidden">{{ annotation.content }}</li>
           {% endfor %}
         {% endif %}
+        </section>
     {% endif %}
 
   </div>

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -42,7 +42,13 @@
         {% endif %}
 
         {% if node.is_resource %}
-        {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
+          {% if node.resource_type.lower == 'legaldocument' %}
+
+            <section class="legal_doc_header">
+              {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
+            </section>
+          {% endif %}
+          {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
           <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>
 
           {% for annotation in node.annotations.valid %}

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -132,9 +132,7 @@
     padding: 0 var(--headnote-padding);
 
   }
-  section.headnote {
-    margin: 0 0 var(--headnote-padding);
-  }
+
   /* Headnotes don't have indentation */
   section.headnote p {
     text-indent: initial;

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -31,6 +31,7 @@
     --link-icon-margin: 5mm;
     --highlight-background-greyscale: #ededed;
     --highlight-background-color: #fff7b9;
+    --headnote-padding: 5mm;
   }
 
   /* Always start a top-level section on a new page, even if there's preface matter */
@@ -125,6 +126,15 @@
     font-style: italic;
   }
 
+  section.headnote {
+    border: 1px solid var(--highlight-background-greyscale);
+    margin: 0 calc(-1 * (var(--headnote-padding)));
+    padding: 0 var(--headnote-padding);
+
+  }
+  section.headnote {
+    margin: 0 0 var(--headnote-padding);
+  }
   /* Headnotes don't have indentation */
   section.headnote p {
     text-indent: initial;
@@ -251,7 +261,9 @@
     text-decoration: none;
     color: inherit;
   }
-
+  section.headnote p {
+    margin: var(--casebook-font-size) 0;
+  }
   /* Style footnotes, allowing the URLs to break midway. PagedJS will put these in the bottom margin */
   .footnote-generated {
     float: footnote;

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -127,10 +127,8 @@
   }
 
   section.headnote {
-    border: 1px solid var(--highlight-background-greyscale);
     margin: 0 calc(-1 * (var(--headnote-padding)));
     padding: 0 var(--headnote-padding);
-
   }
 
   /* Headnotes don't have indentation */

--- a/web/static/as_printable_html/cap.css
+++ b/web/static/as_printable_html/cap.css
@@ -1,7 +1,11 @@
 /* Cap-specific style */
 
+:root {
+  --legal-doc-outset: 20px;
+}
+
 .legaldocument sup {
-  font-size: calc(var(--casebook-font-size) * .75);
+  font-size: calc(var(--casebook-font-size) * 0.75);
 }
 
 .legaldocument a[href^="#"] {
@@ -13,7 +17,6 @@
   font-size: calc(var(--casebook-font-size) / 2);
   vertical-align: super;
 }
-
 
 .legaldocument header.case-header .title,
 .legaldocument header.case-header .citation,
@@ -63,10 +66,23 @@
 
 .legaldocument aside.footnote > a {
   float: left;
+  padding-right: 1rem;
 }
 
 .legaldocument img {
   max-width: 100%;
   width: auto;
   height: auto;
+}
+
+section.legaldocument-container {
+
+  padding: calc(3 * var(--legal-doc-outset));
+  margin: calc(2 * var(--legal-doc-outset))
+          calc(-1 * var(--legal-doc-outset))
+          calc(10 * var(--legal-doc-outset))
+          calc(-1 * var(--legal-doc-outset)) ;
+  box-shadow: rgba(100, 100, 111, 0.1) 0px 10px 29px 0px;
+  ;
+  box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 10px 0px, rgba(14, 30, 37, 0.2) 0px 2px 8px 0px;
 }

--- a/web/static/as_printable_html/cap.css
+++ b/web/static/as_printable_html/cap.css
@@ -32,13 +32,13 @@
 }
 
 .legaldocument header.case-header .court {
-  font-size: 24px;
+  font-size: 24px !important;
 }
 
 .legaldocument header.case-header .citation,
 .legaldocument header.case-header .decisiondate,
 .legaldocument header.case-header .docketnumber {
-  font-size: 18px;
+  font-size: 18px !important;
 }
 
 .legaldocument header.case-header .title {
@@ -48,17 +48,16 @@
   padding: 20px 4px 10px 4px;
 }
 
-.legaldocument .parties,
-.legaldocument .decisiondate,
-.legaldocument .docketnumber,
-.legaldocument .citations,
-.legaldocument .syllabus,
-.legaldocument .synopsis,
-.legaldocument .court {
-  display: none;
-}
+/* Hide embedded metadata in case content */
 
-.legaldocument .page-label {
+.legaldocument section.resource .parties,
+.legaldocument section.resource .decisiondate,
+.legaldocument section.resource .docketnumber,
+.legaldocument section.resource .citations,
+.legaldocument section.resource .syllabus,
+.legaldocument section.resource .synopsis,
+.legaldocument section.resource .court,
+.legaldocument section.resource .page-label {
   display: none;
 }
 

--- a/web/static/as_printable_html/cap.css
+++ b/web/static/as_printable_html/cap.css
@@ -2,6 +2,7 @@
 
 :root {
   --legal-doc-outset: 20px;
+  --legal-doc-shadow: rgba(14, 30, 37, 0.2);
 }
 
 .legaldocument sup {
@@ -82,7 +83,23 @@ section.legaldocument-container {
           calc(-1 * var(--legal-doc-outset))
           calc(10 * var(--legal-doc-outset))
           calc(-1 * var(--legal-doc-outset)) ;
-  box-shadow: rgba(100, 100, 111, 0.1) 0px 10px 29px 0px;
-  ;
-  box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 10px 0px, rgba(14, 30, 37, 0.2) 0px 2px 8px 0px;
+  box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 10px 0px, var(--legal-doc-shadow) 0px 2px 8px 0px;
+}
+@media print {
+  section.legaldocument-container {
+    box-shadow: none;
+
+  }
+  section.legaldocument-container:before {
+    border-top: 1px solid var( --legal-doc-shadow);
+    height: 1rem;
+    display: block;
+    content: '';
+  }
+  section.legaldocument-container:after {
+    border-bottom: 1px solid var( --legal-doc-shadow);
+    height: 2rem;
+    display: block;
+    content: '';
+  }
 }


### PR DESCRIPTION
In reading mode, put a light shadow around case content to set it apart from the headnote:

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/19571/211635001-3b34ecc2-4569-449c-abca-f48a3e3bc849.png">

This is meant to evoke the notion that this is a whole document embedded inside the casebook.

The treatment needs to be different in the paginated, printable view, because the border ends up appearing on every page and isn't padded correctly. In this view instead I just set it off with a light line:

<img width="1476" alt="image" src="https://user-images.githubusercontent.com/19571/211637265-4cb53dcb-b78c-4c11-a126-f52eb09a1cca.png">

This also fixes an unintentional regression in the PagedJS layout where styles meant to target the print CSS weren't made available to PagedJS.

Fixes #1862 and #1861 