### PR TITLE
Monitor PDF export result status

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "webpack_loader",
     "django_json_widget",
     "simple_history",
+    "django_celery_results",
     # built-in
     "django.contrib.admin.apps.SimpleAdminConfig",
     "django.contrib.auth",
@@ -262,6 +263,9 @@ CELERY_TASK_ROUTES = {
 }
 
 CELERY_BEAT_SCHEDULE = {}
+CELERY_RESULT_BACKEND = "django-db"
+CELERY_CACHE_BACKEND = "django-cache"
+CELERY_RESULT_EXTENDED = True  # Include full metadata in TaskResult entries
 
 ###
 ### /END CELERY settings ###

--- a/web/config/settings/settings_dev.py
+++ b/web/config/settings/settings_dev.py
@@ -48,6 +48,6 @@ from celery.schedules import crontab
 CELERY_BEAT_SCHEDULE = {
     "demo-scheduled-task": {
         "task": "main.tasks.demo_scheduled_task",
-        "schedule": crontab(hour="*"),
+        "schedule": crontab(minute="1"),
     },
 }

--- a/web/frontend/components/AuditButton.vue
+++ b/web/frontend/components/AuditButton.vue
@@ -22,7 +22,7 @@ export default {
     PublishButton
   },
   props: {
-    noSave: Boolean, 
+    noSave: Boolean,
     publishCheck: Object,
   },
   data: () => ({autoAudited: {}

--- a/web/frontend/components/ExportButton.vue
+++ b/web/frontend/components/ExportButton.vue
@@ -3,11 +3,25 @@
         <button class="action export-pdf" @click="exportPdf">
             Export PDF<br /><small>BETA</small>
         </button>
-        <Modal v-if="showModal" @close="showModal = false">
+        <Modal v-if="showModal" @close="close">
             <template slot="title">
                 <div>Exporting as PDF...</div>
             </template>
-            <template slot="body"> Exporting ... </template>
+            <template slot="body">
+                <div>
+                    <div
+                        class="spinner"
+                        v-show="!this.response"
+                    >
+                        <div class="bounce1"></div>
+                        <div class="bounce2"></div>
+                        <div class="bounce3"></div>
+                    </div>
+                    <p>
+                        {{ this.response }}
+                    </p>
+                </div>
+            </template>
             <template slot="footer"> </template>
         </Modal>
     </div>
@@ -20,55 +34,82 @@ import Modal from "./Modal";
 const RETRY_INTERVAL = 1_000;
 const MAX_RETRIES = 10;
 
+function init() {
+    return {
+        showModal: false,
+        taskId: null,
+        retries: 0,
+        result: null,
+    };
+}
 export default {
     components: {
         Modal,
     },
     data() {
-        return {
-            showModal: false,
-            taskId: null,
-            completed: false,
-            retries: 0,
-            result: null,
-        };
+        return init();
     },
     computed: {
         casebook: function () {
             return this.$store.getters["globals/casebook"]();
         },
+        response: function () {
+            if (this.result) {
+                if (this.result.succeeded) {
+                    return `Success! PDF file is at ${this.result.succeeded}`;
+                }
+                if (this.result.timeout) {
+                    return `PDF export did not succeed—export did not finish in time.`;
+                } else {
+                    return `PDF export did not succeed: ${this.result.error}`;
+                }
+            }
+            return null;
+        },
     },
     methods: {
+        close() {
+          this.showModal = false;
+          Object.assign(this.$data, init());
+        },
         exportPdf() {
-            Axios.post(`/api/casebooks/${this.casebook}/export-pdf.json`).then((res) => {
-              this.taskId = res.data;
-              this.showModal = true;
-              this.pollForStatus();
-            });
-
+            Axios.post(`/api/casebooks/${this.casebook}/export-pdf.json`).then(
+                (res) => {
+                    this.taskId = res.data;
+                    this.showModal = true;
+                    this.pollForStatus();
+                }
+            );
         },
         pollForStatus() {
-            Axios.get(
-                `/api/casebooks/${this.casebook}/export-pdf.json`, {
-                  params: {task_id: this.taskId}
-                }
-            ).then((res) => {
-                this.result = {succeeded: res.data};
-                this.completed = true;
-                console.log(res.data)
-            }).catch((err) => {
-              if (err.response.status === 404) {
-                this.retries++;
-                if (this.retries < MAX_RETRIES) {
-                  setTimeout(() => this.pollForStatus(), RETRY_INTERVAL)
-                }
-                else {
-                  this.result = {error: "Maximum retries exceeded."};
-                  this.completed = true;
-                }
-              }
-            });
+            Axios.get(`/api/casebooks/${this.casebook}/export-pdf.json`, {
+                params: { task_id: this.taskId },
+            })
+                .then((res) => {
+                    this.result = { succeeded: res.data };
+                })
+                .catch((err) => {
+                    if (err.response.status === 404) {
+                        this.retries++;
+                        if (this.retries < MAX_RETRIES) {
+                            setTimeout(this.pollForStatus, RETRY_INTERVAL);
+                        } else {
+                            this.result = {
+                                timeout: "Maximum retries exceeded.",
+                            };
+                        }
+                    } else {
+                        this.result = { error: err.response.data };
+                    }
+                });
         },
     },
 };
 </script>
+
+<style lang="scss">
+.spinner {
+  text-align: center;
+  margin: auto;
+}
+</style>

--- a/web/frontend/components/ExportButton.vue
+++ b/web/frontend/components/ExportButton.vue
@@ -1,0 +1,27 @@
+<template>
+
+    <button class="action export-pdf" @click="exportPdf">Export PDF<br/><small>BETA</small></button>
+
+</template>
+
+<script>
+import Axios from "../config/axios";
+
+export default {
+  components: {
+  },
+  props: {
+    url: String,
+  },
+  computed: {
+    casebook: function() {
+      return this.$store.getters["globals/casebook"]()
+    }
+  },
+  methods: {
+    exportPdf() {
+      Axios.post(`/api/casebooks/${this.casebook}/export-pdf.json`);
+    }
+  }
+}
+</script>

--- a/web/frontend/components/ExportButton.vue
+++ b/web/frontend/components/ExportButton.vue
@@ -1,27 +1,74 @@
 <template>
-
-    <button class="action export-pdf" @click="exportPdf">Export PDF<br/><small>BETA</small></button>
-
+    <div>
+        <button class="action export-pdf" @click="exportPdf">
+            Export PDF<br /><small>BETA</small>
+        </button>
+        <Modal v-if="showModal" @close="showModal = false">
+            <template slot="title">
+                <div>Exporting as PDF...</div>
+            </template>
+            <template slot="body"> Exporting ... </template>
+            <template slot="footer"> </template>
+        </Modal>
+    </div>
 </template>
 
 <script>
 import Axios from "../config/axios";
+import Modal from "./Modal";
+
+const RETRY_INTERVAL = 1_000;
+const MAX_RETRIES = 10;
 
 export default {
-  components: {
-  },
-  props: {
-    url: String,
-  },
-  computed: {
-    casebook: function() {
-      return this.$store.getters["globals/casebook"]()
-    }
-  },
-  methods: {
-    exportPdf() {
-      Axios.post(`/api/casebooks/${this.casebook}/export-pdf.json`);
-    }
-  }
-}
+    components: {
+        Modal,
+    },
+    data() {
+        return {
+            showModal: false,
+            taskId: null,
+            completed: false,
+            retries: 0,
+            result: null,
+        };
+    },
+    computed: {
+        casebook: function () {
+            return this.$store.getters["globals/casebook"]();
+        },
+    },
+    methods: {
+        exportPdf() {
+            Axios.post(`/api/casebooks/${this.casebook}/export-pdf.json`).then((res) => {
+              this.taskId = res.data;
+              this.showModal = true;
+              this.pollForStatus();
+            });
+
+        },
+        pollForStatus() {
+            Axios.get(
+                `/api/casebooks/${this.casebook}/export-pdf.json`, {
+                  params: {task_id: this.taskId}
+                }
+            ).then((res) => {
+                this.result = {succeeded: res.data};
+                this.completed = true;
+                console.log(res.data)
+            }).catch((err) => {
+              if (err.response.status === 404) {
+                this.retries++;
+                if (this.retries < MAX_RETRIES) {
+                  setTimeout(() => this.pollForStatus(), RETRY_INTERVAL)
+                }
+                else {
+                  this.result = {error: "Maximum retries exceeded."};
+                  this.completed = true;
+                }
+              }
+            });
+        },
+    },
+};
 </script>

--- a/web/frontend/pages/vue_app.js
+++ b/web/frontend/pages/vue_app.js
@@ -7,6 +7,7 @@ import { BrowserTracing } from "@sentry/tracing";
 import AddContent from "../components/AddContent";
 import AuditButton from "../components/AuditButton";
 import Dashboard from "../components/Dashboard";
+import ExportButton from "../components/ExportButton";
 import Globals from "../components/Globals";
 import PortalVue from "portal-vue";
 import QuickAdd from "../components/QuickAdd";
@@ -60,7 +61,9 @@ document.addEventListener("DOMContentLoaded", () => {
         ResourceTypePicker,
         Globals,
         AuditButton,
-        Dashboard
+        Dashboard,
+        ExportButton
+
     }
   });
   if (window.sentry.USE_SENTRY) {

--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -12,6 +12,8 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django_json_widget.widgets import JSONEditorWidget
 from simple_history.admin import SimpleHistoryAdmin
+from django_celery_results.models import TaskResult
+from django_celery_results.admin import TaskResultAdmin
 
 from .models import (
     Casebook,
@@ -1029,3 +1031,4 @@ admin_site.register(CommonTitle, CommonTitleAdmin)
 admin_site.register(LiveSettings, LiveSettingsAdmin)
 admin_site.register(Tag, TagAdmin)
 admin_site.register(CasebookTag, CasebookTagAdmin)
+admin_site.register(TaskResult, TaskResultAdmin)

--- a/web/main/tasks.py
+++ b/web/main/tasks.py
@@ -34,7 +34,8 @@ def generate_pdf(
 
     assert resp
     assert resp.ok
-    assert "/accounts/login" not in resp.url
+    if "/accounts/login" in resp.url:
+        raise PermissionError()
 
     logger.info(
         f"Got status code {resp.status}, waiting for printable page and selector {selector}"

--- a/web/main/templates/includes/action_buttons.html
+++ b/web/main/templates/includes/action_buttons.html
@@ -53,7 +53,8 @@
 
       <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
       {% if user.is_staff %}
-      <a class="action export-pdf" rel="nofollow" target="_blank" href="{% url 'export_as_pdf' casebook %}">Export PDF<br/><small>BETA</small></a>
+      <!-- <a class="action export-pdf" rel="nofollow" target="_blank" href="{% url 'export_as_pdf' casebook %}">Export PDF<br/><small>BETA</small></a> -->
+      <export-button></export-button>
       <a class="action export-html" rel="nofollow" target="_blank" href="{% url 'as_printable_html' casebook %}">Reading mode<br/><small>BETA</small></a>
       {% endif %}
   {% endif %}

--- a/web/main/templates/includes/action_buttons.html
+++ b/web/main/templates/includes/action_buttons.html
@@ -53,9 +53,8 @@
 
       <a class="action one-line export export-{{ section.is_annotated|yesno:"has,no" }}-annotations" role="button" rel="nofollow" href="#">Export</a>
       {% if user.is_staff %}
-      <!-- <a class="action export-pdf" rel="nofollow" target="_blank" href="{% url 'export_as_pdf' casebook %}">Export PDF<br/><small>BETA</small></a> -->
-      <export-button></export-button>
-      <a class="action export-html" rel="nofollow" target="_blank" href="{% url 'as_printable_html' casebook %}">Reading mode<br/><small>BETA</small></a>
+        <export-button></export-button>
+        <a class="action export-html" rel="nofollow" target="_blank" href="{% url 'as_printable_html' casebook %}">Reading mode<br/><small>BETA</small></a>
       {% endif %}
   {% endif %}
 

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -56,6 +56,11 @@ drf_urlpatterns = [
         no_perms_test(views.CommonTitleView.as_view()),
         name="edit_title",
     ),
+    path(
+        "api/casebooks/<idslug:casebook_param>/export-pdf",
+        views.PDFExportView.as_view(),
+        name="export_as_pdf",
+    ),
 ]
 
 urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
@@ -228,9 +233,6 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
         views.as_printable_html,
         {"whole_book": True},
         name="printable_all",
-    ),
-    path(
-        "casebooks/<idslug:casebook_param>/export-pdf/", views.export_as_pdf, name="export_as_pdf"
     ),
     # images
     path("image/", no_perms_test(views.upload_image), name="upload_image"),

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -42,7 +42,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from simple_history.utils import bulk_create_with_history
-from django_celery_results.models import TaskResult, TASK_STATE_CHOICES
+from django_celery_results.models import TaskResult
 
 from .forms import (
     CasebookForm,

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -937,24 +937,8 @@ class CommonTitleView(APIView):
 
 class PDFExportView(APIView):
     @never_cache
+    @no_perms_test  # TODO think through what permissions are required here
     @method_decorator(hydrate_params)
-    @method_decorator(
-        perms_test(
-            {
-                "args": ["full_casebook"],
-                "results": {200: [None, "other_user", "full_casebook.testing_editor"]},
-            },
-            {
-                "args": ["full_private_casebook"],
-                "results": {
-                    200: ["full_private_casebook.testing_editor"],
-                    302: [None],
-                    403: ["other_user"],
-                },
-            },
-        )
-    )
-    @method_decorator(user_has_perm("casebook", "viewable_by"))
     def get(self, request: HttpRequest, casebook: Casebook, **kwargs):
         result = get_object_or_404(TaskResult, task_id=request.GET.get("task_id"))
         if result.status == "SUCCESS":

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2779,32 +2779,6 @@ def as_printable_html(request: HttpRequest, casebook: Casebook, page=1, whole_bo
     )
 
 
-@hydrate_params
-@user_has_perm("casebook", "viewable_by")
-@method_decorator(
-    perms_test(
-        {
-            "args": ["full_casebook"],
-            "results": {200: [None, "other_user", "full_casebook.testing_editor"]},
-        },
-        {
-            "args": ["full_private_casebook"],
-            "results": {
-                200: ["full_private_casebook.testing_editor"],
-                302: [None],
-                403: ["other_user"],
-            },
-        },
-    )
-)
-def export_as_pdf(request: HttpRequest, casebook: Casebook):
-    """Trigger an async job to request this casebook as a PDF."""
-    # TODO: This will fail for non-public casebooks until auth is solved.
-    url = reverse("printable_all", args=[casebook]) + "?print-preview=true"
-    task_id = pdf_from_user.delay(f"{request.scheme}://{request.get_host()}{url}", casebook.slug)
-    return HttpResponse("OK")
-
-
 def reset_password(request):
     """
     Displays the reset password form. We wrap the default Django view to send

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -934,6 +934,55 @@ class CommonTitleView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class PDFExportView(APIView):
+    @method_decorator(hydrate_params)
+    @method_decorator(
+        perms_test(
+            {
+                "args": ["full_casebook"],
+                "results": {200: [None, "other_user", "full_casebook.testing_editor"]},
+            },
+            {
+                "args": ["full_private_casebook"],
+                "results": {
+                    200: ["full_private_casebook.testing_editor"],
+                    302: [None],
+                    403: ["other_user"],
+                },
+            },
+        )
+    )
+    @method_decorator(user_has_perm("casebook", "viewable_by"))
+    def get(self, request: HttpRequest, casebook: Casebook, **kwargs):
+        return HttpResponse("OK")
+
+    @method_decorator(hydrate_params)
+    @method_decorator(
+        perms_test(
+            {
+                "args": ["full_casebook"],
+                "results": {200: [None, "other_user", "full_casebook.testing_editor"]},
+            },
+            {
+                "args": ["full_private_casebook"],
+                "results": {
+                    200: ["full_private_casebook.testing_editor"],
+                    302: [None],
+                    403: ["other_user"],
+                },
+            },
+        )
+    )
+    @method_decorator(user_has_perm("casebook", "viewable_by"))
+    @method_decorator(requires_csrf_token)
+    def post(self, request: HttpRequest, casebook: Casebook, **kwargs):
+        url = reverse("printable_all", args=[casebook]) + "?print-preview=true"
+        task_id = pdf_from_user.delay(
+            f"{request.scheme}://{request.get_host()}{url}", casebook.slug
+        )
+        return HttpResponse(task_id)
+
+
 @perms_test({"results": {200: ["user", None]}})
 def index(request):
     if request.user.is_authenticated:
@@ -2758,7 +2807,7 @@ def export_as_pdf(request: HttpRequest, casebook: Casebook):
     """Trigger an async job to request this casebook as a PDF."""
     # TODO: This will fail for non-public casebooks until auth is solved.
     url = reverse("printable_all", args=[casebook]) + "?print-preview=true"
-    pdf_from_user.delay(f"{request.scheme}://{request.get_host()}{url}", casebook.slug)
+    task_id = pdf_from_user.delay(f"{request.scheme}://{request.get_host()}{url}", casebook.slug)
     return HttpResponse("OK")
 
 

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -42,6 +42,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from simple_history.utils import bulk_create_with_history
+from django_celery_results.models import TaskResult, TASK_STATE_CHOICES
 
 from .forms import (
     CasebookForm,
@@ -954,7 +955,11 @@ class PDFExportView(APIView):
     )
     @method_decorator(user_has_perm("casebook", "viewable_by"))
     def get(self, request: HttpRequest, casebook: Casebook, **kwargs):
-        return HttpResponse("OK")
+        try:
+            result = TaskResult.objects.get(task_id=request.GET.get("task_id"))
+            return HttpResponse(result.result)
+        except:
+            raise Http404
 
     @method_decorator(hydrate_params)
     @method_decorator(

--- a/web/requirements.in
+++ b/web/requirements.in
@@ -23,6 +23,7 @@ diff-match-patch    # update annotations when underlying text changes
 django-json-widget  # fancy editor for Case JSON fields in the Django admin
 django-simple-history # history preservation for contents
 celery[redis, pytest] # task runner
+django-celery-results  # Store celery task results in the ORM
 watchdog            # restart celery in dev (via 'watchmedo' command)
 
 # Testing

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -81,6 +81,7 @@ celery[pytest,redis]==5.2.7 \
     --hash=sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d
     # via
     #   -r requirements.in
+    #   django-celery-results
     #   pytest-celery
 certifi==2022.12.7 \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
@@ -257,6 +258,10 @@ django==3.2.17 \
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework
+django-celery-results==2.4.0 \
+    --hash=sha256:75aa51970db5691cbf242c6a0ff50c8cdf419e265cd0e9b772335d06436c4b99 \
+    --hash=sha256:be91307c02fbbf0dda21993c3001c60edb74595444ccd6ad696552fe3689e85b
+    # via -r requirements.in
 django-crispy-forms==1.12.0 \
     --hash=sha256:a3320356c84d0cdc631e1ec7b8908aa0117bc2a5f0ab1d053d33eba08f584808 \
     --hash=sha256:d196db62ee8b4fc32d1f9583d0e4be1bb17328b662682c1ecb9fb77bbc0fcf77


### PR DESCRIPTION
Part of #1801; does most of #1891

Adds job monitoring for PDF creation and a front-end component to alert the user when it is complete. This is a larger-than-usual PR because all the parts are needed to do something useful.

Includes:

* Adds [django-celery-results](https://django-celery-results.readthedocs.io/), the Celery-endorsed method for monitoring job statuses using the Django ORM. 
* Adds a new Vue component, `ExportButton` which triggers and monitors the PDF export process.
* Replaces the synchronous endpoint URL with an API endpoint that accepts POST requests (to create a new export task) and GET (to check the status of a task)

`django-celery-results` is generic and doesn't do everything you might want in a task monitoring table, but it seems like a good start and it's nice that it provides immediate visibility in the Django admin for any celery job:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/19571/217096332-f9f7d1e4-6244-4784-9784-c8f0385f966e.png">

When a PDF job is triggered, a simple polling mechanism starts in Vue to check the status. The absence of any task result is assumed to be a pending job; when a result is present it'll be in either the SUCCESS or FAILURE state.

This gets reported back to the user as one of three cases:

* The PDF export succeeded, and it prints the path to the temp filesystem where it was generated (this isn't useful yet).
* The PDF export failed because Playwright threw an exception. Usually this is because the casebook isn't public and Playwright can't reach it.
* The polling timed out. This could be any reason, like the Celery task failing to start, or because (as of right now) the polling timeout is shorter than the Playwright timeout. Playwright will time out on long casebooks, but long after the front end has given up on waiting.

## Success


https://user-images.githubusercontent.com/19571/217097270-95a49e22-331c-413f-9b5c-4d10c08d472f.mov

## Failure (non-public casebook)

https://user-images.githubusercontent.com/19571/217097424-d51dced0-5468-4212-bbc0-3618389f6e1e.mov

## Tests

None specifically yet—in large part because the full set of authorization decisions haven't been made—for example, will this be available to anyone, even bots, like the Word export? 

There are no permission checks on the task_id GET endpoint at the moment; you need to know the `task_id` to query for anything, and nothing can be done with the output. We need to think through what _should_ be true for this endpoint, though.

The POST endpoint has the usual "user must be able to view casebook" check.


