### PR TITLE
Minor version PG upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: registry.lil.tools/library/postgres:12.8
+    image: registry.lil.tools/library/postgres:12.11
     volumes:
       - db_data_12:/var/lib/postgresql/data:delegated
     ports:


### PR DESCRIPTION
This is a little embarrassing; our prod database instance has "Auto minor version upgrade" enabled, and has managed itself from 12.8 to 12.11. This reflects that change.