### PR TITLE
Use an environment-specific override for user-agent in PDF generation if requested

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -306,6 +306,9 @@ EXPORT_RATE_FALLOFF = int(MAX_EXPORTS_PER_HOUR / 60)
 
 # PDF export settings
 PDF_EXPORT_BUCKET = os.environ.get("PDF_EXPORT_BUCKET", "")
+PDF_USER_AGENT_OVERRIDE = (
+    None  # If set, will override the user agent used by Playwright during PDF generation
+)
 
 PDF_AWS_QUERYSTRING_EXPIRE = 3_600  # 60 minutes
 AWS_S3_SIGNATURE_VERSION = "s3v4"

--- a/web/main/tasks.py
+++ b/web/main/tasks.py
@@ -15,7 +15,8 @@ def pdf_from_user(url: str, slug: str) -> str:
     with sync_playwright() as p:
         logger.info("Launching browser")
         browser = p.chromium.launch(headless=True)
-        page = browser.new_page()
+        context = browser.new_context(user_agent=settings.PDF_USER_AGENT_OVERRIDE)
+        page = context.new_page()
         url = generate_pdf(url, f"{slug}-{datetime.now().strftime('%Y%m%dT%H%M%S')}.pdf", page)
     return url
 
@@ -32,8 +33,7 @@ def generate_pdf(
 
     resp = page.goto(url)
 
-    assert resp
-    assert resp.ok
+    assert resp and resp.ok
     if "/accounts/login" in resp.url:
         raise PermissionError()
 


### PR DESCRIPTION
Allow configuring the user-agent of the Playwright headless browser. The default is to use the built-in user agent.
