### PR TITLE
Reader mode annotation tests and US Code styles

### DIFF
--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -49,7 +49,11 @@
         <section class="{{ node.resource_type.lower }}-container">
 
           {% if node.resource_type.lower == 'legaldocument' %}
-            {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
+            {% if node.resource.doc_class.lower == 'case' %}
+              {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
+            {% elif node.resource.doc_class.lower == 'code' %}
+              {% include "includes/legal_doc_sources/gpo_header.html" with legal_doc=node.resource %}
+            {% endif %}
           {% endif %}
 
 

--- a/web/main/test/functional/fixtures/contentannotation.json
+++ b/web/main/test/functional/fixtures/contentannotation.json
@@ -50,5 +50,18 @@
     "global_end_offset": 247,
     "resource": 4
   }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 35,
+  "fields": {
+    "created_at": "2023-02-21T19:24:08.079",
+    "updated_at": "2023-02-21T19:24:08.079",
+    "kind": "replace",
+    "content": "word replaced",
+    "global_start_offset": 286,
+    "global_end_offset": 297,
+    "resource": 4
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/contentannotation.json
+++ b/web/main/test/functional/fixtures/contentannotation.json
@@ -63,5 +63,31 @@
     "global_end_offset": 297,
     "resource": 4
   }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 36,
+  "fields": {
+    "created_at": "2023-02-21T22:28:56.414",
+    "updated_at": "2023-02-21T22:28:56.414",
+    "kind": "elide",
+    "content": "",
+    "global_start_offset": 66,
+    "global_end_offset": 129,
+    "resource": 5
+  }
+},
+{
+  "model": "main.contentannotation",
+  "pk": 37,
+  "fields": {
+    "created_at": "2023-02-21T22:29:05.812",
+    "updated_at": "2023-02-21T22:29:05.812",
+    "kind": "elide",
+    "content": "",
+    "global_start_offset": 150,
+    "global_end_offset": 184,
+    "resource": 5
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/contentcollaborators.json
+++ b/web/main/test/functional/fixtures/contentcollaborators.json
@@ -34,5 +34,17 @@
     "user": 3,
     "casebook": 1
   }
+},
+{
+  "model": "main.contentcollaborator",
+  "pk": 4,
+  "fields": {
+    "created_at": "2023-02-21T15:35:50.241",
+    "updated_at": "2023-02-21T15:35:50.241",
+    "has_attribution": true,
+    "can_edit": true,
+    "user": 1,
+    "casebook": 3
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/contentnodes.json
+++ b/web/main/test/functional/fixtures/contentnodes.json
@@ -98,5 +98,30 @@
     "reading_length": null,
     "is_instructional_material": false
   }
+},
+{
+  "model": "main.contentnode",
+  "pk": 5,
+  "fields": {
+    "created_at": "2023-02-21T22:27:41.623",
+    "updated_at": "2023-02-21T22:29:05.809",
+    "ordinals": "[\"2\"]",
+    "display_ordinals": "[\"2\"]",
+    "does_display_ordinals": true,
+    "provenance": "[]",
+    "title": "nest annotations",
+    "subtitle": null,
+    "headnote": "",
+    "headnote_doc_class": "Text",
+    "copy_of": null,
+    "public": false,
+    "draft_mode_of_published_casebook": null,
+    "old_casebook": null,
+    "casebook": 3,
+    "resource_type": "TextBlock",
+    "resource_id": 5,
+    "reading_length": null,
+    "is_instructional_material": false
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/textblocks.json
+++ b/web/main/test/functional/fixtures/textblocks.json
@@ -55,7 +55,7 @@
     "updated_at": "2023-02-21T22:28:47.954",
     "name": "nest annotations",
     "description": null,
-    "content": "<p>This content has an elision which spans multiple node boundaries: <strong>bold text</strong> and then <em>italic tex</em>t and then <strong><em>bold inside italic text</em></strong>.</p><p>This content starts an elision that will </p><p>continue into the next paragraph.</p>",
+    "content": "<p>This content has an elision which spans multiple node boundaries: <strong>bold text</strong> and then <em>italic text</em> and then <strong><em>bold inside italic text</em></strong>.</p><p>This content starts an elision that will </p><p>continue into the next paragraph.</p>",
     "doc_class": "Text"
   }
 }

