### PR TITLE
Drop animation in toc expansion in reading mode

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -15,39 +15,10 @@ class TocControl extends HTMLElement {
     this.tocList = this.querySelector('ol');
     if (this.tocList) {
       this.querySelector('.toc-opener').addEventListener('click', () => {
-        window.requestAnimationFrame(() => this.toggleAttribute('open'));
+        this.toggleAttribute('open');
       })
-      this.tocList.addEventListener('transitionstart', () => {
-        if (this.tocList.classList.contains('collapsing')) {
-          this.tocList.classList.add('invisible')
-        }
-      });
-      this.tocList.addEventListener('transitionend', () => {
-        if (!this.tocList.classList.contains('collapsing')) {
-          this.tocList.classList.remove('invisible')
-        }
-      });
     }
 
-  }
-  attributeChangedCallback(name, previous, value) {
-    switch (name) {
-      case "open": {
-        if (this.tocList) {
-          if (value === null) {
-            this.tocList.classList.add('collapsing');
-            this.tocList.style.height = 0;
-            this.querySelector('svg').classList.remove('open');
-
-          } else {
-            this.tocList.classList.remove('collapsing');
-            this.tocList.style.height = `${this.tocList.getAttribute('data-natural-height')}px`;
-            this.querySelector('svg').classList.add('open');
-
-          }
-        }
-      }
-    }
   }
 }
 
@@ -297,19 +268,5 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
   })
 
   main.classList.add("preview-ready");
-
-  const toc = document.querySelector('toc-control')
-  const tocList = toc.querySelector('ol')
-  const height = parseInt(tocList.getBoundingClientRect().height, 10);
-  tocList.setAttribute('data-natural-height', height);
-
-  if (toc.hasAttribute('start-open')) {
-    toc.querySelector('.toc-opener').click();
-    tocList.style.height = `${height}px`;
-  } else {
-    tocList.style.height = `0px`;
-    tocList.classList.add('invisible');
-    toc.removeAttribute('open');
-  }
 
 }

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -1,11 +1,11 @@
 
 <nav class="toc">
-    <toc-control {{ toc_is_open|yesno:'start-open,,'}}>
+    <toc-control {{ toc_is_open|yesno:'open,,'}}>
         {% if use_pagedjs %}
             <h2>Table of contents</h2>
         {% else %}
             <button class="toc-opener" role="button">
-                <svg class="screen-only collapse-triangle {{ toc_is_open|yesno:'open,,'}}" height="25" width="25">
+                <svg class="screen-only collapse-triangle" height="25" width="25">
                     <polygon points="6,6 20,16 6,24" />
                 </svg>
                 <h2>Table of contents</h2>

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -74,20 +74,17 @@ nav.toc .collapse-triangle polygon {
 nav.toc .collapse-triangle polygon:hover {
     stroke-width: 2;
 }
-nav.toc .collapse-triangle.open {
+nav.toc toc-control[open] .collapse-triangle {
     transform: rotate(90deg);
 }
-nav.toc ol {
-    transition: height 0.25s;
-    height: auto;
-    opacity: 1;
-}
+
 nav.toc toc-control:not([open]) h2::after {
     content: " (click to expand)";
     font-size: 12px;
     display: block;
     text-align: left;
 }
-nav.toc ol.invisible li {
+nav.toc toc-control:not([open]) ol.toc-items {
     display: none;
 }
+


### PR DESCRIPTION
Fixes #1880 by removing the feature

This gives up on an accordion animation for the TOC when opening or closing it in reading mode. Dynamically expanding a variable-height div is very tricky, especially if the div needs to sometimes initially render as closed, as here when not visiting the first chapter. 

I tried a lot of different approaches but this is a well-trod tricky problem that even modern CSS can't solve well (TL;DR you would like to be able to animate `auto` properties; [current still-active spec thread](https://github.com/w3c/csswg-drafts/issues/626).)

Since casebook chapters can be _very_ long, I think it's especially problematic here to do any of the height/JS-based workarounds, because each transition involves a repaint. On mobile devices I think it would have been unworkably slow even without the buggy behavior that generated the related ticket.

Now when clicking the open/close toggle, the TOC is simply shown or hidden in a single tick.


