### PR TITLE
Improve layout of casebook forematter in reading mode

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -9,30 +9,25 @@ class TocControl extends HTMLElement {
     return ['open']
   }
 
+
   connectedCallback() {
 
     this.tocList = this.querySelector('ol');
-
-    this.querySelector('.toc-opener').addEventListener('click', () => {
-      if (!this.tocList.getAttribute('data-natural-height')) {
-        const height = parseInt(this.tocList.getBoundingClientRect().height, 10);
-        this.tocList.setAttribute('data-natural-height', height);
-        this.tocList.style.height = `${height}px`;
-      }
-      window.requestAnimationFrame(() => this.toggleAttribute('open'));
-    })
-
-    this.tocList.addEventListener('transitionstart', () => {
-      if (this.tocList.classList.contains('collapsing')) {
-        this.tocList.classList.add('invisible')
-      }
-    });
-    this.tocList.addEventListener('transitionend', () => {
-      if (!this.tocList.classList.contains('collapsing')) {
-        this.tocList.classList.remove('invisible')
-      }
-    });
-
+    if (this.tocList) {
+      this.querySelector('.toc-opener').addEventListener('click', () => {
+        window.requestAnimationFrame(() => this.toggleAttribute('open'));
+      })
+      this.tocList.addEventListener('transitionstart', () => {
+        if (this.tocList.classList.contains('collapsing')) {
+          this.tocList.classList.add('invisible')
+        }
+      });
+      this.tocList.addEventListener('transitionend', () => {
+        if (!this.tocList.classList.contains('collapsing')) {
+          this.tocList.classList.remove('invisible')
+        }
+      });
+    }
 
   }
   attributeChangedCallback(name, previous, value) {
@@ -42,12 +37,15 @@ class TocControl extends HTMLElement {
           if (value === null) {
             this.tocList.classList.add('collapsing');
             this.tocList.style.height = 0;
+            this.querySelector('svg').classList.remove('open');
+
           } else {
             this.tocList.classList.remove('collapsing');
             this.tocList.style.height = `${this.tocList.getAttribute('data-natural-height')}px`;
+            this.querySelector('svg').classList.add('open');
+
           }
         }
-        this.querySelector('svg').classList.toggle('open');
       }
     }
   }
@@ -301,4 +299,19 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
   main.append(right);
 
   main.classList.add("preview-ready");
+
+  const toc = document.querySelector('toc-control')
+  const tocList = toc.querySelector('ol')
+  const height = parseInt(tocList.getBoundingClientRect().height, 10);
+  tocList.setAttribute('data-natural-height', height);
+
+  if (toc.hasAttribute('start-open')) {
+    toc.querySelector('.toc-opener').click();
+    tocList.style.height = `${height}px`;
+  } else {
+    tocList.style.height = `0px`;
+    tocList.classList.add('invisible');
+    toc.removeAttribute('open');
+  }
+
 }

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -13,9 +13,8 @@
     {% render_bundle 'as_printable_html' attrs="defer" %}
     {% render_bundle 'chunk-common' attrs="defer" %}
 
-    <link href="{% static 'as_printable_html/book.css' %}" type="text/css" rel="stylesheet">
-
     {% if not use_pagedjs %}
+      <link href="{% static 'as_printable_html/book.css' %}" type="text/css" rel="stylesheet">
       <link href="{% static 'as_printable_html/reader-view.css' %}" type="text/css" rel="stylesheet">
     {% endif %}
     <style>
@@ -65,7 +64,9 @@
     </nav>
   </footer>
 
-  <template id="casebook-content" data-stylesheet="{% static 'as_printable_html/book.css' %}" data-use-pagedjs="{{ use_pagedjs|yesno:'true,false' }}">
+  <template id="casebook-content"
+    data-stylesheet="{% static 'as_printable_html/book.css' %}"
+    data-use-pagedjs="{{ use_pagedjs|yesno:'true,false' }}">
     <div class="casebook-metadata" data-paginator-page="{{ page.number }}">
       <h1 class="casebook title">{{ casebook.title }}</h1>
       <h2 class="casebook subtitle">{{ casebook.subtitle|default_if_none:""}}</h2>
