### PR TITLE
Add link anchors with resource slug in reading mode; fixes #1918

### DIFF
--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -9,7 +9,7 @@
 
     {% if node.resource_type == 'Link' %}
 
-      <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}">{{ node.ordinal_string }}{% if node.ordinal_string %}.{% endif %}
+      <h1 class="resource ordinal {{ node.resource_type|lower }}" data-toc-idx="{{ index }}" id="{{ node.slug }}">{{ node.ordinal_string }}{% if node.ordinal_string %}.{% endif %}
         {{ node.title }}
       </h1>
 


### PR DESCRIPTION
@clare-stanton noted that some hyperlinks from the TOC didn't seem to always work—this was simply due to the fact that link-type sections are handled with different markup and were missing their ids/anchors.
