### PR TITLE
Move metadata out of content block and improve TOC layout and navigation

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -254,9 +254,8 @@ if (tmpl.getAttribute("data-use-pagedjs") === "true") {
 
 } else {
 
-  const article = document.createElement('article');
-  article.append(tmpl.content.cloneNode(true));
-  main.append(article);
+
+  main.append(tmpl.content.cloneNode(true));
 
   document.querySelector('#page-selector').addEventListener('change', (e) => {
     location.href = e.target.value;

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -35,14 +35,16 @@
     </p>
   </header>
 
-
   <template id="casebook-content"
     data-stylesheet="{% static 'as_printable_html/book.css' %}"
     data-use-pagedjs="{{ use_pagedjs|yesno:'true,false' }}">
-    <div class="casebook-metadata" data-paginator-page="{{ page.number }}">
-      <h1 class="casebook title">{{ casebook.title }}</h1>
-      <h2 class="casebook subtitle">{{ casebook.subtitle|default_if_none:""}}</h2>
-      <span class="truncated-title hidden">{{ casebook.title }}</span>
+
+    <header class="casebook-metadata" data-paginator-page="{{ page.number }}">
+      <div>
+        <h1 class="casebook title">{{ casebook.title }}</h1>
+        {% if casebook.subtitle %}<h2 class="casebook subtitle">{{ casebook.subtitle}}</h2>{% endif %}
+        <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
+      </div>
       <div class="author-list">
         <ul>
         {% for user in casebook.primary_authors %}
@@ -55,16 +57,19 @@
             {% endfor %}
         </ul>
       </div>
-      <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
+
       <div id="toc">
         {% include "export/as_printable_html/toc.html" with toc=toc toc_is_open=toc_is_open %}
       </div>
+      <span class="truncated-title hidden">{{ casebook.title }}</span>
 
-    </div>
+    </header>
 
-    {% for child in children %}
-      {% include "export/as_printable_html/node.html" with index=forloop.counter node=child %}
-    {% endfor %}
+    <article>
+      {% for child in children %}
+        {% include "export/as_printable_html/node.html" with index=forloop.counter node=child %}
+      {% endfor %}
+    </article>
 
   </template>
 

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -1,10 +1,9 @@
 {% load call_method string_strip %}
 
-<span class="node-heading depth-{{ node.ordinals | length }}">{{ node.ordinal_string }} {{ node.title }}</span>
-
 <section
   data-datetime="{{ node.created_at|date:'c' }}"
   class="{{ node.type }} {{ node.resource_type|default:'' | lower }} depth-{{ node.ordinals | length }}">
+
 
   <div class="node-container">
 
@@ -29,8 +28,11 @@
     {% else %}
 
         <h1 class="{{ node.type }} title" id="{{ node.slug }}">
+          <span class="node-heading depth-{{ node.ordinals | length }}">{{ node.ordinal_string }} {{ node.title }}</span>
+
           <span class="{{ node.type }} ordinal" data-toc-idx="{{ index }}">{{ node.ordinal_string }}</span>
           <span>{{ node.title }}</span>
+
         </h1>
 
         {% if node.subtitle %}
@@ -49,6 +51,7 @@
           {% if node.resource_type.lower == 'legaldocument' %}
             {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
           {% endif %}
+
 
           {# Whitespace between the <section> element and the content must not be introduced to avoid throwing off the annotation offset values #}
           <section class="resource" data-node-id="{{ node.id }}" data-resource-id="{{ node.resource_id }}">{{ node.resource.content|safe }}</section>

--- a/web/main/templates/export/as_printable_html/toc.html
+++ b/web/main/templates/export/as_printable_html/toc.html
@@ -17,7 +17,7 @@
             <li>
                 {% with chapter_num=forloop.counter %}
                     <span class="ordinals">{{ top_level_node.ordinal_string }}</span>
-                    <h3><a href="{% url 'as_printable_html' casebook chapter_num %}">{{ top_level_node.title }}</a></h3>
+                    <h3><a href="{% url 'as_printable_html' casebook chapter_num %}#{{ top_level_node.slug }}">{{ top_level_node.title }}</a></h3>
                     <ol>
                         {% for child in top_level_node.children %}
                             <li>

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -1,22 +1,25 @@
 /* Styling that applies only to the screen-based reader view */
 @media screen, pagedjs-ignore {
   main {
-    margin: 5vh 0;
     box-sizing: border-box;
+    margin: 0 15vw 10vw 15vw;
   }
   /* Lay out frontmatter based on whether this is the first chapter */
   .casebook-metadata:not([data-paginator-page="1"]) .headnote {
     display: none;
   }
 
+  .casebook-metadata {
+    padding: 5vh 5vw;
+  }
   article p,
   article div {
     margin: 1rem 0;
   }
   main > article {
     background-color: white;
-    padding: 5vh 5vw 10vh 5vw;
-    margin: 0 15vw 10vw 15vw;
+    padding: 5vh 5vw;
+
   }
 
   aside.authors-note {
@@ -35,7 +38,7 @@
   mark.note-mark {
     text-decoration: underline;
     text-decoration-style: dotted;
-    text-decoration-color: lightgrey;
+    text-decoration-color: var(--background-color);;
     text-underline-offset: 5px;
     background: none;
   }
@@ -65,8 +68,9 @@
     font-size: 10px;
     width: 13vw;
     margin-left: -20vw;
-    margin-top: -2rem;
+    float: left;
     text-align: right;
+    line-height: initial;
   }
   .node-heading.depth-1 {
     top: 5vh;

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -12,7 +12,7 @@ nav.toc toc-control:not([open]) h2 {
 }
 
 nav.toc h3 {
-    display: inline;
+    /* display: inline; */
     margin: 0;
     font-size: 1em;
     font-weight: bold;
@@ -21,17 +21,26 @@ nav.toc h3 {
 nav.toc ol.toc-items {
     padding: 0;
 }
-
+nav.toc ol.toc-items li {
+    display: flex;
+    flex-wrap: wrap;
+}
+nav.toc ol.toc-items .ordinals {
+    flex-basis: 30px;
+}
+nav.toc ol.toc-items :is(h3, h4) {
+    flex: 1;
+    margin: 0;
+}
+nav.toc ol.toc-items ol {
+    flex-basis: 100%;
+}
 nav.toc ol.toc-items > li {
     padding: var(--toc-row-gap) 0 0 0;
 }
 nav.toc ol.toc-items > li li {
     padding: calc(var(--toc-row-gap) / 2) 0 0 0;
 }
-nav.toc ol.toc-items > li > .ordinals {
-    display: inline-block;
-}
-
 nav.toc .node-title {
     display: inline-block;
     margin: 0 0 0 calc(var(--toc-left-width) / 2);
@@ -40,12 +49,8 @@ nav.toc .node-title {
 nav.toc > ol > li > ol li {
     line-height: calc(var(--casebook-line-height) * 0.8);
 }
-nav.toc ol.toc-items span.ordinals {
-    display: inline-block;
-    width: var(--toc-left-width);
-}
 
-nav.toc > ol > li > ol > li:last-child {
+nav.toc  li:last-child {
     margin: 0 0 calc(var(--toc-row-gap) * 1.5) 0;
 }
 nav.toc .toc-opener {

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -3,12 +3,10 @@ nav.toc {
     --toc-row-gap: calc(var(--casebook-font-size) * 1);
     --toc-left-width: 8mm;
     break-before: right;
+    margin-top: 1rem;
 }
 nav.toc h2 {
-    margin: calc(var(--toc-row-gap) * 2) 0;
-}
-nav.toc toc-control:not([open]) h2 {
-    margin-bottom: 0;
+    margin: 0;
 }
 
 nav.toc h3 {
@@ -17,7 +15,6 @@ nav.toc h3 {
     font-size: 1em;
     font-weight: bold;
 }
-
 nav.toc ol.toc-items {
     padding: 0;
 }
@@ -58,7 +55,7 @@ nav.toc .toc-opener {
     background: none;
     border: 0;
     display: flex;
-    align-items: baseline;
+    align-items: stretch;
     padding: 0;
 }
 nav.toc .toc-opener h2 {


### PR DESCRIPTION
To better align with the platform design, this moves the book title and other metadata outside the white content area:

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/19571/214921199-dc21ec75-ec34-4133-95fc-37f1ecff74b2.png">

Also:

* Addresses #1877; left nav section anchors now appear at the same vertical alignment as in the content flow. Previously they appeared too high up.
* Reworks the TOC layout to be more resilient to varying length chapter titles by being less proscriptive.
* Previously TOC links to top-level chapters would not jump you down to the start of the content; now all TOC links go directly to the content start.