@@ -83,9 +84,8 @@
         </ul>
       </div>
       <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
-
       <div id="toc">
-        {% include "export/as_printable_html/toc.html" with toc=toc %}
+        {% include "export/as_printable_html/toc.html" with toc=toc toc_is_open=toc_is_open %}
       </div>
 
     </div>

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -1,11 +1,11 @@
 
 <nav class="toc">
-    <toc-control open>
+    <toc-control {{ toc_is_open|yesno:'start-open,,'}}>
         {% if use_pagedjs %}
             <h2>Table of contents</h2>
         {% else %}
             <button class="toc-opener" role="button">
-                <svg class="screen-only collapse-triangle open" height="25" width="25">
+                <svg class="screen-only collapse-triangle {{ toc_is_open|yesno:'open,,'}}" height="25" width="25">
                     <polygon points="6,6 20,16 6,24" />
                 </svg>
                 <h2>Table of contents</h2>

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2693,7 +2693,7 @@ def export(request: HttpRequest, node: Union[ContentNode, Casebook], file_type="
 )
 def as_printable_html(request: HttpRequest, casebook: Casebook, page=1, whole_book=False):
     """Load the content of the casebook by top-level nodes, and pass it to an HTML template
-    designed to render it in-place, without site chrome, suitable for printing"""
+    designed to render it in-place, without site chrome, suitable for printing or reading"""
 
     use_pagedjs = True if request.GET.get("print-preview") else False
 
@@ -2701,7 +2701,7 @@ def as_printable_html(request: HttpRequest, casebook: Casebook, page=1, whole_bo
         ordinals__len=1
     )
 
-    logger.info(f"Exporting Casebook {casebook.id}, starting from page {page}: serializing to HTML")
+    logger.info(f"Rendering Casebook {casebook.id}, starting from page {page}: serializing to HTML")
 
     paginator = Paginator(top_level_nodes, 1)
     page = paginator.page(page)
@@ -2723,11 +2723,11 @@ def as_printable_html(request: HttpRequest, casebook: Casebook, page=1, whole_bo
         "export/as_printable_html/casebook.html",
         {
             "casebook": casebook,
-            "section": section,
             "paginator": paginator,
             "page": page,
             "children": children,
             "toc": toc,
+            "toc_is_open": whole_book or page.number == 1,
             "export_date": datetime.now().strftime("%Y-%m-%d"),
             "whole_book": whole_book,
             "use_pagedjs": use_pagedjs,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,7 +40,7 @@
         "mixin-deep": "^1.3.2",
         "moment": "^2.24.0",
         "morphdom": "^2.3.2",
-        "pagedjs": "^0.4.0-beta.1",
+        "pagedjs": "^0.4.0",
         "path-complete-extname": "^0.1.0",
         "portal-vue": "^2.1.7",
         "query-string": "^4.3.4",
@@ -13086,9 +13086,9 @@
       }
     },
     "node_modules/pagedjs": {
-      "version": "0.4.0-beta.1",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0-beta.1.tgz",
-      "integrity": "sha512-4jretXdUFP5kzU2z1gdeWnTTV/J165omK8stn4aOMt1Uo0V3ZVzElODF05DXRHSQeuE5OAQiZRCrhAGQjNaqYw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0.tgz",
+      "integrity": "sha512-AkcG5W/O2sB/uVtfiIvl+ESyalHjecDLiOy1zJVOJIeUBRz+theiL2GHyeMTkgQHs76CGrt9w8vzsoaVKsC0Lw==",
       "dependencies": {
         "@babel/polyfill": "^7.10.1",
         "@babel/runtime": "^7.17.8",
@@ -28807,9 +28807,9 @@
       "dev": true
     },
     "pagedjs": {
-      "version": "0.4.0-beta.1",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0-beta.1.tgz",
-      "integrity": "sha512-4jretXdUFP5kzU2z1gdeWnTTV/J165omK8stn4aOMt1Uo0V3ZVzElODF05DXRHSQeuE5OAQiZRCrhAGQjNaqYw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0.tgz",
+      "integrity": "sha512-AkcG5W/O2sB/uVtfiIvl+ESyalHjecDLiOy1zJVOJIeUBRz+theiL2GHyeMTkgQHs76CGrt9w8vzsoaVKsC0Lw==",
       "requires": {
         "@babel/polyfill": "^7.10.1",
         "@babel/runtime": "^7.17.8",

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "mixin-deep": "^1.3.2",
     "moment": "^2.24.0",
     "morphdom": "^2.3.2",
-    "pagedjs": "^0.4.0-beta.1",
+    "pagedjs": "^0.4.0",
     "path-complete-extname": "^0.1.0",
     "portal-vue": "^2.1.7",
     "query-string": "^4.3.4",

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -121,7 +121,7 @@
     font-size: 110%;
     font-weight: bold;
   }
-  h2.subtitle {
+  h2.subtitle * {
     font-size: 100%;
     font-style: italic;
   }

--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -78,7 +78,7 @@
   }
 
   h2 {
-    font-size: 150%;
+    font-size: 130%;
   }
 
   h3 {
@@ -121,7 +121,7 @@
     font-size: 110%;
     font-weight: bold;
   }
-  h2.subtitle * {
+  h2.subtitle {
     font-size: 100%;
     font-style: italic;
   }
@@ -197,10 +197,6 @@
   /* Only in pagedjs mode, hide the TOC except from the first page */
   .pagedjs_page .casebook-metadata:not([data-paginator-page="1"]) {
     display: none;
-  }
-
-  .casebook-metadata div {
-    margin-bottom: 20mm;
   }
 
   .casebook-metadata li,

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -8,6 +8,11 @@
       grid-template-areas: "left center right";
       grid-template-columns: 15vw 65vw 15vw;
     }
+    /* Lay out frontmatter based on whether this is the first chapter */
+    .casebook-metadata:not([data-paginator-page="1"]) .headnote {
+      display: none;
+    }
+
     article p, article div {
       margin: 1rem 0;
     }

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -52,6 +52,9 @@ nav.toc .toc-opener {
     cursor: pointer;
     background: none;
     border: 0;
+    display: flex;
+    align-items: baseline;
+    padding: 0;
 }
 nav.toc .toc-opener h2 {
     display: inline-block;
@@ -59,8 +62,9 @@ nav.toc .toc-opener h2 {
 nav.toc .collapse-triangle {
     scale: 0.75;
     transition: transform 0.25s;
-    transform: rotate(0deg);
     transform-origin: 30% 50%;
+    transform: rotate(0deg);
+    margin-left: -25px;
 }
 nav.toc .collapse-triangle polygon {
     fill: lightgray;
@@ -70,7 +74,7 @@ nav.toc .collapse-triangle polygon {
 nav.toc .collapse-triangle polygon:hover {
     stroke-width: 2;
 }
-nav.toc .collapse-triangle:not(.open) {
+nav.toc .collapse-triangle.open {
     transform: rotate(90deg);
 }
 nav.toc ol {
@@ -81,6 +85,8 @@ nav.toc ol {
 nav.toc toc-control:not([open]) h2::after {
     content: " (click to expand)";
     font-size: 12px;
+    display: block;
+    text-align: left;
 }
 nav.toc ol.invisible li {
     display: none;


### PR DESCRIPTION
This does most of #1859, namely:

* Collapses the TOC if you aren't on the first chapter
* Only displays the headnote on the first chapter/whole book
* Tightens up the spacing in the forematter area in general to get readers to content more quickly.

The open/close toggle logic had some lazy assumptions that I had to address so some of that logic moved around.

While testing this I noticed some problems with the print-ready layout I introduced in an earlier PR. I'll fix that in a followup and probably expand the Playwright tests to avoid that kind of regression in the future.

Lastly, updates PagedJS to the current version from the release candidate. I'm hoping that will also help with locking down the PDF layout and building in more automated testing.

Trivial example of the layout:

<img width="916" alt="image" src="https://user-images.githubusercontent.com/19571/212193322-3eb19599-7a2b-458e-bcc5-dc15799bb191.png">

<img width="538" alt="image" src="https://user-images.githubusercontent.com/19571/212193273-3a3d8488-c0b4-48e0-8801-e285101049f5.png">

