### PR TITLE
More reading mode updates

### DIFF
--- a/web/static/as_printable_html/all.css
+++ b/web/static/as_printable_html/all.css
@@ -141,15 +141,13 @@
     gap: var(--casebook-font-size);
   }
 
-  a[data-type~="link"] {
-    word-break: break-all;
-  }
+
 
   .link-icon {
-    width: var(--link-icon-width);
-    height: var(--link-icon-height);
-    background: url("../images/Link.svg");
-    background-size: cover;
+    min-width: var(--link-icon-width);
+    min-height: var(--link-icon-height);
+    background: url("../images/Link.svg") no-repeat;
+    background-size: contain;
     display: inline-block;
   }
   .hidden {
@@ -178,7 +176,8 @@
   }
   ins:is(.replace, .correction, .elision-marker) {
     text-decoration: none;
-    font-size: normal;
+    font-weight: normal;
+    text-align: left;
   }
 
   /* Usually hidden node title that will be displayed in screen view */

--- a/web/static/as_printable_html/all.css
+++ b/web/static/as_printable_html/all.css
@@ -80,24 +80,24 @@
     font-size: 110%;
   }
 
-  .depth-3 h1 {
+  :is(.depth-3, .depth-4, .depth-5) h1 {
     font-size: 100%;
     font-weight: bold;
   }
 
-  .depth-3 h2 {
+  :is(.depth-3, .depth-4, .depth-5) h2 {
     font-size: 100%;
     font-weight: bold;
   }
 
-  .depth-3 h3 {
+  :is(.depth-3, .depth-4, .depth-5) h3 {
     font-size: 100%;
     font-weight: bold;
   }
 
   /* Headers for links are much smaller */
   h1.link {
-    font-size: 110%;
+    font-size: 100%;
     font-weight: bold;
   }
   h2.subtitle {

--- a/web/static/as_printable_html/as_printable_html.js
+++ b/web/static/as_printable_html/as_printable_html.js
@@ -198,17 +198,19 @@ annotationRanges.forEach((rg) => {
     }
     case "replace":
     case "correction": {
+      let lastNode;
       // Transparently replace the content inside the node
       ranges.forEach((range) => {
         const deletion = document.createElement("del");
         deletion.setAttribute("correction-deletion-id", id);
         deletion.setAttribute("datetime", datetime);
         deletion.classList.add(type);
-
-        const replacement = `<ins data-${type}-insertion-id="${id}" datetime="${datetime}" class="${type}">${content}</ins>`;
         range.surroundContents(deletion);
-        deletion.insertAdjacentHTML("afterend", replacement);
+        lastNode = deletion;
+
       });
+      const replacement = `<ins data-${type}-insertion-id="${id}" datetime="${datetime}" class="${type}">${content}</ins>`;
+      lastNode.insertAdjacentHTML("afterend", replacement);
       break;
     }
     case "link":

--- a/web/static/as_printable_html/print.css
+++ b/web/static/as_printable_html/print.css
@@ -67,7 +67,9 @@
   article.opinion > p {
     text-indent: 2em;
   }
-
+  a[data-type~="link"] {
+    word-break: break-all;
+  }
   /* Generate the corresponding footnote reference in the footer as e.g. "2. <footnote-text>"
      Don't allow long URLs to break on the space in this marker. */
   [data-footnote-marker]::marker {

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -7,9 +7,8 @@
     --casebook-font-size: 18px;
     --margin-font-size: 14px;
     --casebook-line-height: 1.8em;
-    --link-icon-height: calc(2 * var(--casebook-font-size));
-    --link-icon-width: calc(2 * var(--casebook-font-size));
-    --link-icon-margin: 1rem;
+    --link-icon-height: 25px;
+    --link-icon-width: 25px;
   }
   main {
     box-sizing: border-box;

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -34,6 +34,8 @@
   aside.authors-note {
     float: right;
     clear: both;
+    font-style: normal;
+    font-weight: normal;
     border-radius: 5px;
     margin-right: -20vw;
     margin-bottom: 10px;


### PR DESCRIPTION
* Fixes a bug where replacement text was being injected for each range composing a replacement (for large selections this resulted in duplicated replacements)
* Handles more deeply nested headers
* Makes link icons more predictably sized
* Better resets for some elements which can inherit styles from parents