### PR TITLE
Only show full URL in print preview; fixes #1873

### DIFF
--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -21,7 +21,8 @@
         <section class="headnote">{{ headnote }}</section>
       {% endif %}
       <div class="link-container">
-        <a href="{{ node.resource.url }}" target="_blank" data-type="resource link">{{ node.resource.url }}</a>
+        <a href="{{ node.resource.url }}" target="_blank" data-type="resource link">
+          {% if use_pagedjs %}{{ node.resource.url }}{% else %}{{ node.title }}{% endif %}</a>
         <span class="link-icon"></span>
       </div>
 


### PR DESCRIPTION
Simplest to do this in the Django template rather than with JS.

Reading mode: 

<img width="424" alt="image" src="https://user-images.githubusercontent.com/19571/214604574-b0fdf857-3a88-4abc-a7bd-f421cdbfb5ef.png">

(uses the title of the link)

Print preview:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/19571/214604704-fd0df237-dcb5-4b1f-9c74-d9a792297e27.png">

Outputs the link so the reader can type it in.

In both cases this is an active hyperlink so e.g. in the print case, when reading it as a PDF it'll still go somewhere when clicked.
