### PR TITLE
Remove unused admin pages and optimize slow-loading ones

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -495,7 +495,7 @@ class ContentNodeAdmin(BaseAdmin, SimpleHistoryAdmin):
         ):
             obj.casebook.content_tree__repair()
 
-    ordering = ("id",)
+    ordering = ("-id",)
     paginator = FasterAdminPaginator
     show_full_result_count = False
 


### PR DESCRIPTION
This should make several admin pages which time out on prod now load, and removes parts of the admin that were unused.

* Removes the admin pages that apply to proxy models—while these models aren't being removed imminently, their admin pages don't perform well and aren't strictly necessary because you can just use the resource type filters.
* Works around #1934 by statically providing the list of resource types to be filtered, specific to the model admin pages.
* Removes the queryset override in the contentnode admin; it was prefetching tables we don't display in the list view (anymore?) 
* Uses fast, estimation-style pagination and removes full counts for large admin pages where that value isn't useful because it's usually in the millions of rows.

(If the query is filtered in any way,  it will typically do full counts because I think this is otherwise fast enough now—it will only do estimated pagination for the unfiltered list view. 

**Edited**: the annotations model looked like it would time out on prod in this case, so I've provided a mechanism to list models that should always be estimated.)

Performance counts on my laptop (which is much faster than prod so this is more about the relative difference):

**ContentNode admin**

Before: 7 queries, 435ms (times out on prod)
After: 5 queries, 9ms

**ContentAnnotations admin**

Before: 7 queries, 350 ms (times out on prod)
After: 5 queries, 5ms

