### PR TITLE
Add endpoint that will fetch and add a resource to a casebook in one roundtrip

### DIFF
--- a/web/conftest.py
+++ b/web/conftest.py
@@ -327,7 +327,7 @@ class LegalDocumentFactory(factory.DjangoModelFactory):
     effective_date = datetime(1900, 1, 1)
     publication_date = datetime(1901, 1, 1)
     updated_date = datetime(1902, 1, 1)
-    source_ref = factory.Sequence(lambda n: {"id": n})
+    source_ref = factory.Sequence(lambda n: n)
     content = factory.Sequence(lambda n: f"Dubious legal claim {n}")
     metadata = {}
 

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -61,6 +61,11 @@ drf_urlpatterns = [
         views.PDFExportView.as_view(),
         name="export_as_pdf",
     ),
+    path(
+        "casebooks/<idslug:casebook_param>/resources/from_source/",
+        views.LegalDocumentResourceView.as_view(),
+        name="legal_document_resource_view",
+    ),
 ]
 
 urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
@@ -217,7 +222,7 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path("casebooks/<casebook:node>/export.<file_type>", views.export, name="export_casebook"),
     path("sections/<section:node>/export.<file_type>", views.export, name="export_section"),
     path("resources/<resource:node>/export.<file_type>", views.export, name="export_resource"),
-    # Printable HTML view
+    # Reading mode
     path(
         "casebooks/<idslug:casebook_param>/as-printable-html/",
         views.as_printable_html,

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3,7 +3,7 @@ import logging
 from typing import Union
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 from main.celery_tasks import pdf_from_user
 from test.test_helpers import assert_url_equal, check_response, dump_content_tree_children
@@ -40,6 +40,7 @@ from pytest import raises as assert_raises
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
+from rest_framework.request import Request
 from rest_framework.views import APIView
 from simple_history.utils import bulk_create_with_history
 from django_celery_results.models import TaskResult
@@ -980,6 +981,62 @@ class PDFExportView(APIView):
         return HttpResponse(task_id)
 
 
+class LegalDocumentResourceView(APIView):
+    @method_decorator(hydrate_params)
+    @method_decorator(no_perms_test)  
+    @method_decorator(user_has_perm("casebook", "directly_editable_by"))
+    @method_decorator(requires_csrf_token)
+    def post(self, request: Request, casebook: Casebook):
+        """Given a legal document source ref, attempt to import the document if it doesn't exist or is too old, then
+        create a corresponding resource in the given casebook"""
+        source_id = request.data.get("source_id")
+        source_ref = request.data.get("source_ref")
+        section_id = request.data.get("section_id")
+        source = get_object_or_404(LegalDocumentSource, id=source_id)
+
+        MAX_AGE_BEFORE_REFRESH = timedelta(days=365)
+
+        legal_doc = (
+            LegalDocument.objects.filter(
+                source_ref=source_ref,
+                source=source,
+                updated_date__gte=(datetime.now() - MAX_AGE_BEFORE_REFRESH),
+            )
+            .order_by("-updated_date")
+            .first()
+        )
+        # If we don't have a recent-enough copy of this (or any copy at all), get one from upstream, then try the query again
+        if not legal_doc:
+            if legal_doc := source.pull(id=source_ref):
+                legal_doc.save()
+            else:
+                # If we still don't have one, the source ref probably couldn't be found from upstream
+                raise Http404
+
+        parent: Union[ContentNode, Casebook]
+        if section_id := request.data.get("section_id"):
+            parent = ContentNode.objects.get(id=section_id)
+        else:
+            parent = casebook
+        ordinals, display_ordinals = parent.content_tree__get_next_available_child_ordinals()
+
+        resource = ContentNode.objects.create(
+            title=legal_doc.get_name(),
+            casebook=casebook,
+            ordinals=ordinals,
+            display_ordinals=display_ordinals,
+            resource_id=legal_doc.id,
+            resource_type="LegalDocument",
+        )
+        return Response(
+            data={
+                "resource_id": resource.id,
+                "redirect_url": reverse("annotate_resource", args=[casebook, resource]),
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+
 @perms_test({"results": {200: ["user", None]}})
 def index(request):
     if request.user.is_authenticated:
@@ -1914,7 +1971,8 @@ def new_link(request, casebook):
 @user_has_perm("casebook", "directly_editable_by")
 def new_legal_doc(request, casebook):
     """
-    Creates a new LegalDoc as the last child of a casebook or section
+    Creates a new LegalDocument Resource from an existing LegalDocument as the
+    last child of a casebook or section
     """
 
     if "resource_id" not in request.POST:

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -983,7 +983,7 @@ class PDFExportView(APIView):
 
 class LegalDocumentResourceView(APIView):
     @method_decorator(hydrate_params)
-    @method_decorator(no_perms_test)  
+    @method_decorator(no_perms_test)
     @method_decorator(user_has_perm("casebook", "directly_editable_by"))
     @method_decorator(requires_csrf_token)
     def post(self, request: Request, casebook: Casebook):


### PR DESCRIPTION
To optimize the add-legal-doc workflow, this adds a new API endpoint that performs the work of currently done by https://github.com/harvard-lil/h2o/blob/develop/web/main/views.py#L2591-L2630 and https://github.com/harvard-lil/h2o/blob/develop/web/main/views.py#L1915-L1939 as separate HTTP requests.

This endpoint simplifies and optimizes that flow in these ways:

* For legal docs that have previously been imported, it won't try to check the remote API for an updated version unless it's more than "max age" old. Per @cath9 we set this date at one year.
* It returns a JSON response rather than an HTTP redirect, including the new resource ID and the redirection URL so the client may redirect, but isn't required to
* Leverages the DRF automatic mechanism to transparently support JSON requests and responses rather than hardcoding form or JSON input

It includes the same logic as the dual endpoint it replaces, including accepting an optional section to add the new resource in a particular part of the casebook, or default to adding it at the end.

This doesn't add the frontend consumer for this endpoint, but does include a number of tests which should fully cover its functionality.

