### PR TITLE
Correctly handle that institution names are single fields in author index, not arrays

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -925,6 +925,7 @@ class SearchIndex(models.Model):
             facets[facet] = (
                 base_query.filter(category=category)
                 .exclude(**{facet_param: ""})
+                .exclude(**{facet_param: None})
                 .order_by(facet_param)
                 .values_list(facet_param, flat=True)
                 .distinct()

--- a/web/main/test/test_search.py
+++ b/web/main/test/test_search.py
@@ -122,7 +122,7 @@ def test_site_search_school_dropdown(
     casebook = casebook_factory()
     user1 = casebook.collaborators.first()
     user2 = content_collaborator_factory(casebook=casebook).user
-    user3 = content_collaborator_factory(casebook=casebook).user
+    content_collaborator_factory(casebook=casebook).user
 
     Institution.objects.all().delete()
     institution1 = institution_factory(name="University 1")

--- a/web/main/test/test_search.py
+++ b/web/main/test/test_search.py
@@ -93,7 +93,7 @@ def test_search_inside_prof_only(
         ],
     ],
 )
-def test_site_search_metadata(type, factory_class, metadata_fields, db):
+def test_site_search_metadata(type, factory_class, metadata_fields, client, db):
     """The site search should return the expected metadata for a specific typed search"""
     total_results = 3
 
@@ -107,6 +107,10 @@ def test_site_search_metadata(type, factory_class, metadata_fields, db):
     for result in page:
         assert all((result.metadata[field] for field in metadata_fields)) is not None
     assert page.count == total_results
+
+    url = reverse("internal_search")
+    resp = client.get(url, {type: type})
+    check_response(resp)
 
 
 def test_site_search_school_dropdown(

--- a/web/main/test/test_search.py
+++ b/web/main/test/test_search.py
@@ -122,6 +122,7 @@ def test_site_search_school_dropdown(
     casebook = casebook_factory()
     user1 = casebook.collaborators.first()
     user2 = content_collaborator_factory(casebook=casebook).user
+    user3 = content_collaborator_factory(casebook=casebook).user
 
     Institution.objects.all().delete()
     institution1 = institution_factory(name="University 1")
@@ -150,3 +151,9 @@ def test_site_search_school_dropdown(
 
     resp = client.get(url, {"school": not_indexed.name})
     assert resp.context["results"].count == 0
+
+    resp = client.get(url, {"type": "user"})
+    assert resp.context["results"].count == 3
+
+    resp = client.get(url, {"type": "user", "school": institution1.name})
+    assert resp.context["results"].count == 1

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3089,9 +3089,14 @@ def internal_search(request: HttpRequest):
     full_counts = SearchIndex.counts(query=SearchIndex.objects.all())
 
     institutions: set[str] = set()
+
+    # Institution from the authors index is a string; from casebooks it's a list
     for result in facets["institution"]:
-        for value in result:
-            institutions.add(value)
+        if isinstance(result, list):
+            for value in result:
+                institutions.add(value)
+        else:
+            institutions.add(result)
 
     return render(
         request,


### PR DESCRIPTION
PR #1907 modified the casebook search index to allow for the institution (previously affiliation) field to be an array, to represent the case where multiple educators from different institutions contribute to a single casebook.

I neglected to notice that the code to populate the institution dropdown also runs on the Authors tab, and because authors can only belong to one Institution, in the search index it's a string, not an array. If an author doesn't belong to an institution, sensibly the database will represent this as a `null`.

What was happening is that if someone clicked on the author tab, some code tried to iterate through the value of `institution`, thinking it was an array, and most often hit a `None` value (because it was a null in the database) and then the server barfed.

Here we:

* Specifically filter away `None` values (to avoid ending up with an author school dropdown containing a useless "None" as the first entry).
* Check whether the value from the database was a list before iterating, and not iterating if it isn't.
* Add some basic test coverage of the author tab search _view_, which wasn't present even before #1907. If that had been present it would have caught this.

I verified that the new test does catch the bug if applied to the old code.
