### PR TITLE
Improve design and copy of other add-content tabs

### DIFF
--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -33,6 +33,11 @@
         </div>
         <div class="add-resource-body" v-else-if="textTab">
           <form ref="textForm" class="new-text" v-on:submit.stop.prevent="submitTextForm()">
+
+            <p>Add your own content, paste in a case or other legal document not in our database, 
+              or embed images and videos.
+            </p>
+
             <div v-bind:class="{'form-group': true, 'has-error': errors.name}">
               <label class="title">
                 Title
@@ -59,20 +64,22 @@
                 </span>
               </label>
             </div>
-            <input class="save-button" type="submit" :value="pendingSubmit ? 'Save in progress' : 'Save Text'" :disabled="pendingSubmit" />
+            <input class="save-button" type="submit" :value="pendingSubmit ? 'Save in progress' : 'Add'" :disabled="pendingSubmit" />
           </form>
         </div>
         <div class="add-resource-body" v-else-if="linkTab">
-          <h3>Enter the URL of any asset to link from the web.</h3>
-          <h4>Some examples: YouTube videos, PDFs, JPG, PNG, or GIF images</h4>
+
           <form ref="linkForm" class="new-link" v-on:submit.stop.prevent="submitLinkForm()">
+            <p>Enter a URL to direct readers to a web resource. Examples could include online news articles, 
+            law review articles or podcasts.
+            </p>
             <div v-bind:class="{'form-group': true, 'has-error': errors.url}">
               <input
                 class="form-control"
                 ref="link_body"
                 name="url"
                 type="text"
-                placeholder="Enter a URL to add it to your casebook"
+                placeholder="https://example.com"
                 v-model="linkTarget"
                 v-focus
               />
@@ -80,7 +87,7 @@
                 <strong>{{errors.url[0].message}}</strong>
               </span>
             </div>
-            <input class="search-button" type="submit" :value="pendingSubmit ? 'Save in progress' : 'Add Link'" :disabled="pendingSubmit" />
+            <input class="search-button" type="submit" :value="pendingSubmit ? 'Save in progress' : 'Add'" :disabled="pendingSubmit" />
           </form>
         </div>
       </template>
@@ -227,10 +234,27 @@ export default {
 .add-resource-body {
   width: 95%;
   margin: auto;
+
+  :is(.new-text, .new-link) {
+    
+    label.textarea {
+      width: 100%;
+    }
+    label > :is(input, div) {
+      margin-top: .5em;
+    }
+    label {
+      margin: 1em 0;
+    }
+    input[type="submit"] {
+      margin: 1em 0;
+    }
+  }
+  .new-link input {
+    margin: .5em 0;
+  }
 }
-label.textarea {
-  width: 100%;
-}
+
 .search-tabs {
   display: flex;
   flex-direction: row;
@@ -286,7 +310,5 @@ label.textarea {
   }
 }
 
-a.action.add-resource {
-  background-image: url(http://localhost:8080/static/dist/img/add-material.d109215f.svg);
-}
+
 </style>


### PR DESCRIPTION
Some copy changes from @cath9 plus some more layout improvements:

* Rationalized the button labels
* Streamlined some haphazard font sizes and markup
* Regularized spacing between elements

## Before

<img width="950" alt="image" src="https://user-images.githubusercontent.com/19571/226654779-2b0f2366-0974-463d-bc53-223a1a75aa1f.png">
<img width="950" alt="image" src="https://user-images.githubusercontent.com/19571/226654870-a8a90541-c237-4d01-ba9b-45c0660503f4.png">

## After

<img width="950" alt="image" src="https://user-images.githubusercontent.com/19571/226654988-321fa4bc-2a8a-4126-8c2a-75ca062f6f02.png">
<img width="950" alt="image" src="https://user-images.githubusercontent.com/19571/226655089-1fbd9ad0-52e2-47b8-9ad8-0002708f3d0c.png">


