### PR TITLE
Reading mode: reflow on small devices; move nav to right

### DIFF
--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -49,28 +49,7 @@
 
 
   <main>
-    <nav class="left">
-      <div class="metadata-block">
 
-          <a href="{% url 'casebook' casebook %}">
-            <img src="{% static 'images/ui/casebook/prev_page.svg' %}" alt="Back to site"  width="32">
-
-          </a>
-          <a href="{% url 'casebook' casebook %}">
-            <img src="{% static 'images/logo-color-full-lockup.svg' %}" alt="H2O"  width="50">
-            <h1 class="casebook-title">{{ casebook.title }}</h1>
-            <span class="authors">
-            {% for user in casebook.primary_authors %}
-              {{ user.display_name }}
-            {% endfor %}
-            </span>
-          </a>
-          <button class="toc-opener" data-state="open">Hide</button>
-      </div>
-      
-      {% reading_mode_toc_item toc casebook children.0 %}
-    
-    </nav>
     <div>
       <header class="site-header">
           <p>
@@ -106,6 +85,28 @@
       </article>
 
     </div>
+    <nav class="toc">
+      <div class="metadata-block">
+
+          <a href="{% url 'casebook' casebook %}">
+            <img src="{% static 'images/ui/casebook/cancel-icon.svg' %}" alt="Back to site"  width="32">
+
+          </a>
+          <a href="{% url 'casebook' casebook %}">
+            <img src="{% static 'images/logo-color-full-lockup.svg' %}" alt="H2O"  width="50">
+            <h1 class="casebook-title">{{ casebook.title }}</h1>
+            <span class="authors">
+            {% for user in casebook.primary_authors %}
+              {{ user.display_name }}
+            {% endfor %}
+            </span>
+          </a>
+          <button class="toc-opener" data-state="open">Hide</button>
+      </div>
+      <h1>Table of contents</h1>
+      {% reading_mode_toc_item toc casebook children.0 %}
+    
+    </nav>
 
   </main>
 

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -95,7 +95,7 @@
           <button class="toc-opener" data-state="open">Hide</button>
 
           <a href="{% url 'casebook' casebook %}">
-            <img src="{% static 'images/logo-color-full-lockup.svg' %}" alt="H2O"  width="50">
+            <img src="{% static 'images/logo-color-wordmark.svg' %}" alt="H2O"  width="50">
             <h1 class="casebook-title">{{ casebook.title }}</h1>
             <span class="authors">
             {% for user in casebook.primary_authors %}

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -94,7 +94,7 @@
           </a>
           <button class="toc-opener" data-state="open">Hide</button>
 
-          <a href="{% url 'casebook' casebook %}">
+          <a href="{% url 'casebook' casebook %}" class="metadata">
             <img src="{% static 'images/logo-color-wordmark.svg' %}" alt="H2O"  width="50">
             <h1 class="casebook-title">{{ casebook.title }}</h1>
             <span class="authors">

--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -52,29 +52,29 @@
 
     <div>
       <header class="site-header">
-          <p>
-            This free and open legal casebook from <a href="{% url 'index' %}">H2O</a>
-          is licensed under a Creative Commons license. <a href="{% url 'terms-of-service' %}">Learn more</a>.
-          </p>
+
       </header>
       <header class="casebook-metadata" data-paginator-page="{{ page.number }}">
         <div>
           <h1 class="casebook title">{{ casebook.title }}</h1>
           {% if casebook.subtitle %}<h2 class="casebook subtitle">{{ casebook.subtitle}}</h2>{% endif %}
+
+          <div class="author-list">
+            <ul>
+            {% for user in casebook.primary_authors %}
+                <li class="user {% if user.verified_professor %} verified{% endif %}">
+                    {{ user.display_name }}
+                    {% if user.affiliation %}
+                      ({{ user.affiliation }})
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+          </div>
+
           <section class="casebook headnote">{{ casebook.headnote|safe}}</section>
         </div>
