### PR TITLE
Change simple instance methods to getters where appropriate

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1251,10 +1251,6 @@ class LegalDocument(NullableTimestampedModel, AnnotatedModel):
         cleanse_html_field(self, "content")
         super().save(*args, **kwargs)
 
-    @property
-    def get_title(self):
-        return self.short_name or self.name
-
     def get_name(self):
         return self.short_name or self.name
 
@@ -2491,7 +2487,8 @@ class ContentNode(
         for cls, ids in to_delete.items():
             cls.objects.filter(id__in=ids).delete()
 
-    def get_slug(self):
+    @property
+    def slug(self):
         return slugify(self.title)
 
     def viewable_by(self, user: User) -> bool:
@@ -3595,7 +3592,8 @@ class Casebook(EditTrackedModel, TimestampedModel, BigPkModel, TrackedCloneable)
         cleanse_html_field(self, "headnote", True)
         super().save(*args, **kwargs)
 
-    def get_slug(self):
+    @property
+    def slug(self):
         return slugify(self.title)
 
     def viewable_by(self, user: Union[User, AnonymousUser]):

--- a/web/main/templates/casebook_outline_edit.html
+++ b/web/main/templates/casebook_outline_edit.html
@@ -20,7 +20,7 @@
 
 <section class="wide-casebook {{casebook_color_class}}">
     <casebook-outliner
-        casebook="{{casebook.id}}-{{ casebook.get_slug }}"
+        casebook="{{casebook.id}}-{{ casebook.slug }}"
         root-id="{{ section.id }}"
         editing="{{ editing }}"
         root-ordinals="{{ section.ordinal_string }}">

--- a/web/main/url_converters.py
+++ b/web/main/url_converters.py
@@ -65,7 +65,7 @@ class IdSlugConverter:
         """
         if hasattr(value, "id"):
             id = value.id
-            slug = value.get_slug()
+            slug = value.slug
         elif isinstance(value, int):
             id = value
             slug = None
@@ -91,7 +91,7 @@ class OrdinalSlugConverter:
         return {"ordinals": [int(i) for i in ord_slug[0].split(".")], "slug": slug}
 
     @staticmethod
-    def to_url(value):
+    def to_url(value: any):
         """
         >>> assert OrdinalSlugConverter.to_url({"ordinals": [1, 2]}) == "1.2"
         >>> assert OrdinalSlugConverter.to_url({"ordinals": [1, 2], "slug": "foo"}) == "1.2-foo"
@@ -99,7 +99,7 @@ class OrdinalSlugConverter:
         """
         if hasattr(value, "ordinals"):
             ordinals = value.ordinals
-            slug = value.get_slug()
+            slug = value.slug
         elif isinstance(value, dict):
             ordinals = value["ordinals"]
             slug = value.get("slug")

--- a/web/main/url_converters.py
+++ b/web/main/url_converters.py
@@ -91,7 +91,7 @@ class OrdinalSlugConverter:
         return {"ordinals": [int(i) for i in ord_slug[0].split(".")], "slug": slug}
 
     @staticmethod
-    def to_url(value: any):
+    def to_url(value):
         """
         >>> assert OrdinalSlugConverter.to_url({"ordinals": [1, 2]}) == "1.2"
         >>> assert OrdinalSlugConverter.to_url({"ordinals": [1, 2], "slug": "foo"}) == "1.2-foo"

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1482,7 +1482,7 @@ def clone_casebook_nodes(request, from_casebook_dict, from_section_dict, to_case
     to_casebook.clone_nodes(nodes_to_clone, append=True)
     to_casebook.refresh_from_db()
     new_add = to_casebook.children.order_by("-ordinals").first()
-    link_hash = new_add.ordinal_string() + "-" + new_add.get_slug()
+    link_hash = new_add.ordinal_string() + "-" + new_add.slug
     return redirect(to_casebook.get_edit_url() + "#" + link_hash)
 
 


### PR DESCRIPTION
This is a minor cleanup but touches on something I'll use in #1860.

For the method `get_slug(self)` in models where it appears, replace it with a `@property` decorator. 

There are a lot more instances of `def get_something_easily_computable(self)` that could be switched to a property, and even more cases like:

```python
@property
def get_something(self)
```

which is surprising—I would not expect a property to be prepended by `get_`, and some of these methods do more computation than is recommended for properties. See https://realpython.com/python-getter-setter/ for best practices if you're curious!

Also removes one seemingly unused property: `LegalDocument.get_title()`
