### PR TITLE
Integrate Celery for running async tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
         aliases:
           - 'opencasebook.minio.test'
 
+  redis:
+    image: registry.lil.tools/library/redis:7.0
+    volumes:
+      - redis_data:/data:delegated
+
   pandoc-lambda:
     image: registry.lil.tools/harvardlil/h2o-pandoc-lambda:0.64-776ceab36509fa43d4c505e6e3c84252
     tty: true
@@ -74,6 +79,7 @@ services:
 volumes:
   db_data_12:
   minio_data:
+  redis_data:
 
 networks:
   default:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.sqlite3
 .python-version
 settings.py
+celerybeat-schedule

--- a/web/config/__init__.py
+++ b/web/config/__init__.py
@@ -1,0 +1,6 @@
+# via http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ["celery_app"]

--- a/web/config/celery.py
+++ b/web/config/celery.py
@@ -1,0 +1,19 @@
+# via http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
+
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+# when creating app, include any files with tasks outside of 'tasks.py', as they won't be found by autodiscover_tasks()
+app = Celery("config", include=[])
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -239,7 +239,7 @@ WEBPACK_LOADER = {
 ### CELERY settings ###
 ###
 
-CELERY_BROKER_URL = "redis://redis:6379/1"
+CELERY_BROKER_URL = "redis://redis:6379/0"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -235,6 +235,46 @@ WEBPACK_LOADER = {
     }
 }
 
+###
+### CELERY settings ###
+###
+
+CELERY_BROKER_URL = "redis://redis:6379/1"
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = "UTC"
+
+# These default time limits are useful in Perma, where capturing tasks
+# sometimes hang, for still-undiagnosed reasons, and where all tasks
+# are expected to be short-lived.
+#
+# It remains to be determined whether they will prove appropriate here.
+#
+# If a task is running longer than five minutes, ask it to shut down
+# CELERY_TASK_SOFT_TIME_LIMIT=300
+# If a task is running longer than seven minutes, kill it
+# CELERY_TASK_TIME_LIMIT = 420
+CELERY_TASK_TIME_LIMIT = 2
+
+# Control whether Celery tasks should be run asynchronously in a background worker
+# process or synchronously in the main thread of the calling script / Django request.
+# This should normally be False, but it's handy to not require the broker and a
+# celery worker daemon to be running sometimes... for instance, if you want to drop into pdb.
+CELERY_TASK_ALWAYS_EAGER = False
+CELERY_TASK_EAGER_PROPAGATES = True  # propagate exceptions when CELERY_TASK_ALWAYS_EAGER=True
+
+CELERY_TASK_ROUTES = {
+    "main.tasks.sample_scheduled_task": {"queue": "background"},
+}
+
+# from celery.schedules import crontab
+CELERY_BEAT_SCHEDULE = {}
+
+###
+### /END CELERY settings ###
+###
+
 CAPAPI_BASE_URL = "https://api.case.law/v1/"
 CAPAPI_API_KEY = ""
 

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -245,17 +245,10 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "UTC"
 
-# These default time limits are useful in Perma, where capturing tasks
-# sometimes hang, for still-undiagnosed reasons, and where all tasks
-# are expected to be short-lived.
-#
-# It remains to be determined whether they will prove appropriate here.
-#
-# If a task is running longer than five minutes, ask it to shut down
-# CELERY_TASK_SOFT_TIME_LIMIT=300
-# If a task is running longer than seven minutes, kill it
-# CELERY_TASK_TIME_LIMIT = 420
-CELERY_TASK_TIME_LIMIT = 2
+# If a task is running longer than twenty minutes, ask it to shut down
+CELERY_TASK_SOFT_TIME_LIMIT = 20 * 60
+# If a task continues for twenty two minutes, kill it
+CELERY_TASK_TIME_LIMIT = 22 * 60
 
 # Control whether Celery tasks should be run asynchronously in a background worker
 # process or synchronously in the main thread of the calling script / Django request.
@@ -268,7 +261,6 @@ CELERY_TASK_ROUTES = {
     "main.tasks.demo_scheduled_task": {"queue": "background"},
 }
 
