### PR TITLE
Handle errors when calculating reading length; fixes #1922

### DIFF
--- a/web/main/export.py
+++ b/web/main/export.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Any
 
@@ -10,6 +11,8 @@ from main.models import ContentAnnotation, ContentNode
 from .utils import block_level_elements, remove_empty_tags, void_elements
 
 SortedAnnotation = tuple[int, bool, ContentAnnotation]
+
+logger = logging.getLogger(__name__)
 
 
 class AnnotationContentHandler(sax.ContentHandler):
@@ -236,7 +239,10 @@ class AnnotationContentHandler(sax.ContentHandler):
         # each entry in out_ops will be a method on out_handler and a list of arguments, like
         # (self.out_handler.startElement, 'span')
         for method, *args in self.out_ops:
-            method(*args)
+            try:
+                method(*args)
+            except sax.SaxError as e:
+                logger.warning(f"Got SAX error when reserializing: {e}")
         return self.out_handler.etree.getroot()
 
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2706,7 +2706,6 @@ class ContentNode(
 
     def calculate_reading_length(self) -> Union[None, int]:
         from main.export import annotated_content_for_export
-        from lxml.sax import SaxError
 
         # Assuming ~200 wpm reading rate for dense text
         # 240 estimated as per:
@@ -2714,11 +2713,11 @@ class ContentNode(
         # get rendered html, without annotations in content
         try:
             html_out = annotated_content_for_export(self)
-        except (AttributeError, SaxError) as e:
+        except (Exception) as e:
             logger.warning(
                 f"Got error when serializing content for reading length calculation: {e}"
             )
-            return None
+            return 0
         text = parse_html_fragment(html_out).text_content()
         return len(text)
 

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2704,7 +2704,7 @@ class ContentNode(
         words_per_minute = 200
         return self.reading_length / (chars_per_word * words_per_minute)
 
-    def calculate_reading_length(self) -> Union[None, int]:
+    def calculate_reading_length(self) -> int:
         from main.export import annotated_content_for_export
 
         # Assuming ~200 wpm reading rate for dense text

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2704,8 +2704,9 @@ class ContentNode(
         words_per_minute = 200
         return self.reading_length / (chars_per_word * words_per_minute)
 
-    def calculate_reading_length(self):
+    def calculate_reading_length(self) -> Union[None, int]:
         from main.export import annotated_content_for_export
+        from lxml.sax import SaxError
 
         # Assuming ~200 wpm reading rate for dense text
         # 240 estimated as per:
@@ -2713,7 +2714,8 @@ class ContentNode(
         # get rendered html, without annotations in content
         try:
             html_out = annotated_content_for_export(self)
-        except AttributeError:
+        except (AttributeError, SaxError) as e:
+            logger.warning(f"Got error when serializing content for reading length calculation: {e}")
             return None
         text = parse_html_fragment(html_out).text_content()
         return len(text)

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2715,7 +2715,9 @@ class ContentNode(
         try:
             html_out = annotated_content_for_export(self)
         except (AttributeError, SaxError) as e:
-            logger.warning(f"Got error when serializing content for reading length calculation: {e}")
+            logger.warning(
+                f"Got error when serializing content for reading length calculation: {e}"
+            )
             return None
         text = parse_html_fragment(html_out).text_content()
         return len(text)


### PR DESCRIPTION
There's a subtle bug somewhere in the code that reserializes annotations in cases where it's possible to add a link annotation inside another tag and end up with the serializer trying to output:

```html
<a href="..."><span>I'm unclosed for some reason</a></span>
```

As a consequence, any code that called this (either the docx export or the reading length calculation) would stop at this point due to an uncaught exception.

The problem is something introduced by our code, not due to bad markup in the original. But in practice I think it doesn't matter if we output `<a href=""><span>I'm unclosed</a></span>` because both real browsers and the docx export code can deal with this fine. 

This PR also more strongly guards against uncaught exceptions in the serialization code _in the context of calculating reading length_. This calculation is not mission-critical and so there's no particular reason we need to be notified nor that the user should be prevented from continuing. Unknown errors will still otherwise propagate during exports, because we want to know about those. Lastly, the correct behavior when skipping calculations due to errors is to report 0 here, because a value of `None` means it will try to recalculate every time, even if the content is unchanged.

