### PR TITLE
Add links to subsections in the nav in reader mode, fixes  #1860

### DIFF
--- a/web/main/serializers.py
+++ b/web/main/serializers.py
@@ -102,6 +102,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
             "ordinal_string",
             "ordinals",
             "is_instructional_material",
+            "slug",
         )
 
 
@@ -439,6 +440,7 @@ def manually_serialize_content_query(content_query: ContentNodeQuerySet):
     ...         "ordinals",
     ...         "ordinal_string",
     ...         "children",
+    ...         "slug",
     ...     )
     ... ])
 

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -9,25 +9,25 @@
   <div class="node-container">
 
     {% if node.resource_type == 'Link' %}
-      <div class="link-container">
-        <div class="link-icon"></div>
 
-        <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}{% if node.ordinal_string %}.{% endif %}
-          Hyperlink to a web resource
-        </h4>
-      </div>
+      <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}{% if node.ordinal_string %}.{% endif %}
+        {{ node.title }}
+      </h1>
+
       <h2 class="subtitle">{{ node.subtitle|default_if_none:"" }}</h2>
 
       {% if node.headnote %}
         {% call_method node 'headnote_for_export' export_options=export_options as headnote %}
         <section class="headnote">{{ headnote }}</section>
       {% endif %}
-
-      <a href="{{ node.resource.url }}" target="_blank" data-type="resource link">{{ node.resource.url }}</a>
+      <div class="link-container">
+        <a href="{{ node.resource.url }}" target="_blank" data-type="resource link">{{ node.resource.url }}</a>
+        <span class="link-icon"></span>
+      </div>
 
     {% else %}
 
-        <h1 class="{{ node.type }} title">
+        <h1 class="{{ node.type }} title" id="{{ node.slug }}">
           <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
           <span>{{ node.title }}</span>
         </h1>

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -15,17 +15,20 @@
         <ol class="toc-items">
         {% for top_level_node in toc %}
             <li>
-                <span class="ordinals">{{ top_level_node.ordinal_string }}</span>
-                <h3><a href="{% url 'as_printable_html' casebook forloop.counter %}">{{ top_level_node.title }}</a></h3>
-
-                <ol>
-                {% for child in top_level_node.children %}
-                    <li>
-                        <span class="ordinals">{{ child.ordinal_string }}</span>
-                        <span class="node-title">{{ child.title }}</span>
-                    </li>
-                {% endfor %}
-                </ol>
+                {% with chapter_num=forloop.counter %}
+                    <span class="ordinals">{{ top_level_node.ordinal_string }}</span>
+                    <h3><a href="{% url 'as_printable_html' casebook chapter_num %}">{{ top_level_node.title }}</a></h3>
+                    <ol>
+                        {% for child in top_level_node.children %}
+                            <li>
+                                <span class="ordinals">{{ child.ordinal_string|default:"—" }}</span>
+                                <h4 class="node-title">
+                                    <a href="{% url 'as_printable_html' casebook chapter_num %}#{{ child.slug }}">{{ child.title }}</a>
+                                </h4>
+                            </li>
+                        {% endfor %}
+                        </ol>
+                {% endwith %}
             </li>
         {% endfor %}
         </ol>

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -26,8 +26,8 @@
     --casebook-font-size: 3.5mm;
     --casebook-line-height: calc(var(--casebook-font-size) * 1.8);
     --casebook-font-family: "LibreCaslon";
-    --link-icon-height: 10mm;
-    --link-icon-width: 10mm;
+    --link-icon-height: calc(2 * var(--casebook-font-size));
+    --link-icon-width: calc(2 * var(--casebook-font-size));
     --link-icon-margin: 5mm;
     --highlight-background-greyscale: #ededed;
     --highlight-background-color: #fff7b9;
@@ -121,7 +121,7 @@
     font-size: 110%;
     font-weight: bold;
   }
-  h2.subtitle {
+  h2.subtitle * {
     font-size: 100%;
     font-style: italic;
   }
@@ -166,7 +166,9 @@
   }
   .link-container {
     min-height: var(--link-icon-height);
-    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--casebook-font-size);
   }
 
   a[data-type~="link"] {
@@ -176,10 +178,9 @@
   .link-icon {
     width: var(--link-icon-width);
     height: var(--link-icon-height);
-    margin-right: var(--link-icon-margin);
     background: url("../images/Link.svg");
     background-size: cover;
-    float: left;
+    display: inline-block;
   }
 
   .truncated-title {

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -121,7 +121,7 @@
     font-size: 110%;
     font-weight: bold;
   }
-  h2.subtitle * {
+  h2.subtitle {
     font-size: 100%;
     font-style: italic;
   }

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -1,7 +1,7 @@
 nav.toc {
     --toc-column-gap: 2mm;
     --toc-row-gap: calc(var(--casebook-font-size) * 1);
-    --toc-left-width: 10mm;
+    --toc-left-width: 8mm;
     break-before: right;
 }
 nav.toc h2 {
@@ -17,28 +17,32 @@ nav.toc h3 {
     font-size: 1em;
     font-weight: bold;
 }
-nav.toc ol {
+
+nav.toc ol.toc-items {
     padding: 0;
 }
-nav.toc ol > li {
-    padding: var(--toc-row-gap) 0 0 0;
 
+nav.toc ol.toc-items > li {
+    padding: var(--toc-row-gap) 0 0 0;
 }
-nav.toc .ordinals {
-    width: calc(var(--toc-left-width) + var(--toc-column-gap));
-    float: left;
+nav.toc ol.toc-items > li li {
+    padding: calc(var(--toc-row-gap) / 2) 0 0 0;
+}
+nav.toc ol.toc-items > li > .ordinals {
+    display: inline-block;
 }
 
 nav.toc .node-title {
-    display: block;
-    margin-left: calc(var(--toc-left-width) + var(--toc-column-gap));
+    display: inline-block;
+    margin: 0 0 0 calc(var(--toc-left-width) / 2);
 }
 
 nav.toc > ol > li > ol li {
     line-height: calc(var(--casebook-line-height) * 0.8);
 }
-nav.toc > ol > li > ol li span {
+nav.toc ol.toc-items span.ordinals {
     display: inline-block;
+    width: var(--toc-left-width);
 }
 
 nav.toc > ol > li > ol > li:last-child {


### PR DESCRIPTION
A bit of a rewrite in how the TOC is laid out:

<img width="531" alt="image" src="https://user-images.githubusercontent.com/19571/211926726-b928b3ad-cd29-4735-961d-6983380683d6.png">

I changed the markup in the TOC to be less fragile, then added indentation to the sub-section items. As before, the TOC doesn't descend further than 2 levels, though it could.

Each item in the toc is now hyperlinked, not just the top items. If you follow them, you go to the section via an anchor link.

As before, the underlining is not visible when printing: 

<img width="419" alt="image" src="https://user-images.githubusercontent.com/19571/211927206-87d11689-f7f8-45ba-b5ab-21a4fb172d90.png">

Also modifies the display of `Link` items, which I think wasn't working well. Now it's less exuberant:

<img width="608" alt="image" src="https://user-images.githubusercontent.com/19571/211927579-474b3ba9-40de-4d15-88cb-2457bdce1cd2.png">
 
