### PR TITLE
Move Quick Add results to bottom to match other search behavior

### DIFF
--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -24,8 +24,6 @@
 
         <div class="add-resource-body" v-if="caseTab">
           <case-searcher
-            :search-on-top="false"
-            :can-cancel="true"
             v-model="caseQueryObj"
             @choose="selectCase"
           />

--- a/web/frontend/components/CaseSearcher.vue
+++ b/web/frontend/components/CaseSearcher.vue
@@ -155,7 +155,7 @@ const jurisdictions = [
 ];
 
 export default {
-  props: ["searchOnTop", "canCancel", "value", "searchLabel"],
+  props: ["value", "searchLabel"],
   data: () => ({
     jurisdictions,
     showingLimits: false,

--- a/web/frontend/components/TableOfContents/EntryAuditor.vue
+++ b/web/frontend/components/TableOfContents/EntryAuditor.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
-    <case-results :queryObj="searchOptions" @choose="selectCase"></case-results>
+  <div class="entry-auditor">
     <case-searcher v-model="searchOptions"></case-searcher>
+    <case-results :queryObj="searchOptions" @choose="selectCase"></case-results>
   </div>
 </template>
 
@@ -75,4 +75,12 @@ export default {
 .listing.resource.temporary {
   outline: 2px solid red;
 }
+.entry-auditor {
+  margin-top: 1em;
+  
+  & > div {
+    margin-top: 1em;
+  }
+}
+
 </style>


### PR DESCRIPTION
There was a deliberate design decision that legal document search results would appear below the search box on some pages, and above it in others. This is a bit confusing in practice though, so we've decided make the results appear below the search box in all cases. (There's a second occurrence of this but it's in #1953 which should just be deleted.)

This has an additional advantage in reducing visual page jank, as the search box stays in place now after clicking submit rather than bouncing below the viewport.

This also deletes two Vue props that had no effect (one seemed related to this positioning issue, but was unused).

## Before 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/19571/228015693-ec16e279-7447-4160-a8e3-35ecd48c67ae.png">


## After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/19571/228015828-93c2cbcc-4137-4e61-8030-af693cf875b4.png">

