### PR TITLE
Remove exemption for superuser for legacy legal doc source

### DIFF
--- a/web/main/models.py
+++ b/web/main/models.py
@@ -1110,12 +1110,9 @@ class LegalDocumentSource(models.Model):
             cls.source_apis[api.details["name"]] = api
 
     @classmethod
-    def active_sources(cls, user: Union[AnonymousUser, User]) -> QuerySet[LegalDocumentSource]:
-        """Return the queryset of active sources based on the user's current permissions"""
-        search_sources = LegalDocumentSource.objects.order_by("priority")
-        if user.is_anonymous or not user.is_superuser:
-            search_sources = search_sources.filter(active=True)
-        return search_sources
+    def active_sources(cls) -> QuerySet[LegalDocumentSource]:
+        """Return the queryset of active sources"""
+        return LegalDocumentSource.objects.order_by("priority").filter(active=True)
 
     def api_model(self):
         # short_description, long_description, bulk_process, search(long_citation_json), import(id)

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1636,7 +1636,7 @@ def edit_casebook(request: HttpRequest, casebook: Casebook):
 
     casebook.contents.prefetch_resources()
     serialized_sources = LegalDocumentSourceSerializer(
-        LegalDocumentSource.active_sources(request.user), many=True
+        LegalDocumentSource.active_sources(), many=True
     ).data
 
     return render_with_actions(
@@ -2186,7 +2186,7 @@ def edit_section(request, casebook, section):
 
     section.contents.prefetch_resources()
     serialized_sources = LegalDocumentSourceSerializer(
-        LegalDocumentSource.active_sources(request.user), many=True
+        LegalDocumentSource.active_sources(), many=True
     ).data
 
     return render_with_actions(
@@ -2492,7 +2492,7 @@ def annotate_resource(request, casebook, resource):
         return redirect("edit_resource", resource.casebook, resource)
 
     serialized_sources = LegalDocumentSourceSerializer(
-        LegalDocumentSource.active_sources(request.user), many=True
+        LegalDocumentSource.active_sources(), many=True
     ).data
 
     body_json = resource.json


### PR DESCRIPTION
Currently superusers will see three sources for legal documents: CAP, GPO, and "Legacy." The legacy type isn't exposed to non-admins already; this just puts admins on the same footing.

This will result in a small performance optimization for staff users doing searches—the front-end API is written such that it issues one distinct HTTP query for each source type, so are waiting for 3 HTTP responses to get results instead of 2 (one which is always empty of results). 

In the [related ticket](https://github.com/harvard-lil/h2o/issues/1936) I noted a test failure following this change, but I can't reproduce this now. 