### PR TITLE
Apply paragraph spacing to headnote as well as body text in reading mode

### DIFF
--- a/web/static/as_printable_html/book.css
+++ b/web/static/as_printable_html/book.css
@@ -156,10 +156,6 @@
     margin: 0;
   }
 
-  /* Book content (but not metadata or other types) should be indented. */
-  .node-container > p, section > p, article.opinion > p {
-    text-indent: 2em;
-  }
 
   .title > span:nth-of-type(2) {
     display: block;
@@ -278,6 +274,11 @@
     border-top: 1px solid var(--highlight-background-greyscale);
     margin-top: 2mm;
   }
+  /* Book content (but not metadata or other types) should be indented. */
+    .node-container > p, section > p, article.opinion > p {
+      text-indent: 2em;
+  }
+
   /* Generate the corresponding footnote reference in the footer as e.g. "2. <footnote-text>"
    Don't allow long URLs to break on the space in this marker. */
   [data-footnote-marker]::marker {

--- a/web/static/as_printable_html/reader-view.css
+++ b/web/static/as_printable_html/reader-view.css
@@ -12,8 +12,7 @@
   .casebook-metadata {
     padding: 5vh 5vw;
   }
-  article p,
-  article div {
+  article :is(p, div), .headnote :is(p, div) {
     margin: 1rem 0;
   }
   main > article {


### PR DESCRIPTION
Headnote paragraphs were previously missing before/after margins.

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/19571/216627356-4473d1e4-2637-4713-9c8d-8adffddf6614.png">


Also only applies first-line paragraph indenting in PDF layout, never in screen.