### PR TITLE
Open external links in new tabs if they don't have a target defined

### DIFF
--- a/web/frontend/pages/as_printable_html.js
+++ b/web/frontend/pages/as_printable_html.js
@@ -235,6 +235,11 @@ annotationRanges.forEach((rg) => {
   }
 });
 
+// Any existing URLs that are external and don't open in a new tab should
+tmpl.content.querySelectorAll('a[href^="http"]:not([target])').forEach((el) => {
+  el.setAttribute('target', '_blank');
+});
+
 function renderAsPagedJS() {
   // For any existing URLs that aren't resources, turn them into footnotes
   tmpl.content.querySelectorAll('a[href^="http"]:not([data-type])').forEach((el) => {

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -23,11 +23,12 @@ nav.toc ol.toc-items li {
     flex-wrap: wrap;
 }
 nav.toc ol.toc-items .ordinals {
-    flex-basis: 30px;
+    flex-basis: 5ch;
 }
 nav.toc ol.toc-items :is(h3, h4) {
     flex: 1;
     margin: 0;
+    line-height: 180%;
 }
 nav.toc ol.toc-items ol {
     flex-basis: 100%;


### PR DESCRIPTION
…fixes #1878

Amends internal links in content to open in new tabs to facilitate deep reading. Verified with a casebook with lots of internal links.

Results in:

```html
<a href="https://www.tribstar.com/news/news_columns/article.html" target="_blank"> ... </a>
```

* Small change to TOC layout which should have been character- rather than pixel-based to begin with. This improves the appearance of deep TOCs.

