### PR TITLE
Handle long URL strings in annotations with scrolling and generated hyperlinks in reading mode; fixes #1926

### DIFF
--- a/web/frontend/components/NoteAnnotation.vue
+++ b/web/frontend/components/NoteAnnotation.vue
@@ -145,7 +145,7 @@ a:active {
     padding: 10px 15px;
     width: fit-content;
   }
-
+ 
   .button {
     margin-top: 1em;
   }
@@ -166,6 +166,7 @@ a:active {
   padding: 10px;
   background-color: $white;
   color: $black;
+  overflow: scroll; 
 }
 .top {
   z-index: 10;

--- a/web/static/as_printable_html/as_printable_html.js
+++ b/web/static/as_printable_html/as_printable_html.js
@@ -114,6 +114,7 @@ const annotationRanges = annotationsToRanges(
 
 annotationRanges.forEach((rg) => {
   const { id, type, datetime, ranges, content } = rg;
+  
   switch (type) {
     case "highlight": {
       ranges.forEach((range) => {
@@ -161,6 +162,9 @@ annotationRanges.forEach((rg) => {
     }
     case "note": {
       let lastNode;
+      // Replace any annotations that look like URLs with hyperlinks
+      const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/ig;
+      const noteContent = content.replace(urlRegex, (url) => `<a target="_blank" href="${url}">${url}</a>`);
 
       // Wrap the specific text the author highlighted to allow for downstream styling
       ranges.forEach((range) => {
@@ -173,7 +177,7 @@ annotationRanges.forEach((rg) => {
       });
 
       // Add the note after the last range
-      const note = `<aside note-id="${id}" class="authors-note">${content}</aside>`;
+      const note = `<aside note-id="${id}" class="authors-note">${noteContent}</aside>`;
       lastNode.insertAdjacentHTML("afterend", note);
 
       break;

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -47,6 +47,7 @@
     line-height: var(--casebook-line-height);
     font-family: var(--font-sans-serif) !important;
     font-size: var(--margin-font-size) !important;
+    overflow: scroll;
   }
 
   mark.note-mark {


### PR DESCRIPTION
In both the regular and reading mode UIs, long hyperlinks can break out of their containers.

Ideally authors would have creates these as the hyperlink type, but currently in the platform adding rich/HTML content in author notes is not supported; they are always plain text.

In both the platform UI and reading mode, this will force scrolling inside the annotation if the browser could not line-break it.

In reading mode only, this will also transform plain text URLs into hyperlinked ones. This is harder to do in Vue because Vue enforces not modifying the DOM in templates. Since this case is rare overall, this only does the DOM transformation in reading mode.

## Before

Platform UI—the first link does break because the browser can wrap on the hyphen:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/19571/224749421-7d37c7e3-58b8-4f54-9c3f-821874c3063c.png">

## After

Platform UI—the bottom one will scroll:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/19571/224749721-ad6e5a65-8bfb-409f-a571-47f8b87c9b33.png">

Reading mode—the bottom scrolls and the links are clickable:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/19571/224751573-f8157cc7-7afd-4273-ae39-9c52ebedb9dd.png">




