### PR TITLE
Switch site search to use Institution to populate school dropdown

### DIFF
--- a/web/conftest.py
+++ b/web/conftest.py
@@ -23,6 +23,7 @@ from main.models import (
     ContentAnnotation,
     ContentCollaborator,
     ContentNode,
+    Institution,
     LegalDocument,
     LegalDocumentSource,
     Link,
@@ -105,6 +106,15 @@ def celery_config():
 
 
 @register_factory
+class InstitutionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Institution
+
+    name = factory.Sequence(lambda n: f"{n} University")
+    url = factory.Sequence(lambda n: f"https://example.com/{n}")
+
+
+@register_factory
 class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
@@ -112,6 +122,7 @@ class UserFactory(factory.DjangoModelFactory):
     email_address = factory.Sequence(lambda n: f"user{n}@example.com")
     attribution = factory.Sequence(lambda n: f"Some User {n}")
     affiliation = factory.Sequence(lambda n: f"Affiliation {n}")
+    institution = factory.SubFactory(InstitutionFactory)
     is_active = True
 
 
@@ -193,7 +204,7 @@ class ContentCollaboratorFactory(factory.DjangoModelFactory):
     class Meta:
         model = ContentCollaborator
 
-    user = factory.SubFactory(UserFactory, verified_professor=True)
+    user = factory.SubFactory(VerifiedProfessorFactory)
     casebook = factory.SubFactory(CasebookFactory)
     has_attribution = True
     can_edit = True

--- a/web/main/create_search_index.sql
+++ b/web/main/create_search_index.sql
@@ -1,7 +1,6 @@
 DROP MATERIALIZED VIEW IF EXISTS search_view;
 DROP MATERIALIZED VIEW IF EXISTS internal_search_view;
 CREATE MATERIALIZED VIEW internal_search_view AS
-    -- via app/models/case.rb
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            c.id AS result_id,
@@ -21,14 +20,13 @@ CREATE MATERIALIZED VIEW internal_search_view AS
         main_legaldocument c
     GROUP BY c.id
 UNION ALL
-    -- via app/models/content/casebook.rb
     SELECT
         row_number() OVER (PARTITION BY true) AS id,
         c.id AS result_id,
         (
             setweight(to_tsvector('english',coalesce(c.title, '')), 'A') ||
             setweight(to_tsvector('english',coalesce(string_agg(u.attribution, ', '), '')), 'A') ||
-            setweight(to_tsvector('english',coalesce(string_agg(u.affiliation, ', '), '')), 'A') ||
+            setweight(to_tsvector('english',coalesce(string_agg(inst.name, ', '), '')), 'A') ||
             setweight(to_tsvector('english',coalesce(subtitle, '')), 'D') ||
             setweight(to_tsvector('english',coalesce(headnote, '')), 'D') ||
             setweight(to_tsvector('english',coalesce(description, '')), 'A')
@@ -36,7 +34,7 @@ UNION ALL
         jsonb_build_object(
             'title', coalesce(c.title, 'Untitled'),
             'attribution', string_agg(u.attribution, ', '),
-            'affiliation', string_agg(u.affiliation, ', '),
+            'institution', coalesce(array_agg(inst.name) filter (where inst.name is not null), '{}'),
             'created_at', c.created_at,
             'description', c.description
         ) AS metadata,
@@ -45,12 +43,12 @@ UNION ALL
         main_casebook c
         LEFT JOIN main_contentcollaborator cc ON cc.casebook_id = c.id AND cc.has_attribution = true
         LEFT JOIN main_user u ON cc.user_id = u.id
+        LEFT JOIN main_institution inst ON u.institution_id = inst.id
     WHERE
         state IN ('Public','Revising') AND
         u.verified_professor = true
     GROUP BY c.id
 UNION ALL
-    -- via app/models/user.rb
     SELECT
            row_number() OVER (PARTITION BY true) AS id,
            u.id AS result_id,
@@ -59,7 +57,7 @@ UNION ALL
             )  AS document,
            jsonb_build_object(
                'attribution', u.attribution,
-               'affiliation', u.affiliation,
+               'institution', inst.name,
                'casebook_count', count(cb.id)
            ) AS metadata,
            'user'::text AS category
@@ -67,9 +65,11 @@ UNION ALL
         main_user u
         INNER JOIN main_contentcollaborator cc ON cc.user_id = u.id
         INNER JOIN main_casebook cb ON cc.casebook_id = cb.id AND cb.state='Public'
+        LEFT JOIN main_institution inst on u.institution_id = inst.id
+
     WHERE
           u.verified_professor = true AND
           u.attribution != ''
-    GROUP BY u.id
+    GROUP BY u.id, inst.id
 ;
 CREATE UNIQUE INDEX search_view_refresh_index ON internal_search_view (result_id, category);

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -41,7 +41,6 @@ from django.core.paginator import Paginator, Page
 from django.core.validators import MaxLengthValidator, validate_unicode_slug
 from django.db import ProgrammingError, connection, models, transaction
 from django.db.models import Count, F, JSONField, Q, QuerySet
-from django.db.models.expressions import RawSQL
 
 from django.template.defaultfilters import truncatechars
 from django.template.loader import render_to_string
@@ -886,7 +885,7 @@ class SearchIndex(models.Model):
             if k == "institution":
                 # Institutions are arrays, but the ORM won't know that by default.
                 # It does know that it's a JSONB blob, and a `contains` query does the right thing.
-                base_query = base_query.filter(**{f"metadata__institution__contains": v})
+                base_query = base_query.filter(**{"metadata__institution__contains": v})
             else:
                 base_query = base_query.filter(**{f"metadata__{k}": v})
 

--- a/web/main/templates/search/filters.html
+++ b/web/main/templates/search/filters.html
@@ -20,7 +20,7 @@
     <div class="form-group select required search_school">
       <select class="form-control select required" name="school" aria-label="Filter by School" id="search_school">
         <option {% if not request.GET.school %}selected {% endif %}value="">All Schools</option>
-        {% for school in facets.affiliation %}
+        {% for school in institutions %}
           <option {% if request.GET.school and request.GET.school == school %}selected {% endif %}value="{{ school }}">{{school}}</option>
         {% endfor %}
       </select>
@@ -37,7 +37,7 @@
     <div class="form-group select required search_school">
       <select class="form-control select required" name="school" aria-label="Filter by School" id="search_school">
         <option {% if not request.GET.school %}selected {% endif %}value="">All Schools</option>
-        {% for school in facets.affiliation %}
+        {% for school in institutions %}
           <option {% if request.GET.school == school %}selected {% endif %}value="{{ school }}">{{ school }}</option>
         {% endfor %}
       </select>


### PR DESCRIPTION
Currently, the site search uses the user-supplied "affiliation" field to drive the "School" dropdown used for faceting casebook results. There are a few issues with this:

1. The results list includes many variations on the same university name, see #1651
2. It's freeform text, so not every value here is really a "school"
3. The index is built at the casebook level; the indexing code uses `string_agg` to aggregate multiple affiliation fields into one comma-delimited field. This in turn introduces more duplicates based on whichever order was picked at indexing time.

A sample of what the dropdown contains now:
<img width="1558" alt="image" src="https://user-images.githubusercontent.com/19571/218862169-cb0dd8f7-ad36-4566-9a54-3f49d706e17b.png">

It's also the case that selecting from the dropdown will only **exactly** match the set of affiliations associated with that casebook. For example, [filtering by "Columbia Law School"](https://opencasebook.org/search/?type=casebook&q=&sort=display_name&author=&school=Harvard%20University,%20Columbia%20Law%20School) returns only two results, when a [third result](https://opencasebook.org/search/?type=casebook&q=&sort=display_name&author=&school=Columbia%20Law%20School,%20Harvard%20University) exists where a Columbia Law School professor was a co-author.

This PR:

* Switches the indexed field to be from the controlled vocabulary of the `Institution` model. @cath9 manually populated all the verified professors with this value awhile back.
* In the full-text index, populates the institution field as an array rather than a string, one entry for each represented institution.
* On the front end, populates the school dropdown with unique values from the set of institutions in the search index.

**My local institution data isn't reflective of prod and is made up**; before merging we should update the staging site DB so it incorporates Catherine's data work, and then really test this before going live.

## New dropdown

Dropdown is coming from the Institution table:

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/19571/218861752-d509d975-90d0-440a-8f44-998c324943c2.png">

Filtering on one institution will also show other institutions from that result set:

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/19571/218861968-dad30b57-ecc5-4e4e-9331-cccaa055c203.png">

Of the 4 results here, 3 are from coauthors and one is solo.

If we switch to Santa Clara, we get 3 of the same results, but we're missing the 4th, because that's CUNY only:

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/19571/218862083-ff0205e9-18e2-4c5e-9f26-e691bb84167a.png">