--- a/web/main/test/functional/fixtures/textblocks.json
+++ b/web/main/test/functional/fixtures/textblocks.json
@@ -46,5 +46,17 @@
     "content": "<p>This is the first paragraph. This sentence is highlighted.</p><p>This is the second paragraph. This sentence is corected.</p><p>This is the third paragraph. This and the following paragraph are elided.</p><p>This paragraph is also elided.</p><p>This paragraph has a note here. You can read it.</p><p>This paragraph has a replacement.</p><p>This is the last paragraph. It's normal.</p>",
     "doc_class": "Text"
   }
+},
+{
+  "model": "main.textblock",
+  "pk": 5,
+  "fields": {
+    "created_at": "2023-02-21T22:27:41.620",
+    "updated_at": "2023-02-21T22:28:47.954",
+    "name": "nest annotations",
+    "description": null,
+    "content": "<p>This content has an elision which spans multiple node boundaries: <strong>bold text</strong> and then <em>italic tex</em>t and then <strong><em>bold inside italic text</em></strong>.</p><p>This content starts an elision that will </p><p>continue into the next paragraph.</p>",
+    "doc_class": "Text"
+  }
 }
 ]

--- a/web/main/test/functional/fixtures/textblocks.json
+++ b/web/main/test/functional/fixtures/textblocks.json
@@ -40,10 +40,10 @@
   "pk": 4,
   "fields": {
     "created_at": "2023-02-21T15:36:18.701",
-    "updated_at": "2023-02-21T15:37:31.082",
+    "updated_at": "2023-02-21T19:23:55.876",
     "name": "notes",
     "description": null,
-    "content": "<p>This is the first paragraph. This sentence is highlighted.</p><p>This is the second paragraph. This sentence is corected.</p><p>This is the third paragraph. This and the following paragraph are elided.</p><p>This paragraph is also elided.</p><p>This is the last paragraph. It's normal.</p>",
+    "content": "<p>This is the first paragraph. This sentence is highlighted.</p><p>This is the second paragraph. This sentence is corected.</p><p>This is the third paragraph. This and the following paragraph are elided.</p><p>This paragraph is also elided.</p><p>This paragraph has a note here. You can read it.</p><p>This paragraph has a replacement.</p><p>This is the last paragraph. It's normal.</p>",
     "doc_class": "Text"
   }
 }

--- a/web/main/test/functional/test_platform.py
+++ b/web/main/test/functional/test_platform.py
@@ -44,8 +44,7 @@ def test_auth(static_live_server, page: Page):
 def test_view_casebook(static_live_server, page: Page, login_as_default):
     """An authenticated user should be able to view their casebooks in edit mode"""
     page.goto(static_live_server.url)
