### PR TITLE
Hide/show reading mode TOC

### DIFF
--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -72,9 +72,7 @@
     </nav>
     <div>
       <header class="site-header">
-        
-    
-          <p >
+          <p>
             This free and open legal casebook from <a href="{% url 'index' %}">H2O</a>
           is licensed under a Creative Commons license. <a href="{% url 'terms-of-service' %}">Learn more</a>.
           </p>

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -65,10 +65,11 @@
             {% endfor %}
             </span>
           </a>
+          <button class="toc-opener" data-state="open">Hide</button>
       </div>
-
+      
       {% reading_mode_toc_item toc casebook children.0 %}
-
+    
     </nav>
     <div>
       <header class="site-header">

--- a/web/main/templates/includes/reading_mode_toc_item.html
+++ b/web/main/templates/includes/reading_mode_toc_item.html
@@ -4,16 +4,16 @@
 <ol>
 {% for child in toc %}
     <li class="{% if child.id == top_level_node.id %}current-chapter{% endif %}">
-     {% with chapter_num=forloop.counter %}
-        <span class="ordinals">{{ child.ordinal_string|default:"—" }}</span>
-        
-        <h{{ child.ordinals|length }} class="node-title">
-            <a href="{% url 'as_printable_html' casebook chapter_num %}#{{ child.slug }}">{{ child.title }}</a>
-        </h{{ child.ordinals|length }}>
-        {% if child.children and child.id == top_level_node.id %}
-          {% reading_mode_toc_item child.children casebook top_level_node %}
-        {% endif %}
-    {% endwith %}
+
+    <span class="ordinals">{{ child.ordinal_string|default:"—" }}</span>
+    
+    <h{{ child.ordinals|length }} class="node-title">
+        <a href="{% url 'as_printable_html' casebook child.ordinals.0 %}#{{ child.slug }}">{{ child.title }}</a>
+    </h{{ child.ordinals|length }}>
+    {% if child.children and child.id == top_level_node.id %}
+        {% reading_mode_toc_item child.children casebook top_level_node %}
+    {% endif %}
+
     </li>
 {% endfor %}
 </ol>

