### PR TITLE
Correct overlapping annotations and improve usability

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -262,43 +262,14 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
 
 } else {
 
-  const left = document.createElement('div');
-  const right = document.createElement('div');
-  const center = document.createElement('article');
-
-  left.classList.add('left');
-  right.classList.add('right');
-  center.classList.add('center');
-
-  center.append(tmpl.content.cloneNode(true));
-
-
-
-  main.append(left);
-  main.append(center);
-  main.append(right);
+  const article = document.createElement('article');
+  article.append(tmpl.content.cloneNode(true));
+  main.append(article);
 
   document.querySelector('#page-selector').addEventListener('change', (e) => {
     location.href = e.target.value;
   })
 
   main.classList.add("preview-ready");
-  requestAnimationFrame(() => {
-    let count = 0;
-    let lastTop = undefined;
-    for (const aside of main.querySelectorAll('aside.authors-note')) {
-      if (lastTop != aside.getBoundingClientRect().top) {
-        count = 0;
-      }
-      else {
-        count++;
-      }
-      lastTop = aside.getBoundingClientRect().top
-      aside.style.marginTop = `${count * 10}px`;
-      aside.style.marginRight = `-${count * 5}px`;
 
-
-
-    }
-  })
 }

--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -198,6 +198,7 @@ annotationRanges.forEach((rg) => {
       ranges.forEach((range) => {
         const wrap = document.createElement("mark");
         wrap.id = `mark-${id}`;
+        wrap.setAttribute("tabindex", "0");
         wrap.classList.add("note-mark");
         range.surroundContents(wrap);
         lastRange = wrap;
@@ -294,7 +295,7 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
       }
       lastTop = aside.getBoundingClientRect().top
       aside.style.marginTop = `${count * 10}px`;
-      aside.style.marginRight = `-${count * 4}px`;
+      aside.style.marginRight = `-${count * 5}px`;
 
 
 

--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -154,6 +154,7 @@ annotationRanges.forEach((rg) => {
     ranges,
     content
   } = rg;
+
   switch (type) {
     case "highlight": {
       ranges.forEach((range) => {
@@ -196,7 +197,7 @@ annotationRanges.forEach((rg) => {
       // Wrap the specific text the author highlighted to allow for downstream styling
       ranges.forEach((range) => {
         const wrap = document.createElement("mark");
-        wrap.id = `note-${id}`;
+        wrap.id = `mark-${id}`;
         wrap.classList.add("note-mark");
         range.surroundContents(wrap);
         lastRange = wrap;
@@ -204,12 +205,15 @@ annotationRanges.forEach((rg) => {
 
       // Add the note after the last range
       const note = document.createElement("aside");
+      note.id = `note-${id}`;
       note.classList.add("authors-note");
 
       // Ask PagedJS to render it as a footnote on the current page
       note.classList.add("footnote-generated");
       note.innerText = content
+
       lastRange.insertAdjacentElement("afterend", note);
+
       break;
     }
     case "replace":
@@ -267,6 +271,8 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
 
   center.append(tmpl.content.cloneNode(true));
 
+
+
   main.append(left);
   main.append(center);
   main.append(right);
@@ -276,5 +282,22 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
   })
 
   main.classList.add("preview-ready");
+  requestAnimationFrame(() => {
+    let count = 0;
+    let lastTop = undefined;
+    for (const aside of main.querySelectorAll('aside.authors-note')) {
+      if (lastTop != aside.getBoundingClientRect().top) {
+        count = 0;
+      }
+      else {
+        count++;
+      }
+      lastTop = aside.getBoundingClientRect().top
+      aside.style.marginTop = `${count * 10}px`;
+      aside.style.marginRight = `-${count * 4}px`;
 
+
+
+    }
+  })
 }

--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -99,6 +99,7 @@ function annotationsToRanges(annotations, content) {
     }
 
     return {
+      id: el.getAttribute("data-annotation-id"),
       type: el.getAttribute("data-annotation-type"),
       datetime: el.getAttribute("data-datetime"),
       content: el.textContent,
@@ -147,6 +148,7 @@ const annotationRanges = annotationsToRanges(
 // When all Ranges are ready, start updating the DOM
 annotationRanges.forEach((rg) => {
   const {
+    id,
     type,
     datetime,
     ranges,
@@ -156,6 +158,7 @@ annotationRanges.forEach((rg) => {
     case "highlight": {
       ranges.forEach((range) => {
         const wrap = document.createElement("mark");
+        wrap.id = `highlight-${id}`;
         wrap.classList.add("highlighted");
         range.surroundContents(wrap);
       });
@@ -164,10 +167,12 @@ annotationRanges.forEach((rg) => {
     case "elide": {
       ranges.forEach((range) => {
         const elision = document.createElement("del");
+        elision.id = `elision-${id}`;
         elision.classList.add("elided");
         elision.setAttribute("datetime", datetime);
 
         const marker = document.createElement("ins");
+        marker.id = `elision-marker-${id}`;
         marker.setAttribute("datetime", datetime);
         marker.classList.add("elision-marker");
         marker.innerText = " … ";
@@ -191,6 +196,7 @@ annotationRanges.forEach((rg) => {
       // Wrap the specific text the author highlighted to allow for downstream styling
       ranges.forEach((range) => {
         const wrap = document.createElement("mark");
+        wrap.id = `note-${id}`;
         wrap.classList.add("note-mark");
         range.surroundContents(wrap);
         lastRange = wrap;
@@ -211,10 +217,12 @@ annotationRanges.forEach((rg) => {
       // Transparently replace the content inside the node
       ranges.forEach((range) => {
         const deletion = document.createElement("del");
+        deletion.id = `correction-deletion-${id}`;
         deletion.classList.add(type);
         deletion.setAttribute("datetime", datetime);
 
         const replacement = document.createElement("ins");
+        replacement.id = `correction-insertion-${id}`;
         replacement.setAttribute("datetime", datetime);
         replacement.classList.add(type);
         replacement.innerText = content;

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -34,6 +34,42 @@
     is licensed under a Creative Commons license. <a href="{% url 'terms-of-service' %}">Learn more</a>.
     </p>
   </header>
+
+
+  <template id="casebook-content"
+    data-stylesheet="{% static 'as_printable_html/book.css' %}"
+    data-use-pagedjs="{{ use_pagedjs|yesno:'true,false' }}">
+    <div class="casebook-metadata" data-paginator-page="{{ page.number }}">
+      <h1 class="casebook title">{{ casebook.title }}</h1>
+      <h2 class="casebook subtitle">{{ casebook.subtitle|default_if_none:""}}</h2>
+      <span class="truncated-title hidden">{{ casebook.title }}</span>
+      <div class="author-list">
+        <ul>
+        {% for user in casebook.primary_authors %}
+            <li class="user {% if user.verified_professor %} verified{% endif %}">
+                {{ user.display_name }}
+                {% if user.affiliation %}
+                  ({{ user.affiliation }})
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+      </div>
+      <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
+      <div id="toc">
+        {% include "export/as_printable_html/toc.html" with toc=toc toc_is_open=toc_is_open %}
+      </div>
+
+    </div>
+
+    {% for child in children %}
+      {% include "export/as_printable_html/node.html" with index=forloop.counter node=child %}
+    {% endfor %}
+
+  </template>
+
+  <main id="as-printable-html"></main>
+
   <footer class="screen-only">
     <nav>
       {% if whole_book or use_pagedjs %}
@@ -70,41 +106,6 @@
     {% endif %}
     </nav>
   </footer>
-
-  <template id="casebook-content"
-    data-stylesheet="{% static 'as_printable_html/book.css' %}"
-    data-use-pagedjs="{{ use_pagedjs|yesno:'true,false' }}">
-    <div class="casebook-metadata" data-paginator-page="{{ page.number }}">
-      <h1 class="casebook title">{{ casebook.title }}</h1>
-      <h2 class="casebook subtitle">{{ casebook.subtitle|default_if_none:""}}</h2>
-      <span class="truncated-title hidden">{{ casebook.title }}</span>
-      <div class="author-list">
-        <ul>
-        {% for user in casebook.primary_authors %}
-            <li class="user {% if user.verified_professor %} verified{% endif %}">
-                {{ user.display_name }}
-                {% if user.affiliation %}
-                  ({{ user.affiliation }})
-                {% endif %}
-            </li>
-            {% endfor %}
-        </ul>
-      </div>
-      <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
-      <div id="toc">
-        {% include "export/as_printable_html/toc.html" with toc=toc toc_is_open=toc_is_open %}
-      </div>
-
-    </div>
-
-    {% for child in children %}
-      {% include "export/as_printable_html/node.html" with index=forloop.counter node=child %}
-    {% endfor %}
-
-  </template>
-
-  <main id="as-printable-html"></main>
-
   {% include "includes/analytics.html" %}
 </body>
 </html>

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -54,6 +54,7 @@
 
           {% for annotation in node.annotations.valid %}
           <li data-annotation-type="{{ annotation.kind }}"
+              data-annotation-id="{{ annotation.id }}"
               data-node-id="{{ annotation.resource_id }}"
               data-start-offset="{{ annotation.global_start_offset }}"
               data-end-offset="{{ annotation.global_end_offset }}"

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -46,20 +46,20 @@
     text-underline-offset: 5px;
     background: none;
   }
-  mark.note-mark:hover {
+  mark.note-mark:is(:hover, :focus) {
     background: var(--highlight-background-color);
   }
-  mark.note-mark:hover + aside {
-    background: var(--highlight-background-color);
-    z-index: 99;
-    border: 1px solid black;
-  }
-  aside.authors-note:hover {
+  mark.note-mark:is(:hover, :focus) + aside {
     background: var(--highlight-background-color);
     z-index: 99;
     border: 1px solid black;
   }
-  mark.note-mark:has(+ aside:hover) {
+  aside.authors-note:is(:hover, :focus) {
+    background: var(--highlight-background-color);
+    z-index: 99;
+    border: 1px solid black;
+  }
+  mark.note-mark:has(+ aside:is(:hover, :focus)) {
     background: var(--highlight-background-color);
   }
   a.footnote-generated {

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -2,9 +2,7 @@
 @media screen, pagedjs-ignore {
   main {
     margin: 5vh 0;
-    display: grid;
-    grid-template-areas: "left center right";
-    grid-template-columns: 15vw 65vw 15vw;
+    box-sizing: border-box;
   }
   /* Lay out frontmatter based on whether this is the first chapter */
   .casebook-metadata:not([data-paginator-page="1"]) .headnote {
@@ -18,27 +16,22 @@
   main > article {
     background-color: white;
     padding: 5vh 5vw 10vh 5vw;
-    grid-area: center;
+    margin: 0 15vw 10vw 15vw;
   }
-  main > .left {
-    height: auto;
-    grid-area: left;
-  }
-  main > .right {
-    height: auto;
-    grid-area: right;
-  }
+
   aside.authors-note {
-    position: absolute;
-    right: 2vw;
+    float: right;
+    clear: both;
+    border-radius: 5px;
+    margin-right: -20vw;
+    margin-bottom: 10px;
     background: white;
     border: 1px solid lightgray;
     padding: 1rem;
     width: 15vw;
+    transition: transform 0.1s ease-in;
   }
-  .right aside.authors-note {
-    position: inherit;
-  }
+
   mark.note-mark {
     text-decoration: underline;
     text-decoration-style: dotted;
@@ -53,11 +46,13 @@
     background: var(--highlight-background-color);
     z-index: 99;
     border: 1px solid black;
+    transform: translateX(-10px);
   }
   aside.authors-note:is(:hover, :focus) {
     background: var(--highlight-background-color);
     z-index: 99;
     border: 1px solid black;
+    transform: translateX(-10px);
   }
   mark.note-mark:has(+ aside:is(:hover, :focus)) {
     background: var(--highlight-background-color);

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -1,87 +1,104 @@
-
 /* Styling that applies only to the screen-based reader view */
 @media screen, pagedjs-ignore {
+  main {
+    margin: 5vh 0;
+    display: grid;
+    grid-template-areas: "left center right";
+    grid-template-columns: 15vw 65vw 15vw;
+  }
+  /* Lay out frontmatter based on whether this is the first chapter */
+  .casebook-metadata:not([data-paginator-page="1"]) .headnote {
+    display: none;
+  }
 
+  article p,
+  article div {
+    margin: 1rem 0;
+  }
+  main > article {
+    background-color: white;
+    padding: 5vh 5vw 10vh 5vw;
+    grid-area: center;
+  }
+  main > .left {
+    height: auto;
+    grid-area: left;
+  }
+  main > .right {
+    height: auto;
+    grid-area: right;
+  }
+  aside.authors-note {
+    position: absolute;
+    right: 2vw;
+    background: white;
+    border: 1px solid lightgray;
+    padding: 1rem;
+    width: 15vw;
+  }
+  .right aside.authors-note {
+    position: inherit;
+  }
+  mark.note-mark {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-color: lightgrey;
+    text-underline-offset: 5px;
+    background: none;
+  }
+  mark.note-mark:hover {
+    background: var(--highlight-background-color);
+  }
+  mark.note-mark:hover + aside {
+    background: var(--highlight-background-color);
+    z-index: 99;
+    border: 1px solid black;
+  }
+  aside.authors-note:hover {
+    background: var(--highlight-background-color);
+    z-index: 99;
+    border: 1px solid black;
+  }
+  mark.note-mark:has(+ aside:hover) {
+    background: var(--highlight-background-color);
+  }
+  a.footnote-generated {
+    display: none;
+  }
+  .node-heading {
+    display: block;
+    font-size: 10px;
+    width: 13vw;
+    margin-left: -20vw;
+    margin-top: -2rem;
+    text-align: right;
+  }
+  .node-heading.depth-1 {
+    top: 5vh;
+  }
+  .node-heading.depth-2 {
+    top: 10vh;
+  }
+  .node-heading.depth-3 {
+    top: 15vh;
+  }
+  .node-heading.depth-4 {
+    top: 20vh;
+  }
+  @media (max-width: 552px) {
     main {
-      margin: 5vh 0;
-      display: grid;
-      grid-template-areas: "left center right";
-      grid-template-columns: 15vw 65vw 15vw;
+      margin: 0 auto;
+      grid-template-areas: center;
+      grid-template-columns: 1fr;
     }
-    /* Lay out frontmatter based on whether this is the first chapter */
-    .casebook-metadata:not([data-paginator-page="1"]) .headnote {
+    header.screen-only {
+      margin-bottom: 2rem;
+    }
+    header.screen-only p {
+      margin: 0 0 0 1rem;
+    }
+    footer nav button.print-preview {
       display: none;
-    }
-
-    article p, article div {
-      margin: 1rem 0;
-    }
-    main > article {
-      background-color: white;
-      padding: 5vh 5vw 10vh 5vw;
-      grid-area: center;
-    }
-    main > .left {
-      height: auto;
-      grid-area: left;
-    }
-    main > .right {
-      height: auto;
-      grid-area: right;
-    }
-    aside.authors-note {
-      position: absolute;
-      right: 2vw;
-      background: white;
-      border: 1px solid lightgray;
-      padding: 1rem;
-      width: 15vw;
-    }
-    mark.note-mark {
-      text-decoration: underline;
-      text-decoration-style: dotted;
-      text-decoration-color: lightgrey;
-      text-underline-offset: 5px;
-      background: none;
-    }
-    a.footnote-generated {
-      display: none;
-    }
-    .node-heading {
-      display: block;
-      font-size: 10px;
-      width: 13vw;
-      margin-left: -20vw;
-      margin-top: -2rem;
-      text-align: right;
-    }
-    .node-heading.depth-1 {
-      top: 5vh;
-    }
-    .node-heading.depth-2 {
-      top: 10vh;
-    }
-    .node-heading.depth-3 {
-      top: 15vh;
-    }
-    .node-heading.depth-4 {
-      top: 20vh;
-    }
-    @media (max-width: 552px) {
-
-      main {
-        margin: 0 auto;
-        grid-template-areas: center;
-        grid-template-columns: 1fr;
-      }
-      header.screen-only {
-        margin-bottom: 2rem;
-      }
-      header.screen-only p {
-        margin: 0 0 0 1rem;
-      }
-      footer nav button.print-preview {
-        display: none;
-      }
     }
   }
+}


### PR DESCRIPTION
Fixes #1872 

After talking with @cath9 we settled on a Google Docs-like presentation for annotations in the margin. Previously these could easily overlap because they were absolutely positioned and would land in the same spot if multiple notes appeared in the same source line.

After a number of fancy attempts to reflow the positions in code, I had the obvious-in-retrospect thought to see what the regular site does, and they're simple floats that lay out themselves. Bright idea, past LIL!

Added highlights that appear on hover or keyboard nav that visually link the note to the text. They're bidirectional, so hovering over either the note or the annotated text works. (This is entirely CSS and relies on the `has:` operator for one direction; in Firefox only hovering over the note will produce the effect until that support is added this year.)

https://user-images.githubusercontent.com/19571/214433977-1b020395-b3ab-4ade-8601-fa953a5c67d1.mov

Couple other changes:

* Some CSS was moved around to be grouped more predictably.
* To make the floats work, I dropped laying this out in a grid. The grid columns weren't being used much anyway.
* Added IDs to all the annotation types to make debugging in the browser console easier.
* The footer used to appear before the content in DOM order, which affected keyboard nav. Now it's laid out logically.

Note: the annotations here are keyboard accessible but not accessible to screenreaders. I haven't researched this yet but I'd like the annotation to be made available to the reader when the annotated text is selected.