-    expect(page.locator(".casebook-info .title")).to_have_text("Simple casebook")
-    page.locator(".casebook-info .title").click()
+    page.get_by_text("Simple casebook").click()
     page.get_by_role("link", name="First content").click()
 
     expect(page).to_have_url(

--- a/web/main/test/functional/test_reading_mode.py
+++ b/web/main/test/functional/test_reading_mode.py
@@ -18,3 +18,48 @@ def test_reading_mode_nav(static_live_server, page: Page, full_casebook):
     page.locator("#page-selector").select_option(label="2 of 2 sections")
     page.get_by_role("option", name="2 of 2 sections")
     expect(page).to_have_url(re.compile("/as-printable-html/2/$"))
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_elisions(static_live_server, page: Page, login_as_default):
+    """Reading mode should render the correct text  for elisions"""
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[3]))
+    expect(page.get_by_text("[…]")).to_be_visible()
+    expect(page.get_by_text("This paragraph is also elided")).to_be_hidden()
+    expect(page.get_by_text("This is the third paragraph")).to_be_hidden()
+    expect(page.get_by_text("This is the last paragraph")).to_be_visible()
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_highlights(static_live_server, page: Page, login_as_default):
+    """Reading mode should mark up highlights"""
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[3]))
+    highlight = page.locator("mark.highlighted")
+    expect(highlight).to_have_text("This sentence is highlighted.")
+    expect(highlight).to_be_visible()
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_correction(static_live_server, page: Page, login_as_default):
+    """Reading mode should render corrected text"""
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[3]))
+    expect(page.locator("ins").get_by_text("corrected")).to_be_visible()
+    assert page.locator("del.correction").count() == 1
+    expect(page.get_by_text("corected")).to_be_hidden()
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_replacement(static_live_server, page: Page, login_as_default):
+    """Reading mode should render replaced text"""
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[3]))
+    expect(page.locator("ins").get_by_text("word replaced")).to_be_visible()
+    assert page.locator("del.replace").count() == 1
+    expect(page.get_by_text("replacement")).to_be_hidden()
+
+
+@pytest.mark.xdist_group("functional")
+def test_reading_mode_note(static_live_server, page: Page, login_as_default):
+    """Reading mode should render notes"""
+    page.goto(static_live_server.url + reverse("as_printable_html", args=[3]))
+    expect(page.locator("mark.note-mark").get_by_text("here")).to_be_visible()
+    expect(page.locator("aside").get_by_text("Here is the note")).to_be_visible()

--- a/web/static/as_printable_html/all.css
+++ b/web/static/as_printable_html/all.css
@@ -1,4 +1,5 @@
 @import "cap.css";
+@import "uscode.css";
 @import "toc.css";
 
 @media all {

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -5,7 +5,8 @@
   :root {
     --casebook-font-family: "Chronicle Text G3";
     --casebook-font-size: 18px;
-    --casebook-line-height: calc(var(--casebook-font-size) * 1.8);
+    --margin-font-size: 14px;
+    --casebook-line-height: 1.8em;
     --link-icon-height: calc(2 * var(--casebook-font-size));
     --link-icon-width: calc(2 * var(--casebook-font-size));
     --link-icon-margin: 1rem;
@@ -42,6 +43,9 @@
     padding: 1rem;
     width: 15vw;
     transition: transform 0.1s ease-in;
+    line-height: var(--casebook-line-height);
+    font-family: var(--font-sans-serif) !important;
+    font-size: var(--margin-font-size) !important;
   }
 
   mark.note-mark {
@@ -74,12 +78,13 @@
   }
   .node-heading {
     display: block;
-    font-size: 10px;
     width: 13vw;
     margin-left: -20vw;
     float: left;
     text-align: right;
-    line-height: initial;
+    font-family: var(--font-sans-serif) !important;
+    font-size: var(--margin-font-size) !important;
+    line-height: var(--casebook-line-height);
   }
   .node-heading.depth-1 {
     top: 5vh;

--- a/web/static/as_printable_html/uscode.css
+++ b/web/static/as_printable_html/uscode.css
@@ -1,0 +1,23 @@
+h4.subsection-head {
+  font-weight: bold;
+  font-size: 22px;
+}
+
+h4.notes-section {
+  margin-top: 6rem;
+  font-weight: bold;
+  font-size: 22px;
+}
+
+h4.paragraph-head {
+  padding-left: 1rem;
+}
+
+header.uscode-header {
+  text-align: center;
+  font-size: 18px;
+  font-weight: bold;
+}
+header.uscode-header .citation {
+  font-size: 18px;
+}


### PR DESCRIPTION
A batch of fixes and new tests for reader mode. This adds some missing markup/styles for US code content, and some simple tests for annotations. 

There will be more batches like this as I work through the list of featured casebooks as examples.