-# from celery.schedules import crontab
 CELERY_BEAT_SCHEDULE = {}
 
 ###

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -265,7 +265,7 @@ CELERY_TASK_ALWAYS_EAGER = False
 CELERY_TASK_EAGER_PROPAGATES = True  # propagate exceptions when CELERY_TASK_ALWAYS_EAGER=True
 
 CELERY_TASK_ROUTES = {
-    "main.tasks.sample_scheduled_task": {"queue": "background"},
+    "main.tasks.demo_scheduled_task": {"queue": "background"},
 }
 
 # from celery.schedules import crontab

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -40,3 +40,14 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 ADMINS = [("John", "john@example.com"), ("Mary", "mary@example.com")]
 
 LOGGING["loggers"]["main"] = {"level": "DEBUG", "handlers": ["console", "file"]}
+
+CELERY_TASK_ALWAYS_EAGER = True
+
+from celery.schedules import crontab
+
+CELERY_BEAT_SCHEDULE = {
+    "demo-scheduled-task": {
+        "task": "main.tasks.demo_scheduled_task",
+        "schedule": crontab(minute="*"),
+    },
+}

--- a/web/conftest.py
+++ b/web/conftest.py
@@ -91,6 +91,16 @@ def register_factory(cls):
     return cls
 
 
+@pytest.fixture(scope="session")
+def celery_config():
+    # NOTE: when the `celery_worker` fixture is included, peculiar
+    # (and seemingly spurious) DB-related warnings are sometimes
+    # printed when tests fail... Very confusing when debugging!
+    # Be sure to read all the way up, for the original assertion
+    # failure, before wasting time investigating fixtures' DB access.
+    return {"broker_url": settings.CELERY_BROKER_URL}
+
+
 ### model factories ###
 
 

--- a/web/main/tasks.py
+++ b/web/main/tasks.py
@@ -1,55 +1,9 @@
 from celery import shared_task
-from celery.signals import task_failure
-import socket
 from time import sleep
-
-from django.core.mail import mail_admins
 
 import logging
 
 logger = logging.getLogger("celery.django")
-
-
-### ERROR REPORTING ###
-
-
-@task_failure.connect()
-def celery_task_failure_email(**kwargs):
-    """
-    Celery 4.0+ has no method to send emails on failed tasks.
-    This event handler provides equivalent functionality to Celery < 4.0,
-    and reports truly failed tasks, like those terminated after CELERY_TASK_TIME_LIMIT
-    and those that throw uncaught exceptions.
-    From https://github.com/celery/celery/issues/3389
-
-    Given:
-    >>> mocker, _ = [getfixture(i) for i in ['mocker', 'celery_worker']]
-    >>> sleep = mocker.patch('main.tasks.sleep')
-    >>> mailer = mocker.patch('main.tasks.mail_admins')
-
-    Patch the task so that it errors, and then run in:
-    >>> sleep.side_effect = lambda seconds: 1/0
-    >>> _ = demo_scheduled_task.apply_async(kwargs={'pause_for_seconds': 1})
-
-    Wait for the task to execute and return (without using the patched copy of sleep)
-    >>> import time; time.sleep(1)
-
-    Observe that an error email was sent, as expected.
-    >>> mailer.assert_called_once()
-    """
-    subject = "[{queue_name}@{host}] Error: Task {sender.name} ({task_id}): {exception}".format(
-        queue_name="celery", host=socket.gethostname(), **kwargs
-    )
-
-    message = """Task {sender.name} with id {task_id} raised exception:
-{exception!r}
-Task was called with args: {args} kwargs: {kwargs}.
-The contents of the full traceback was:
-{einfo}
-    """.format(
-        **kwargs
-    )
-    mail_admins(subject, message)
 
 
 ### TASKS ###
@@ -60,6 +14,11 @@ def demo_scheduled_task(pause_for_seconds=0):
     """
     A demo task, scheduled to run once a minute dev. To see it in action,
     set CELERY_TASK_ALWAYS_EAGER = False in setting.py before running `fab run`.
+
+    >>> caplog = getfixture('caplog')
+    >>> with caplog.at_level(logging.DEBUG):
+    ...     _ = demo_scheduled_task.apply_async(kwargs={'pause_for_seconds': 1})
+    >>> assert 'Celerybeat is working!' in caplog.text
     """
     if pause_for_seconds:
         sleep(pause_for_seconds)

