### PR TITLE
Remove references to deleted Resource admin pages; fixes #1948

### DIFF
--- a/web/main/admin.py
+++ b/web/main/admin.py
@@ -822,27 +822,19 @@ class LegalDocumentAdmin(BaseAdmin, SimpleHistoryAdmin):
         "id",
         "short_name",
         "source_name",
+        "source_ref",
         "doc_class",
-        "related_resources",
         "live_annotations_count",
         "created_at",
         "updated_at",
     ]
     list_filter = ["doc_class", LegalDocumentSourceFilter]
-    search_fields = ["short_name", "name"]
+    search_fields = ["short_name", "name", "source_ref"]
     raw_id_fields = []
     exclude = ("annotations_count", "source")
 
     def has_add_permission(self, request):
         return super(BaseAdmin, self).has_add_permission(request)
-
-    def related_resources(self, obj):
-        return format_html(
-            '<a href="{}?resource_type=LegalDocument&resource-id={}">{}</a>',
-            reverse("admin:main_resource_changelist"),
-            obj.id,
-            obj.related_resources().count(),
-        )
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         return self.enable_richeditor_for_field("content", db_field, **kwargs)

--- a/web/main/templates/admin/main/casebook/change_form.html
+++ b/web/main/templates/admin/main/casebook/change_form.html
@@ -9,11 +9,6 @@
         View Casebook's Sections
       </a>
     </div>
-    <h2>Resources</h2>
-    <div class="form-row">
-      <a href="{% url 'admin:main_resource_changelist' %}?casebook={{ original.id }}&o=5">
-        View Casebook's Resources
-      </a>
-    </div>
+    
   </div>
 {% endblock %}

--- a/web/main/templates/admin/main/legaldocument/change_form.html
+++ b/web/main/templates/admin/main/legaldocument/change_form.html
@@ -15,18 +15,6 @@
 </div>
 {% endblock %}
 
-{% block after_related_objects %}
-{{ block.super }}
-<div class="module aligned">
-    <h2>Related Resources</h2>
-    <div class="form-row">
-        <a href="{% url 'admin:main_resource_changelist' %}?resource_type=LegalDocument&resource-id={{ original.id }}">
-            View related resources ({{ original.related_resources.count }})
-        </a>
-    </div>
-</div>
-{% endblock %}
-
 {% block submit_buttons_bottom %}
 {{ block.super }}
 {% endblock %}

--- a/web/main/templates/admin/main/link/change_form.html
+++ b/web/main/templates/admin/main/link/change_form.html
@@ -1,14 +1,3 @@
 {% extends "admin/change_form.html" %}
 {% load admin_urls %}
 
-{% block after_related_objects %}
-  {{ block.super }}
-  <div class="module aligned">
-    <h2>Related Resources</h2>
-    <div class="form-row">
-      <a href="{% url 'admin:main_resource_changelist' %}?resource_type=Link&resource-id={{ original.id }}">
-        View related resources ({{ original.related_resources.count }})
-      </a>
-    </div>
-  </div>
-{% endblock %}

--- a/web/main/templates/admin/main/textblock/change_form.html
+++ b/web/main/templates/admin/main/textblock/change_form.html
@@ -10,14 +10,4 @@
   </div>
 {% endblock %}
 
-{% block after_related_objects %}
-  {{ block.super }}
-  <div class="module aligned">
-    <h2>Related Resources</h2>
-    <div class="form-row">
-      <a href="{% url 'admin:main_resource_changelist' %}?resource_type=TextBlock&resource-id={{ original.id }}">
-        View related resources ({{ original.related_resources.count }})
-      </a>
-    </div>
-  </div>
-{% endblock %}
+


### PR DESCRIPTION
This PR restores the use of some admin pages which were returning server errors.

In #1935 the `Resource` admin views were removed because they were not useful in their current state—the list pages timed out.

An unintended consequence was that some other admin pages had template customizations that tried to `reverse()` now-deleted views, and would then server error on load. 

This removes the remaining references to Resource admin pages. If it's useful to follow the relationship from a Casebook to its internal resources, that could be traversed via `ContentNode` and grouping them by their resource type. 

