### PR TITLE
Refactor functional tests and add new content for testing

### DIFF
--- a/web/main/test/functional/conftest.py
+++ b/web/main/test/functional/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from django.core.management import call_command
+from pytest_django.live_server_helper import LiveServer
+
+
+@pytest.fixture(autouse=True, scope="function")
+def load_fixtures(transactional_db, django_db_serialized_rollback):
+    call_command(
+        "loaddata",
+        [
+            "main/test/functional/fixtures/casebooks.json",
+            "main/test/functional/fixtures/contentannotation.json",
+            "main/test/functional/fixtures/contentcollaborators.json",
+            "main/test/functional/fixtures/contentnodes.json",
+            "main/test/functional/fixtures/textblocks.json",
+            "main/test/functional/fixtures/users.json",
+        ],
+    )
+
+
+# Ensure that staticfiles has been dropped from the app list before the live_server constructor runs.
+# Implementation of this fix: https://github.com/pytest-dev/pytest-django/issues/294#issuecomment-1269236192
+# This fixture be deleted when there's a better mechanism upstream to handle.
+@pytest.fixture
+def static_live_server(request, settings):
+    if "django.contrib.staticfiles" in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS.remove("django.contrib.staticfiles")
+    server = LiveServer("localhost")
+    request.addfinalizer(server.stop)
+    return server
+
+
+@pytest.fixture
+def login_as_default(static_live_server, page):
+    from main.test.functional.test_platform import login
+
+    login(static_live_server, page)

--- a/web/main/test/functional/fixtures/casebooks.json
+++ b/web/main/test/functional/fixtures/casebooks.json
@@ -36,5 +36,24 @@
     "common_title": null,
     "export_fails": 0
   }
+},
+{
+  "model": "main.casebook",
+  "pk": 3,
+  "fields": {
+    "created_at": "2023-02-21T15:35:50.234",
+    "updated_at": "2023-02-21T15:35:58.362",
+    "provenance": "[]",
+    "old_casebook": null,
+    "title": "Casebook with annotations",
+    "subtitle": null,
+    "headnote": "",
+    "description": "",
+    "cover_image": "",
+    "state": "Fresh",
+    "draft": null,
+    "common_title": null,
+    "export_fails": 0
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/contentannotation.json
+++ b/web/main/test/functional/fixtures/contentannotation.json
@@ -1,0 +1,54 @@
+[
+{
+  "model": "main.contentannotation",
+  "pk": 31,
+  "fields": {
+    "created_at": "2023-02-21T15:37:41.293",
+    "updated_at": "2023-02-21T15:37:41.293",
+    "kind": "highlight",
+    "content": "",
+    "global_start_offset": 29,
+    "global_end_offset": 58,
+    "resource": 4
+  }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 32,
+  "fields": {
+    "created_at": "2023-02-21T15:37:51.937",
+    "updated_at": "2023-02-21T15:37:51.937",
+    "kind": "correction",
+    "content": "corrected",
+    "global_start_offset": 105,
+    "global_end_offset": 113,
+    "resource": 4
+  }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 33,
+  "fields": {
+    "created_at": "2023-02-21T15:37:56.829",
+    "updated_at": "2023-02-21T15:37:56.829",
+    "kind": "elide",
+    "content": "",
+    "global_start_offset": 114,
+    "global_end_offset": 217,
+    "resource": 4
+  }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 34,
+  "fields": {
+    "created_at": "2023-02-21T17:09:39.895",
+    "updated_at": "2023-02-21T17:09:39.895",
+    "kind": "note",
+    "content": "Here is the note.",
+    "global_start_offset": 243,
+    "global_end_offset": 247,
+    "resource": 4
+  }
+}
+]

--- a/web/main/test/functional/fixtures/contentnodes.json
+++ b/web/main/test/functional/fixtures/contentnodes.json
@@ -73,5 +73,30 @@
     "reading_length": 0,
     "is_instructional_material": false
   }
+},
+{
+  "model": "main.contentnode",
+  "pk": 4,
+  "fields": {
+    "created_at": "2023-02-21T15:36:18.704",
+    "updated_at": "2023-02-21T17:09:39.887",
+    "ordinals": "[\"1\"]",
+    "display_ordinals": "[\"1\"]",
+    "does_display_ordinals": true,
+    "provenance": "[]",
+    "title": "notes",
+    "subtitle": null,
+    "headnote": "",
+    "headnote_doc_class": "Text",
+    "copy_of": null,
+    "public": false,
+    "draft_mode_of_published_casebook": null,
+    "old_casebook": null,
+    "casebook": 3,
+    "resource_type": "TextBlock",
+    "resource_id": 4,
+    "reading_length": null,
+    "is_instructional_material": false
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/textblocks.json
+++ b/web/main/test/functional/fixtures/textblocks.json
@@ -34,5 +34,17 @@
     "content": "",
     "doc_class": "Text"
   }
+},
+{
+  "model": "main.textblock",
+  "pk": 4,
+  "fields": {
+    "created_at": "2023-02-21T15:36:18.701",
+    "updated_at": "2023-02-21T15:37:31.082",
+    "name": "notes",
+    "description": null,
+    "content": "<p>This is the first paragraph. This sentence is highlighted.</p><p>This is the second paragraph. This sentence is corected.</p><p>This is the third paragraph. This and the following paragraph are elided.</p><p>This paragraph is also elided.</p><p>This is the last paragraph. It's normal.</p>",
+    "doc_class": "Text"
+  }
 }
 ]

--- a/web/main/test/functional/test_reading_mode.py
+++ b/web/main/test/functional/test_reading_mode.py
@@ -1,0 +1,20 @@
+import re
+
+import pytest
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+
+from .test_platform import login
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_nav(static_live_server, page: Page, full_casebook):
+    """Reading mode should allow users to visit the content and navigate between chapters"""
+    login(static_live_server, page, user="functional-staff@example.edu")
+
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[full_casebook]))
+    expect(page.locator("main")).not_to_be_empty()
+    page.get_by_role("option", name="1 of 2 sections")
+    page.locator("#page-selector").select_option(label="2 of 2 sections")
+    page.get_by_role("option", name="2 of 2 sections")
+    expect(page).to_have_url(re.compile("/as-printable-html/2/$"))


### PR DESCRIPTION
This has no functionality changes; it's purely a refactor to make adding more functional tests easy.

* Dumps out some test data to be used for annotations tests in Playwright.
* Moves the functional tests to a module so it's not all in `test_functional.py`.
* Sets up the file for more reading mode tests.