--- a/web/main/tasks.py
+++ b/web/main/tasks.py
@@ -1,0 +1,66 @@
+from celery import shared_task
+from celery.signals import task_failure
+import socket
+from time import sleep
+
+from django.core.mail import mail_admins
+
+import logging
+
+logger = logging.getLogger("celery.django")
+
+
+### ERROR REPORTING ###
+
+
+@task_failure.connect()
+def celery_task_failure_email(**kwargs):
+    """
+    Celery 4.0+ has no method to send emails on failed tasks.
+    This event handler provides equivalent functionality to Celery < 4.0,
+    and reports truly failed tasks, like those terminated after CELERY_TASK_TIME_LIMIT
+    and those that throw uncaught exceptions.
+    From https://github.com/celery/celery/issues/3389
+
+    Given:
+    >>> mocker, _ = [getfixture(i) for i in ['mocker', 'celery_worker']]
+    >>> sleep = mocker.patch('main.tasks.sleep')
+    >>> mailer = mocker.patch('main.tasks.mail_admins')
+
+    Patch the task so that it errors, and then run in:
+    >>> sleep.side_effect = lambda seconds: 1/0
+    >>> _ = demo_scheduled_task.apply_async(kwargs={'pause_for_seconds': 1})
+
+    Wait for the task to execute and return (without using the patched copy of sleep)
+    >>> import time; time.sleep(1)
+
+    Observe that an error email was sent, as expected.
+    >>> mailer.assert_called_once()
+    """
+    subject = "[{queue_name}@{host}] Error: Task {sender.name} ({task_id}): {exception}".format(
+        queue_name="celery", host=socket.gethostname(), **kwargs
+    )
+
+    message = """Task {sender.name} with id {task_id} raised exception:
+{exception!r}
+Task was called with args: {args} kwargs: {kwargs}.
+The contents of the full traceback was:
+{einfo}
+    """.format(
+        **kwargs
+    )
+    mail_admins(subject, message)
+
+
+### TASKS ###
+
+
+@shared_task
+def demo_scheduled_task(pause_for_seconds=0):
+    """
+    A demo task, scheduled to run once a minute dev. To see it in action,
+    set CELERY_TASK_ALWAYS_EAGER = False in setting.py before running `fab run`.
+    """
+    if pause_for_seconds:
+        sleep(pause_for_seconds)
+    return "Celerybeat is working!"

--- a/web/requirements.in
+++ b/web/requirements.in
@@ -22,6 +22,8 @@ bleach              # html sanitization
 diff-match-patch    # update annotations when underlying text changes
 django-json-widget  # fancy editor for Case JSON fields in the Django admin
 django-simple-history # history preservation for contents
+celery[redis, pytest] # task runner
+watchdog            # restart celery in dev (via 'watchmedo' command)
 
 # Testing
 pytest>=7.1.3

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,10 +4,18 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes
 #
+amqp==5.1.1 \
+    --hash=sha256:2c1b13fecc0893e946c65cbd5f36427861cffa4ea2201d8f6fca22e2a373b5e2 \
+    --hash=sha256:6f0956d2c23d8fa6e7691934d8c3930eadb44972cbbd1a7ae3a520f735d43359
+    # via kombu
 asgiref==3.5.2 \
     --hash=sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4 \
     --hash=sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
     # via django
+async-timeout==4.0.2 \
+    --hash=sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15 \
+    --hash=sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c
+    # via redis
 attrs==21.2.0 \
     --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
     --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
@@ -25,6 +33,10 @@ bcrypt==3.2.2 \
     --hash=sha256:a2c46100e315c3a5b90fdc53e429c006c5f962529bc27e1dfd656292c20ccc40 \
     --hash=sha256:cd43303d6b8a165c29ec6756afd169faba9396a9472cdff753fe9f19b96ce2fa
     # via paramiko
+billiard==3.6.4.0 \
+    --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
+    --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
+    # via celery
 black==22.6.0 \
     --hash=sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90 \
     --hash=sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c \
@@ -64,6 +76,12 @@ botocore==1.20.98 \
     # via
     #   boto3
     #   s3transfer
+celery[pytest,redis]==5.2.7 \
+    --hash=sha256:138420c020cd58d6707e6257b6beda91fd39af7afde5d36c6334d175302c0e14 \
+    --hash=sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d
+    # via
+    #   -r requirements.in
+    #   pytest-celery
 certifi==2022.12.7 \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
@@ -128,12 +146,28 @@ chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
     # via requests