-        <div class="author-list">
-          <ul>
-          {% for user in casebook.primary_authors %}
-              <li class="user {% if user.verified_professor %} verified{% endif %}">
-                  {{ user.display_name }}
-                  {% if user.affiliation %}
-                    ({{ user.affiliation }})
-                  {% endif %}
-              </li>
-              {% endfor %}
-          </ul>
-        </div>
+        
       </header>
 
 
@@ -88,10 +88,12 @@
     <nav class="toc">
       <div class="metadata-block">
 
-          <a href="{% url 'casebook' casebook %}">
+          <a href="{% url 'casebook' casebook %}" class="back">
             <img src="{% static 'images/ui/casebook/cancel-icon.svg' %}" alt="Back to site"  width="32">
 
           </a>
+          <button class="toc-opener" data-state="open">Hide</button>
+
           <a href="{% url 'casebook' casebook %}">
             <img src="{% static 'images/logo-color-full-lockup.svg' %}" alt="H2O"  width="50">
             <h1 class="casebook-title">{{ casebook.title }}</h1>
@@ -101,8 +103,12 @@
             {% endfor %}
             </span>
           </a>
-          <button class="toc-opener" data-state="open">Hide</button>
+          <p>
+            This free and open casebook
+          is Creative Commons licensed. <a href="https://about.opencasebook.org/making-casebooks/#copyright">Learn more</a> 
+          </p>
       </div>
+
       <h1>Table of contents</h1>
       {% reading_mode_toc_item toc casebook children.0 %}
     

--- a/web/static/as_printable_html/as_printable_html.js
+++ b/web/static/as_printable_html/as_printable_html.js
@@ -245,18 +245,17 @@ document.querySelector("#page-selector").addEventListener("change", (e) => {
 });
 
 document.querySelectorAll(".toc-opener").forEach(button => {
+  const toc = document.querySelector("nav.toc")
   button.addEventListener("click", () => {
     if (button.getAttribute("data-state") === "open") {
-      document.querySelector("nav.left").style.marginLeft = "-20vw";
       button.setAttribute("data-state", "closed")
       button.innerText = "Show"
     }
     else {
-      document.querySelector("nav.left").style.marginLeft = "0";   
       button.setAttribute("data-state", "open")
       button.innerText = "Hide"
     }
-    document.querySelector("nav.left").classList.toggle("closed");
+    toc.classList.toggle("closed");
 
   })
 })

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -57,9 +57,13 @@
   nav.toc .metadata-block a.back {
     display: inline-flex;
   }
+  nav.toc .metadata-block a.metadata {
+    flex-basis: 100%;
+  }
   nav.toc .metadata-block p {
     font-size: 14px !important;
     line-height: 1.4em !important;
+    flex-basis: 100%;
   }
   nav.toc .metadata-block p a {
     text-decoration: underline;

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -51,9 +51,18 @@
     clip-path: inset(0px 0px -10px 0px); 
     background: rgb(240, 240, 240, 240);
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
   }