--- a/web/static/as_printable_html/as_printable_html.js
+++ b/web/static/as_printable_html/as_printable_html.js
@@ -243,3 +243,20 @@ requestAnimationFrame(
 document.querySelector("#page-selector").addEventListener("change", (e) => {
   location.href = e.target.value;
 });
+
+document.querySelectorAll(".toc-opener").forEach(button => {
+  button.addEventListener("click", () => {
+    if (button.getAttribute("data-state") === "open") {
+      document.querySelector("nav.left").style.marginLeft = "-20vw";
+      button.setAttribute("data-state", "closed")
+      button.innerText = "Show"
+    }
+    else {
+      document.querySelector("nav.left").style.marginLeft = "0";   
+      button.setAttribute("data-state", "open")
+      button.innerText = "Hide"
+    }
+    document.querySelector("nav.left").classList.toggle("closed");
+
+  })
+})

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -16,6 +16,7 @@
     height: 100vh;
     background-color: var(--color-background);
     box-sizing: border-box;
+
   }
 
   main {
@@ -26,11 +27,11 @@
   main > div {
     max-height: 120vh; /* Try to ensure that the content area is effectively longer than the side nav */
     overflow-y: scroll;
+    scrollbar-width: none;
   }
   nav.left {
     border-right: 1px solid var(--color-light-gray);
     max-height: 100vh;
-    overflow-y: scroll;
   }
   nav.left .metadata-block {
     margin: 0;
@@ -65,10 +66,7 @@
   .casebook-metadata:not([data-paginator-page="1"]) .headnote {
     display: none;
   }
-  main > div > header.site-header {
-    padding: 0 10vw 0 5vw;
-  }
-  main > div > header {
+  div > header.casebook-metadata {
     padding: 5vh 10vw 5vh 5vw;
 
   }
@@ -104,7 +102,8 @@
     line-height: var(--casebook-line-height);
     font-family: var(--font-sans-serif) !important;
     font-size: var(--margin-font-size) !important;
-    overflow: scroll;
+    word-break: break-all;
+
   }
 
   mark.note-mark {
@@ -133,15 +132,12 @@
     background: var(--highlight-background-color);
   }
 
-  header.site-header {
-    margin: 2rem auto 0 auto;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+
   header.site-header p {
     font-family: var(--font-sans-serif) !important;
-    margin: 0 2rem;
+    font-size: smaller !important;
+    text-align: center;
+    margin: 2em auto 0 auto;
   }
 
   header.site-header button {

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -16,26 +16,29 @@
     height: 100vh;
     background-color: var(--color-background);
     box-sizing: border-box;
-
   }
 
   main {
-    display: grid;
-    grid-template-columns: 25vw 1fr;
+    display: flex;
     position: relative;
   }
   main > div {
     max-height: 120vh; /* Try to ensure that the content area is effectively longer than the side nav */
-    overflow-y: scroll;
+    overflow-y: auto;
     scrollbar-width: none;
   }
+  main > div::-webkit-scrollbar {
+    display: none;
+  } 
   nav.left {
-    border-right: 1px solid var(--color-light-gray);
+    
     max-height: 100vh;
+    scrollbar-width: none;
+    min-width: 25vw;
   }
   nav.left .metadata-block {
     margin: 0;
-    padding: var(--toc-row-gap) 0 var(--toc-row-gap) var(--toc-column-gap);
+    padding: var(--toc-row-gap) var(--toc-column-gap);
     display: flex;
     gap: calc(var(--toc-column-gap) * 2);
     box-shadow: 0 1px 10px rgba(0,0,0,0.15);
@@ -43,7 +46,9 @@
     background: rgb(240, 240, 240, 240);
     align-items: center;
   }
-
+  nav.left .metadata-block button {
+    margin-left: auto;
+  }
   nav.left .metadata-block * {
     color: var(--color-black) !important;
     font-weight: normal;
@@ -56,7 +61,17 @@
   nav.left * {
     font-family: var(--font-sans-serif) !important;
   }
+  nav.left.closed .metadata-block  * {
+    opacity: 0;
+  }
+  nav.left.closed ol {
+    opacity: 0;
+  }
+  
 
+  nav.left.closed .metadata-block button {
+    opacity: 1;
+  }
   main > div > article {
     margin-right: 10vw;
     height: auto;

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -16,7 +16,6 @@ nav.left > ol {
   position: absolute;
   overflow-x: hidden;
   color: grey !important;
-  overflow-y: scroll;
   height: 100vh;
 }
 nav.left > ol li {

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -17,7 +17,13 @@ nav.left > ol {
   overflow-x: hidden;
   color: grey !important;
   height: 100vh;
+  scrollbar-width: none;
+
 }
+nav.left > ol::-webkit-scrollbar {
+  display: none;
+} 
+
 nav.left > ol li {
   display: flex;
   flex-wrap: wrap;
@@ -57,14 +63,21 @@ nav.left .node-title {
 nav.left > ol > li > ol li {
   line-height: calc(var(--casebook-line-height) * 0.8);
 }
+nav.left {
+  outline-offset: -1px;
+  outline: 1px solid var(--color-light-gray);
+}
+nav.left .metadata-block {
+  border-right: 1px solid var(--color-light-gray);
 
-
+}
 nav.left .current-chapter {
   background: white;
   border-top: 1px solid var(--color-light-gray);
   border-bottom: 1px solid var(--color-light-gray);
   padding-top: var(--toc-row-gap);
   padding-bottom: var(--toc-row-gap);
+  border-right: 1px solid white;
   
 }
 


### PR DESCRIPTION
Couple features/extensions to reading mode:

* Show/hide the TOC based on a button. This doesn't animate, though it could if we wanted.
* Fixes a bug with the links in the TOC, which @cath9 thinks "should actually work." Ugh fine now they do.
* Is more explicit about the desired behavior of scrollbars. Because this layout is familiar to our users from Google Docs and elsewhere, it hides the intra-div scrollbars on browsers that might otherwise show them. We can change this behavior if users find it confusing.
* Is more explicit about how the dividing line between the sections is drawn. Before it was something of a side effect that the active TOC area was not offset with a line. Thanks @matteocargnelutti for looking at that with me.


## TOC open

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/19571/225427371-88cff174-a87f-4989-828d-ee70a2bafa06.png">


## TOC closed
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/19571/225427495-7874fb2c-660a-47ef-8677-b473c069a3b9.png">