-click==8.0.1 \
-    --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a \
-    --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6
+click==8.1.3 \
+    --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
+    --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via
     #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   pip-tools
+click-didyoumean==0.3.0 \
+    --hash=sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667 \
+    --hash=sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035
+    # via celery
+click-plugins==1.1.1 \
+    --hash=sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b \
+    --hash=sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8
+    # via celery
+click-repl==0.2.0 \
+    --hash=sha256:94b3fbbc9406a236f176e0506524b2937e4b23b6f4c0c0b2a0a83f8a64e9194b \
+    --hash=sha256:cd12f68d745bf6151210790540b4cb064c7b13e571bc64b6957d98d120dacfd8
+    # via celery
 coverage==5.5 \
     --hash=sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c \
     --hash=sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6 \
@@ -359,6 +393,10 @@ jmespath==0.10.0 \
     # via
     #   boto3
     #   botocore
+kombu==5.2.4 \
+    --hash=sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610 \
+    --hash=sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4
+    # via celery
 lxml==4.9.1 \
     --hash=sha256:04da965dfebb5dac2619cb90fcf93efdb35b3c6994fea58a157a834f2f94b318 \
     --hash=sha256:0538747a9d7827ce3e16a8fdd201a99e661c7dee3c96c885d8ecba3c35d1032c \
@@ -572,6 +610,10 @@ pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
     # via pytest
+prompt-toolkit==3.0.36 \
+    --hash=sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63 \
+    --hash=sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305
+    # via click-repl
 psycopg2==2.9.1 \
     --hash=sha256:079d97fc22de90da1d370c90583659a9f9a6ee4007355f5825e5f1c70dffc1fa \
     --hash=sha256:2087013c159a73e09713294a44d0c8008204d06326006b7f652bef5ace66eebb \
@@ -653,6 +695,10 @@ pytest-base-url==2.0.0 \
     --hash=sha256:e1e88a4fd221941572ccdcf3bf6c051392d2f8b6cef3e0bc7da95abec4b5346e \
     --hash=sha256:ed36fd632c32af9f1c08f2c2835dcf42ca8fcd097d6ed44a09f253d365ad8297
     # via pytest-playwright
+pytest-celery==0.0.0 \
+    --hash=sha256:63dec132df3a839226ecb003ffdbb0c2cb88dd328550957e979c942766578060 \
+    --hash=sha256:cfd060fc32676afa1e4f51b2938f903f7f75d952186b8c6cf631628c4088f406
+    # via celery
 pytest-cov==2.12.1 \
     --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a \
     --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7
@@ -688,10 +734,16 @@ python-slugify==6.1.2 \
     --hash=sha256:272d106cb31ab99b3496ba085e3fea0e9e76dcde967b5e9992500d1f785ce4e1 \
     --hash=sha256:7b2c274c308b62f4269a9ba701aa69a797e9bca41aeee5b3a9e79e36b6656927
     # via pytest-playwright
-pytz==2021.1 \
-    --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da \
-    --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798
-    # via django
+pytz==2022.7.1 \
+    --hash=sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0 \
+    --hash=sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a
+    # via
+    #   celery
+    #   django
+redis==4.4.2 \
+    --hash=sha256:a010f6cb7378065040a02839c3f75c7e0fb37a87116fb4a95be82a95552776c7 \
+    --hash=sha256:e6206448e2f8a432871d07d432c13ed6c2abcf6b74edb436c99752b1371be387
+    # via celery
 requests==2.25.1 \
     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
@@ -716,6 +768,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   bleach
+    #   click-repl
     #   fabric3
     #   paramiko
     #   python-dateutil
@@ -789,6 +842,47 @@ urllib3==1.26.5 \
     #   botocore
     #   requests
     #   sentry-sdk