-  nav.toc .metadata-block button {
-    margin-left: auto;
+  nav.toc .metadata-block a.back {
+    display: inline-flex;
+  }
+  nav.toc .metadata-block p {
+    font-size: 14px !important;
+    line-height: 1.4em !important;
+  }
+  nav.toc .metadata-block p a {
+    text-decoration: underline;
   }
   nav.toc .metadata-block * {
     color: var(--color-black) !important;
@@ -92,6 +101,10 @@
 
   nav.toc.closed .metadata-block button {
     display: block;
+    margin: 0;
+  }
+  nav.toc.closed .metadata-block {
+    padding: 0;
   }
   main > div > article {
     margin-right: 10vw;

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -44,7 +44,7 @@
   
   nav.toc .metadata-block {
     margin: 0;
-    padding: var(--toc-row-gap) var(--toc-column-gap);
+    padding: var(--toc-row-gap) calc(var(--toc-column-gap) * 2);
     display: flex;
     gap: calc(var(--toc-column-gap) * 2);
     box-shadow: 0 1px 10px rgba(0,0,0,0.15);

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -21,22 +21,28 @@
   main {
     display: flex;
     position: relative;
+    flex-wrap: wrap;
+    flex-direction: row;
+
   }
   main > div {
     max-height: 120vh; /* Try to ensure that the content area is effectively longer than the side nav */
     overflow-y: auto;
     scrollbar-width: none;
+    flex-basis: 0;
+    flex-grow: 999;
+    min-inline-size: 60%;
   }
   main > div::-webkit-scrollbar {
     display: none;
   } 
-  nav.left {
-    
-    max-height: 100vh;
+  nav.toc {
     scrollbar-width: none;
-    min-width: 25vw;
+    flex-basis: 40ch;
+    flex-grow: 1;
   }
-  nav.left .metadata-block {
+  
+  nav.toc .metadata-block {
     margin: 0;
     padding: var(--toc-row-gap) var(--toc-column-gap);
     display: flex;
@@ -46,31 +52,46 @@
     background: rgb(240, 240, 240, 240);
     align-items: center;
   }
-  nav.left .metadata-block button {
+  nav.toc .metadata-block button {
     margin-left: auto;
   }
-  nav.left .metadata-block * {
+  nav.toc .metadata-block * {
     color: var(--color-black) !important;
     font-weight: normal;
   }
-  nav.left .metadata-block h1 {
+  nav.toc .metadata-block h1 {
     font-size: 120%;
     padding: 0;
     margin: 0;
   }
-  nav.left * {
+  nav.toc > ol {
+    padding: 0;
+    margin-top: calc(var(--toc-row-gap) * 2);
+    overflow-x: hidden;
+    color: grey !important;
+    height: 100vh;
+    scrollbar-width: none;
+  }
+  nav.toc > ol::-webkit-scrollbar {
+    display: none;
+  } 
+  nav.toc * {
     font-family: var(--font-sans-serif) !important;
   }
-  nav.left.closed .metadata-block  * {
-    opacity: 0;
+
+  nav.toc.closed .metadata-block  * {
+    display: none;
   }
-  nav.left.closed ol {
-    opacity: 0;
+  nav.toc.closed {
+    flex-basis: 5ch;
+  }
+  nav.toc.closed :is(ol, h1) {
+    display: none;  
   }
   
 
-  nav.left.closed .metadata-block button {
-    opacity: 1;
+  nav.toc.closed .metadata-block button {
+    display: block;
   }
   main > div > article {
     margin-right: 10vw;
@@ -107,18 +128,17 @@
     font-style: normal;
     font-weight: normal;
     border-radius: 5px;
-    margin-right: -20vw;
+    margin-right: -15vw;
     margin-bottom: 10px;
     background: white;
     border: 1px solid lightgray;
     padding: 1rem;
-    width: 15vw;
+    width: 10vw;
     transition: transform 0.1s ease-in;
     line-height: var(--casebook-line-height);
     font-family: var(--font-sans-serif) !important;
     font-size: var(--margin-font-size) !important;
-    word-break: break-all;
-
+    overflow-x: scroll;
   }
 
   mark.note-mark {
@@ -219,24 +239,25 @@
     font-size: var(--nav-font-size);
     border: none;
   }
-
-  
   @media (max-width: 552px) {
-    .left a {
-      left: 40vw;
+    :root {
+      --legal-doc-outset: 0px;
     }
-    main {
-      margin: 0 auto;
-      grid-template-areas: center;
-      grid-template-columns: 1fr;
+    .metadata-block button {
+      display: none;
     }
-    header.screen-only {
-      margin-bottom: 2rem;
+    main > div > article {
+      margin: 0;
     }
-    header.screen-only p {
-      margin: 0 0 0 1rem;
+    section.legaldocument-container {
+      border-top: 1px solid var(--color-light-gray);
+      border-bottom: 1px solid var(--color-light-gray);
+      box-shadow: none;
+      
     }
-
+    blockquote {
+      margin-inline: 1em;
+    }
   }
   @font-face {
     font-family: "Chronicle Text G3";

--- a/web/static/as_printable_html/toc.css
+++ b/web/static/as_printable_html/toc.css
@@ -1,77 +1,69 @@
 
-nav.left h2 {
+nav.toc h2 {
   margin: 0;
 }
 
-nav.left h3 {
+nav.toc h3 {
   margin: 0;
   font-size: 1em;
   font-weight: bold;
 }
 
-nav.left > ol {
-  padding: 0;
-  margin-top: calc(var(--toc-row-gap) * 2);
-  max-width: 25vw;
-  position: absolute;
-  overflow-x: hidden;
-  color: grey !important;
-  height: 100vh;
-  scrollbar-width: none;
-
+nav.toc > h1 {
+  font-size: 100%;
+  line-height: 1em;
+  padding-left: calc(var(--toc-column-gap) * 2);
 }
-nav.left > ol::-webkit-scrollbar {
-  display: none;
-} 
 
-nav.left > ol li {
+
+nav.toc > ol li {
   display: flex;
   flex-wrap: wrap;
   padding: 0 calc(var(--toc-column-gap) * 4) 0 calc(var(--toc-column-gap) * 2); 
 }
 
-nav.left > ol .ordinals {
+nav.toc > ol .ordinals {
   flex-basis: 4ch;
 }
 
-nav.left > ol :is(h1, h2, h3, h4, h5, h6) {
+nav.toc > ol :is(h1, h2, h3, h4, h5, h6) {
   flex: 1;
   margin: 0;
   font-size: 100%;
   line-height: 1.6em;
 }
-nav.left > ol ol {
+nav.toc > ol ol {
   flex-basis: 100%;
   padding: var(--toc-row-gap) 0 0  var(--toc-column-gap);
   
 }
-nav.left > ol ol li .ordinals {
+nav.toc > ol ol li .ordinals {
   flex-basis: 4ch;
 }
 
-nav.left > ol > * {
+nav.toc > ol > * {
   margin-bottom: var(--toc-row-gap);
 }
-nav.left > ol > li li {
+nav.toc > ol > li li {
   padding: 0 0 0 0;
 }
-nav.left .node-title {
+nav.toc .node-title {
   display: inline-block;
   margin: 0 0 0 calc(var(--toc-left-width) / 2);
 }
 
-nav.left > ol > li > ol li {
+nav.toc > ol > li > ol li {
   line-height: calc(var(--casebook-line-height) * 0.8);
 }
-nav.left {
+nav.toc {
   outline-offset: -1px;
   outline: 1px solid var(--color-light-gray);
 }
-nav.left .metadata-block {
+nav.toc .metadata-block {
   border-right: 1px solid var(--color-light-gray);
 
 }
-nav.left .current-chapter {
+nav.toc .current-chapter {
   background: white;
   border-top: 1px solid var(--color-light-gray);
   border-bottom: 1px solid var(--color-light-gray);
@@ -81,15 +73,15 @@ nav.left .current-chapter {
   
 }
 
-nav.left .current-chapter h1 {
+nav.toc .current-chapter h1 {
   font-weight: bold;
 }
 
-nav.left a {
+nav.toc a {
   text-decoration: none;
   color: var(--color-dark-gray) !important;
 }
-nav.left a:hover {
+nav.toc a:hover {
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-color: var(--color-medium-gray);


### PR DESCRIPTION
The people have spoken so the nav moves to the right. This also changes the behavior of the "hide toc" button to match.

Following stuff I learned from "[Every Layout](https://every-layout.de/)" this relies on flex to bounce the nav to the bottom if there isn't enough room in the viewport for both columns.

I am still using media breakpoints for internal sizing changes to the content window in small viewports. (This would be an ideal place to use container queries but they may be just a bit too new to rely on for production software.)

Other changes:

* Adds the title heading "Table of contents" to the TOC mostly for screenreader announcements
* Swaps to the logo that's just the wordmark
* Fixes incorrect placement of author names in headnotes
* Moves the copyright notice to the nav and reduces the content
* Changes the "learn more" link to point directly to our copyright statement


## Desktop
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/19571/226020932-ac9662d0-7d4b-4397-9fc5-476cfd31158b.png">

## Mobile

Top and bottom of viewport

<img width="300" alt="image" src="https://user-images.githubusercontent.com/19571/226021430-847534a7-73dd-4e77-a64a-ed2c13d4ce29.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/19571/226021577-7f0403eb-ac62-428b-b6b9-f9fb39a213a4.png">

