### PR TITLE
Improve navigation of reading mode and toc; fixes #1954

### DIFF
--- a/web/main/templates/export/as_printable_html/casebook.html
+++ b/web/main/templates/export/as_printable_html/casebook.html
@@ -88,18 +88,15 @@
     <nav class="toc">
       <div class="metadata-block">
 
-          <a href="{% url 'casebook' casebook %}" class="back">
-            <img src="{% static 'images/ui/casebook/cancel-icon.svg' %}" alt="Back to site"  width="32">
-
-          </a>
           <button class="toc-opener" data-state="open">Hide</button>
+          <button class="reading-mode-exit" data-exit-url='{% url 'casebook' casebook %}'">Exit</button>
 
           <a href="{% url 'casebook' casebook %}" class="metadata">
             <img src="{% static 'images/logo-blue-wordmark.svg' %}" alt="H2O"  width="50">
             <h1 class="casebook-title">{{ casebook.title }}</h1>
             <span class="authors">
             {% for user in casebook.primary_authors %}
-              {{ user.display_name }}
+              <span class="author">{{ user.display_name }}</span>
             {% endfor %}
             </span>
           </a>
@@ -127,13 +124,13 @@
         {% else %}
           <span class="unlinked">Previous</span>
         {% endif %}
-
+        
         <select id="page-selector">
-        {% for p in paginator %}
+        {% for p in paginator.object_list %}
           <option
-            value="{% url 'as_printable_html' casebook p.number %}"
-          {% if p.number == page.number %}selected{% endif %}>
-          {{ p.number }} of {{ paginator.num_pages }} section{{ paginator.num_pages|pluralize}} </span>
+            value="{% url 'as_printable_html' casebook forloop.counter %}#{{ p.slug }}"
+          {% if forloop.counter == page.number %}selected{% endif %}>
+          {{ forloop.counter }} of {{ paginator.num_pages }} section{{ paginator.num_pages|pluralize}} </span>
           </option>
         {% endfor %}
         </select>

--- a/web/main/test/functional/test_reading_mode.py
+++ b/web/main/test/functional/test_reading_mode.py
@@ -17,7 +17,7 @@ def test_reading_mode_nav(static_live_server, page: Page, full_casebook):
     page.get_by_role("option", name="1 of 2 sections")
     page.locator("#page-selector").select_option(label="2 of 2 sections")
     page.get_by_role("option", name="2 of 2 sections")
-    expect(page).to_have_url(re.compile("/as-printable-html/2/$"))
+    expect(page).to_have_url(re.compile("/as-printable-html/2/"))
 
 
 @pytest.mark.xdist_group("functional")

--- a/web/static/as_printable_html/as_printable_html.js
+++ b/web/static/as_printable_html/as_printable_html.js
@@ -259,3 +259,13 @@ document.querySelectorAll(".toc-opener").forEach(button => {
 
   })
 })
+
+document.querySelectorAll('.reading-mode-exit').forEach(button => 
+  button.addEventListener('click', () => {
+    location.href = button.getAttribute('data-exit-url')
+  })
+)
+
+document.querySelector(`li.current-chapter`).scrollIntoView({
+  block: "center",
+})

--- a/web/static/as_printable_html/screen.css
+++ b/web/static/as_printable_html/screen.css
@@ -54,9 +54,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
   }
-  nav.toc .metadata-block a.back {
-    display: inline-flex;
-  }
+
   nav.toc .metadata-block a.metadata {
     flex-basis: 100%;
   }
@@ -76,6 +74,15 @@
     font-size: 120%;
     padding: 0;
     margin: 0;
+  }
+  nav.toc .metadata-block .authors {
+    margin-top: 1em;
+    display: block;
+  }
+  nav.toc .metadata-block .author {
+    font-size: 14px;
+    display: block;
+    line-height: 1.4em;
   }
   nav.toc > ol {
     padding: 0;
@@ -101,8 +108,6 @@
   nav.toc.closed :is(ol, h1) {
     display: none;  
   }
-  
-
   nav.toc.closed .metadata-block button {
     display: block;
     margin: 0;


### PR DESCRIPTION

Adjusts top of TOC to swap the exit/hide button order and change the exit button to be text-labeled. Puts each author on their own line:

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/19571/228335554-e7d87c23-3244-419d-84dc-fb89a9cdb881.png">

Makes the author font size slightly smaller and tightens the line height for the author block.

Changes the behavior of the chapter selector at the bottom to do the following:

* Always jump to the start of the chapter content instead of starting from the casebook title (same behavior as clicking on a chapter name in the TOC)
* Asks the browser to try to scroll the current chapter in the TOC into the viewport. For very long casebooks it can't quite do this because of the way the independently-scrolling divs work. It will do the right thing in most cases.