+vine==5.0.0 \
+    --hash=sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30 \
+    --hash=sha256:7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e
+    # via
+    #   amqp
+    #   celery
+    #   kombu
+watchdog==2.2.1 \
+    --hash=sha256:102a60093090fc3ff76c983367b19849b7cc24ec414a43c0333680106e62aae1 \
+    --hash=sha256:17f1708f7410af92ddf591e94ae71a27a13974559e72f7e9fde3ec174b26ba2e \
+    --hash=sha256:195ab1d9d611a4c1e5311cbf42273bc541e18ea8c32712f2fb703cfc6ff006f9 \
+    --hash=sha256:4cb5ecc332112017fbdb19ede78d92e29a8165c46b68a0b8ccbd0a154f196d5e \
+    --hash=sha256:5100eae58133355d3ca6c1083a33b81355c4f452afa474c2633bd2fbbba398b3 \
+    --hash=sha256:61fdb8e9c57baf625e27e1420e7ca17f7d2023929cd0065eb79c83da1dfbeacd \
+    --hash=sha256:6ccd8d84b9490a82b51b230740468116b8205822ea5fdc700a553d92661253a3 \
+    --hash=sha256:6e01d699cd260d59b84da6bda019dce0a3353e3fcc774408ae767fe88ee096b7 \
+    --hash=sha256:748ca797ff59962e83cc8e4b233f87113f3cf247c23e6be58b8a2885c7337aa3 \
+    --hash=sha256:83a7cead445008e880dbde833cb9e5cc7b9a0958edb697a96b936621975f15b9 \
+    --hash=sha256:8586d98c494690482c963ffb24c49bf9c8c2fe0589cec4dc2f753b78d1ec301d \
+    --hash=sha256:8b5cde14e5c72b2df5d074774bdff69e9b55da77e102a91f36ef26ca35f9819c \
+    --hash=sha256:8c28c23972ec9c524967895ccb1954bc6f6d4a557d36e681a36e84368660c4ce \
+    --hash=sha256:967636031fa4c4955f0f3f22da3c5c418aa65d50908d31b73b3b3ffd66d60640 \
+    --hash=sha256:96cbeb494e6cbe3ae6aacc430e678ce4b4dd3ae5125035f72b6eb4e5e9eb4f4e \
+    --hash=sha256:978a1aed55de0b807913b7482d09943b23a2d634040b112bdf31811a422f6344 \
+    --hash=sha256:a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260 \
+    --hash=sha256:a480d122740debf0afac4ddd583c6c0bb519c24f817b42ed6f850e2f6f9d64a8 \
+    --hash=sha256:adaf2ece15f3afa33a6b45f76b333a7da9256e1360003032524d61bdb4c422ae \
+    --hash=sha256:bc43c1b24d2f86b6e1cc15f68635a959388219426109233e606517ff7d0a5a73 \
+    --hash=sha256:c27d8c1535fd4474e40a4b5e01f4ba6720bac58e6751c667895cbc5c8a7af33c \
+    --hash=sha256:cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f \
+    --hash=sha256:cece1aa596027ff56369f0b50a9de209920e1df9ac6d02c7f9e5d8162eb4f02b \
+    --hash=sha256:d0f29fd9f3f149a5277929de33b4f121a04cf84bb494634707cfa8ea8ae106a8 \
+    --hash=sha256:d6b87477752bd86ac5392ecb9eeed92b416898c30bd40c7e2dd03c3146105646 \
+    --hash=sha256:e038be858425c4f621900b8ff1a3a1330d9edcfeaa1c0468aeb7e330fb87693e \
+    --hash=sha256:e618a4863726bc7a3c64f95c218437f3349fb9d909eb9ea3a1ed3b567417c661 \
+    --hash=sha256:f8ac23ff2c2df4471a61af6490f847633024e5aa120567e08d07af5718c9d092
+    # via -r requirements.in
+wcwidth==0.2.6 \
+    --hash=sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e \
+    --hash=sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0
+    # via prompt-toolkit
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923


### PR DESCRIPTION
This PR adds Celery for [the running of asynchronous tasks](https://github.com/orgs/harvard-lil/projects/5/views/1).

See the README for more info on how to interact with it locally. This setup is identical to the one we used with the [prototyped perma-capture service](https://github.com/harvard-lil/perma-capture/tree/new-arch-with-vue) and is very similar to Perma.

I included one "demo" task and scheduled it to run once a minute in dev, a) to demo config, b) to make it easy to see if your dev setup is working, and c) to have a task available for the error email test.... but.... it might not want to stay in the repo long-term, once we have at least one real task.

~I set `CELERY_TASK_TIME_LIMIT` to a ridiculously short 2 seconds so that we will be forced to consider what an appropriate time limit is, once we have real tasks.~

I think this gets us in good shape to start [making PDFs asychronously](https://github.com/harvard-lil/h2o/issues/1801).

Closes https://github.com/harvard-lil/h2o/issues/1798.