### PR TITLE
Improve layout and copy of case search modal

### DIFF
--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="add-content">
     <button
       class="action one-line add-resource"
       v-on:click.stop.prevent="displayModal()"
@@ -223,6 +223,11 @@ export default {
 <style lang="scss">
 @use "sass:color";
 @import "variables";
+
+.add-resource-body {
+  width: 95%;
+  margin: auto;
+}
 label.textarea {
   width: 100%;
 }

--- a/web/frontend/components/CaseResults.vue
+++ b/web/frontend/components/CaseResults.vue
@@ -11,11 +11,7 @@
       <span>No legal documents found matching your search</span>
     </div>
   </div>
-  <div class="search-results-wrapper" v-else-if="searchResults.unRun">
-    <div class="search-alert">
-      <span>Click Search to run your search</span>
-    </div>
-  </div>
+
   <div class="search-results-wrapper" v-else>
     <div class="search-results-entry" v-for="c in searchResults.results" :key="c.id">
       <div class="name-column">
@@ -92,14 +88,6 @@ export default {
     padding-right: 1rem;
 }
 .search-results-wrapper {
-  overflow-y: unset;
-  overflow-x: unset;
-  display: table;
-  width: 100%;
-  border-top: 2px solid black;
-  border-bottom: 2px solid black;
-  margin: 8px 0;
-  padding: 2px 0;
   .search-results-entry {
     display: table-row;
     div {

--- a/web/frontend/styles/content/modals.scss
+++ b/web/frontend/styles/content/modals.scss
@@ -72,8 +72,8 @@
     padding-right: 20px;
   }
   .search-tabs {
-    @include make-row();
-
+    display: flex;
+    justify-content: space-evenly;
     margin-bottom: 15px;
 
     .search-tab {
@@ -84,7 +84,7 @@
 
       text-align: center;
       cursor: pointer;
-      border-bottom: 2px solid black;
+      border-bottom: 1px solid $black;
 
       &.active {
         border-bottom-color: $light-blue;


### PR DESCRIPTION
A set of mostly cosmetic and copy changes to the "Add a case" modal:

* Centers the top tabs 
* Removes extraneous lines and copy
* Organizes drop-downs and styles them more evenly
* Better balances the weight of the type on the modal
* Changes the advanced/basic search toggle from an anchor to an underlined button (now more obviously clickable and has the right cursor effects; should be better for a11y)
* Adds a little more breathing room around the edges of the modal content

## Before
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/19571/226451500-01135cce-f62e-4341-8453-0aee9cc7232e.png">

## After

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/19571/226456134-b7387769-4f1d-451d-8802-236ace9c75a7.png">

The above screenshots are Chrome; Firefox looks identical.

Because Safari makes styling form components hard, it looks less nice in that browser, but it also looks less nice in Safari currently:

### Before

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19571/226452966-9643ae5c-b7df-4ea5-a5eb-29f0f2d56176.png"> 

### After 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19571/226454551-0f61bc6e-bbb3-4007-9c90-214b6d690374.png">

There will be some improvements to the actual case selection UX and functionality following this, but I wanted to separate out the copy/styling first.

