### PR TITLE
Rewrite frontend of legal document search + add; fixes #1933

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Run these from inside the container.
 1. `pytest -n auto --dist loadgroup` runs python tests with concurrency (faster, same config as CI)
 1. `flake8` runs python lints
 1. `npm run test` runs javascript unit tests using [Mocha](https://mochajs.org)
+1. `npm run test-watch` runs javascript unit tests with the `--watch` option to auto-rerun on test changes
 1. `npm run lint` runs javascript lints
 1. `pytest -k functional` runs the Playwright tests only.
 

--- a/web/frontend/components/AddContent.vue
+++ b/web/frontend/components/AddContent.vue
@@ -23,12 +23,9 @@
         </div>
 
         <div class="add-resource-body" v-if="caseTab">
-          <case-searcher
-            v-model="caseQueryObj"
-            @choose="selectCase"
-          />
-          <case-results :queryObj="caseQueryObj" @choose="selectCase"/>
+          <legal-document-search :casebook="casebook" :section="section" @close="showModal = false"/>
         </div>
+        
         <div class="add-resource-body" v-else-if="textTab">
           <form ref="textForm" class="new-text" v-on:submit.stop.prevent="submitTextForm()">
 
@@ -95,8 +92,8 @@
 
 <script>
 import Modal from "./Modal";
-import CaseSearcher from "./CaseSearcher";
-import CaseResults from "./CaseResults";
+import LegalDocumentSearch from "./LegalDocumentSearch/LegalDocumentSearch";
+
 import Editor from "./TinyMCEEditor";
 
 
@@ -110,8 +107,7 @@ const { mapActions } = createNamespacedHelpers("case_search");
 export default {
   components: {
     Modal,
-    CaseSearcher,
-    CaseResults,
+    LegalDocumentSearch,
     editor: Editor
   },
   props: ["casebook", "section"],
@@ -170,11 +166,6 @@ export default {
       this.currentTab = newTab;
       tryFocus();
     },
-    runCaseSearch: function runCaseSearch() {
-      if (this.caseQuery !== "") {
-        this.fetch({ query: this.caseQuery });
-      }
-    },
     submitCaseForm: function submitCaseForm() {},
     submitTextForm: function submitTextForm() {
       let formData = new FormData(this.$refs.textForm);
@@ -196,18 +187,6 @@ export default {
         this.handleSubmitResponse,
         this.handleSubmitErrors
       );
-    },
-    selectCase: function(c) {
-      let importUrl = this.docImportUrl({sourceId: c.source_id});
-      let addUrl = this.docAddUrl({casebookId: this.casebook});
-      let formData = new FormData();
-      formData.append("section", this.section);
-      const handler = this.handleSubmitResponse;
-      this.pendingSubmit = true;
-      Axios.post(importUrl, { id: c.id }).then(resp => {
-          formData.append("resource_id", resp.data.id)
-          Axios.post(addUrl, formData).then(handler, this.handleSubmitErrors);
-      });
     },
     handleSubmitResponse: function handleSubmitResponse(response) {
       let location = response.request.responseURL;

--- a/web/frontend/components/CaseSearcher.vue
+++ b/web/frontend/components/CaseSearcher.vue
@@ -2,8 +2,8 @@
 <div class="search-results">
   <form class="case-search">
     <div class="form-control-group">
-      <label style="width:66%;">
-        {{searchLabel}}
+
+      <label class="case-search-input">
         <input
           id="case_search"
           ref="case_search"
@@ -15,10 +15,10 @@
           />
       </label>
       <input
-        style="margin-top:-4px;"
-        class="search-button btn btn-primary"
         type="submit"
-        value="Search"
+        class="search-button btn btn-primary"
+
+        :value="pendingSearch ? 'Searching...' : 'Search'" :disabled="pendingSearch"
         v-on:click.stop.prevent="runCaseSearch"
         />
 
@@ -87,7 +87,6 @@ import pp from "libs/text_outline_parser";
 import { createNamespacedHelpers } from "vuex";
 const { mapActions, mapGetters } = createNamespacedHelpers("case_search");
 
-
 const jurisdictions = [
   { val: "", name: "All jurisdictions" },
   { val: "ala", name: "Alabama" },
@@ -155,9 +154,10 @@ const jurisdictions = [
 ];
 
 export default {
-  props: ["value", "searchLabel"],
+  props: ["value"],
   data: () => ({
     jurisdictions,
+    pendingSearch: false,
     showingLimits: false,
     chosenSource: null,
     overrideSource: false
@@ -258,9 +258,7 @@ export default {
   },
   computed: {
     ...mapGetters(['getSources']),
-    displayedSearchLabel: function() {
-      return this.searchLabel || "";
-    },
+
     cleanQuery: function() {
       const data = this.cleaned(this.value);
       if (data.query) {
@@ -343,6 +341,14 @@ export default {
   justify-content: space-between;
   align-items: center;
   gap: 1em;
+    
+  .case-search-input {
+    flex-basis: 66%;
+    margin: 0;
+  }
+  input[type="submit"] {
+      margin: 0;
+  }
 
   .form-block {
     flex-basis: 100%;

--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -1,0 +1,71 @@
+<template>
+  <section>
+    <search-form @search-results="onSearchResults" />
+    <results-form
+      @add-doc="onAddDoc"
+      @reset-search="resetSearch"
+      @close="$emit('close')"
+      :search-results="results"
+      :added="added"
+      :selected-result="selectedResult"
+    />
+  </section>
+</template>
+
+<script>
+import SearchForm from "./SearchForm";
+import ResultsForm from "./ResultsForm";
+import url from "../../libs/urls";
+import { get_csrf_token } from "../../legacy/lib/helpers";
+
+const api = url.url("legal_document_resource_view");
+
+export default {
+  props: {
+    casebook: String,
+    section: String,
+  },
+  components: {
+    SearchForm,
+    ResultsForm,
+  },
+  data: () => ({
+    results: undefined,
+    added: undefined,
+    selectedResult: undefined,
+  }),
+  methods: {
+    resetSearch: function () {
+      this.results = undefined;
+      this.added = undefined;
+      this.selectedResult = undefined;
+    },
+    onSearchResults: function (res) {
+      this.resetSearch();
+      this.results = res;
+    },
+    onAddDoc: async function (sourceRef, sourceId) {
+      this.added = undefined;
+      this.selectedResult = sourceRef.toString();
+      const resp = await fetch(api({ casebookId: this.casebook }), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": get_csrf_token(),
+        },
+        body: JSON.stringify({
+          source_id: sourceId,
+          source_ref: sourceRef,
+          section_id: this.section,
+        }),
+      });
+      const body = await resp.json();
+      this.added = {
+        resourceId: body.resource_id,
+        redirectUrl: body.redirect_url,
+        sourceRef,
+      };
+    },
+  },
+};
+</script>

--- a/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
@@ -1,0 +1,168 @@
+<template>
+  <section>
+  <ol :class="selectedResult ? 'adding' : ''">
+    <li v-if="sorted.length > 0" class="labels">
+      <span class="name">Case</span>
+      <span class="cite">Citation</span>
+      <span class="date">Effective date</span>
+      <span class="source">Source</span>
+    </li>
+    <li
+      v-for="r in sorted"
+      @click="(e) => add(e.target.closest('li'), r.id, r.sourceId)"
+      @keyup.enter="(e) => add(e.target.closest('li'), r.id, r.sourceId)"
+      :data-result-selected="r.id === selectedResult"
+      :data-result-added="added && r.id === added.sourceRef"
+      :key="r.id"
+      class="results-entry"
+      role="button"
+      tabindex="0"
+    >
+      <span class="name" :title="r.fullName">{{ r.shortName }}</span>
+      <span class="cite" :title="r.fullCitations">{{ r.shortCitations }}</span>
+      <span class="date">{{ r.effectiveDate }}</span>
+      <span class="source">
+        <a v-if="r.url" target="_blank" title="Open on external site" :href="r.url"
+          >{{ r.name }}</a
+        >
+        <span v-else>{{ r.name }}</span>
+      </span>
+      <span class="added-message" v-if="added && r.id === added.sourceRef">
+        <span class="success-message"
+          >This document has been added to your casebook.</span
+        >
+        <button class="btn btn-primary" @click="edit">Edit document</button>
+        <button class="btn btn-default" @click="$emit('reset-search')">New search</button>
+        <button class="btn btn-default btn-close" @click="$emit('close')">Close</button>
+      </span>
+    </li>
+  </ol>
+  <p v-if="Array.isArray(searchResults) && searchResults.length === 0">
+    No legal documents were found matching your search.
+  </p>
+  </section>
+</template>
+
+<script>
+export default {
+  props: {
+    searchResults: Array,
+    selectedResult: String,
+    added: Object,
+  },
+  data: () => ({
+    adding: false,
+  }),
+  computed: {
+     sorted() {     
+      return [...this.searchResults || []].sort((a, b) => a.sourceOrder - b.sourceOrder)
+     }
+  },
+  methods: {
+    edit: function () {
+      location.href = this.added.redirectUrl;
+    },
+    add: function (row, id, sourceId) {
+      if (row.getAttribute("disabled")) {
+        return;
+      }
+      row.classList.toggle("adding");
+      this.$emit("add-doc", id, sourceId);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+ol {
+  padding: 0;
+  list-style-type: none;
+  font-size: 16px;
+
+  li:first-of-type {
+    font-weight: bold;
+
+    &:hover,
+    &:focus-within {
+      background: none;
+    }
+  }
+
+  li + li {
+    border-top: 0.5px solid rgb(149, 149, 149);
+  }
+  &.adding {
+    li:not([data-result-selected]):not(.labels) {
+      display: none;
+    }
+
+    li:hover,
+    li:focus-within {
+      background: inherit;
+    }
+    li[data-result-selected] {
+      background: hsl(43, 94%, 80%);
+      cursor: wait;
+    }
+    li[data-result-added] {
+      background: initial;
+      cursor: auto;
+    }
+  }
+
+  li {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 0.5em;
+    gap: 0.5em;
+
+    &:hover,
+    &:focus-within {
+      background: hsl(43, 94%, 80%);
+    }
+    .name {
+      flex-basis: 40%;
+    }
+
+    .cite {
+      flex-basis: 30%;
+    }
+
+    .date {
+      flex-basis: 10ch;
+      flex-grow: 1;
+    }
+    .source {
+      flex-grow: 1;
+    }
+    .added-message {
+      margin-top: 2em;
+      flex-basis: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1em;
+      justify-content: space-between;
+      .success-message {
+        flex-basis: 100%;
+      }
+      button {
+        width: 30%;
+
+        &.btn-close {
+          background: gray;
+        }
+      }
+    }
+    a {
+      text-decoration: underline !important;
+      text-underline-offset: 4px;
+    }
+    a[href^="http"]:after {
+      content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+      margin: 0 0 0 0.5em;
+    }
+  }
+}
+</style>

--- a/web/frontend/components/LegalDocumentSearch/SearchForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/SearchForm.vue
@@ -1,0 +1,295 @@
+<template>
+  <form class="form-group case-search" @submit.prevent="search">
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Search for a case or section of federal code"
+      ref="queryText"
+      v-model="query"
+    />
+    <input
+      type="submit"
+      class="save-button"
+      :value="pending ? 'Searching...' : 'Search'"
+      :disabled="pending"
+    />
+
+    <button
+      class="advanced-search-toggle"
+      type="button"
+      @click.prevent="toggleAdvanced"
+    >
+      <span v-if="showAdvanced">Basic search</span>
+      <span v-else>Advanced search</span>
+    </button>
+
+    <fieldset v-if="showAdvanced" class="advanced-search">
+      <label>
+        Source:
+        <select class="form-control" v-model="source">
+          <option :value="undefined">All sources</option>
+          <option
+            v-for="source in getSources"
+            :value="source.id"
+            :key="source.id"
+          >
+            {{ source.name }}
+          </option>
+        </select>
+      </label>
+      <label>
+        Jurisdiction:
+        <select class="form-control" v-model="jurisdiction" name="jurisdiction">
+          <option :value="undefined">All jurisdictions</option>
+          <option v-for="j in jurisdictions" :value="j.val" :key="j.val">
+            {{ j.name }}
+          </option>
+        </select>
+      </label>
+      <label>
+        Decision Date
+        <fieldset>
+          <input
+            name="after_date"
+            type="date"
+            class="form-control"
+            placeholder="YYYY-MM-DD"
+            v-model="after_date"
+          />
+          <span> - </span>
+          <input
+            name="before_date"
+            type="date"
+            class="form-control"
+            placeholder="YYYY-MM-DD"
+            v-model="before_date"
+          />
+        </fieldset>
+      </label>
+      <p v-for="s in getSources" :key="s.id" class="source-description" :data-source-selected="source === s.id">
+        {{ s.long_description }}
+      </p>
+    </fieldset>
+  </form>
+</template>
+
+<script>
+import url from "../../libs/urls";
+import { createNamespacedHelpers } from "vuex";
+
+const { mapGetters } = createNamespacedHelpers("case_search");
+const api = url.url("search_using");
+
+export default {
+  data: () => ({
+    pending: false,
+    query: "",
+    jurisdictions: [
+      { val: "ala", name: "Alabama" },
+      { val: "alaska", name: "Alaska" },
+      { val: "am-samoa", name: "American Samoa" },
+      { val: "ariz", name: "Arizona" },
+      { val: "ark", name: "Arkansas" },
+      { val: "cal", name: "California" },
+      { val: "colo", name: "Colorado" },
+      { val: "conn", name: "Connecticut" },
+      { val: "dakota-territory", name: "Dakota Territory" },
+      { val: "dc", name: "District of Columbia" },
+      { val: "del", name: "Delaware" },
+      { val: "fla", name: "Florida" },
+      { val: "ga", name: "Georgia" },
+      { val: "guam", name: "Guam" },
+      { val: "haw", name: "Hawaii" },
+      { val: "idaho", name: "Idaho" },
+      { val: "ill", name: "Illinois" },
+      { val: "ind", name: "Indiana" },
+      { val: "iowa", name: "Iowa" },
+      { val: "kan", name: "Kansas" },
+      { val: "ky", name: "Kentucky" },
+      { val: "la", name: "Louisiana" },
+      { val: "mass", name: "Massachusetts" },
+      { val: "md", name: "Maryland" },
+      { val: "me", name: "Maine" },
+      { val: "mich", name: "Michigan" },
+      { val: "minn", name: "Minnesota" },
+      { val: "miss", name: "Mississippi" },
+      { val: "mo", name: "Missouri" },
+      { val: "mont", name: "Montana" },
+      { val: "native-american", name: "Native American" },
+      { val: "navajo-nation", name: "Navajo Nation" },
+      { val: "nc", name: "North Carolina" },
+      { val: "nd", name: "North Dakota" },
+      { val: "neb", name: "Nebraska" },
+      { val: "nev", name: "Nevada" },
+      { val: "nh", name: "New Hampshire" },
+      { val: "nj", name: "New Jersey" },
+      { val: "nm", name: "New Mexico" },
+      { val: "n-mar-i", name: "Northern Mariana Islands" },
+      { val: "ny", name: "New York" },
+      { val: "ohio", name: "Ohio" },
+      { val: "okla", name: "Oklahoma" },
+      { val: "or", name: "Oregon" },
+      { val: "pa", name: "Pennsylvania" },
+      { val: "pr", name: "Puerto Rico" },
+      { val: "ri", name: "Rhode Island" },
+      { val: "sc", name: "South Carolina" },
+      { val: "sd", name: "South Dakota" },
+      { val: "tenn", name: "Tennessee" },
+      { val: "tex", name: "Texas" },
+      { val: "tribal", name: "Tribal jurisdictions" },
+      { val: "uk", name: "United Kingdom" },
+      { val: "us", name: "United States" },
+      { val: "utah", name: "Utah" },
+      { val: "va", name: "Virginia" },
+      { val: "vi", name: "Virgin Islands" },
+      { val: "vt", name: "Vermont" },
+      { val: "wash", name: "Washington" },
+      { val: "wis", name: "Wisconsin" },
+      { val: "w-va", name: "West Virginia" },
+      { val: "wyo", name: "Wyoming" },
+    ],
+    showAdvanced: false,
+    jurisdiction: undefined,
+    before_date: undefined,
+    after_date: undefined,
+    source: undefined,
+  }),
+  computed: {
+    ...mapGetters(["getSources"]),
+  },
+  mounted() {
+    this.$refs.queryText.focus();
+  },
+  methods: {
+    search: async function () {
+      if (!this.query) {
+        return;
+      }
+
+      this.pending = true;
+      const sources = [];
+      const sourceDetail = this.getSources.filter((s) =>
+        this.source ? s.id === this.source : true
+      );
+
+      let order = 0; // Sources will come back ordered in "priority order", which we want to retain
+      for (const { id, name } of sourceDetail) {
+        const url =
+          api({ sourceId: id }) +
+          "?" +
+          new URLSearchParams({
+            q: this.query,
+            jurisdiction: this.jurisdiction || "",
+            before_date: this.before_date || "",
+            after_date: this.after_date || "",
+          });
+        sources.push({ url, id, name, order });
+        order += 1;
+      }
+      const searchResults = await Promise.all(
+        sources.map(async (source) => {
+          const { url, id, name, order } = source;
+          return fetch(url)
+            .then((r) => r.json())
+            .then((r) => {
+              const { results } = r;
+              return results.map((row) => {
+                row.id = row.id.toString(); // normalize IDs from the API to strings
+                return {
+                  name,
+                  sourceId: id,
+                  sourceOrder: order,
+                  ...row,
+                };
+              });
+            });
+        })
+      );
+      this.pending = false;
+      this.$emit("search-results", searchResults.flat());
+    },
+    toggleAdvanced: function () {
+      this.showAdvanced = !this.showAdvanced;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+form {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 30px auto 30px 0 !important;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1em;
+
+  input {
+    margin: 0 !important;
+    height: 52px;
+  }
+  input[type="text"] {
+    flex-basis: 66%;
+  }
+  button.advanced-search-toggle {
+    background: none;
+    border: none;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    padding: 0;
+  }
+
+  button.advanced-search-toggle {
+    background: none;
+    border: none;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    padding: 0;
+    flex-basis: 100%;
+    text-align: left;
+  }
+  .advanced-search {
+    display: flex;
+    gap: 1em;
+    flex-wrap: wrap;
+    margin: 1em 0;
+    flex-basis: 100%;
+
+    label {
+      width: 100%;
+      line-height: 2em;
+
+      & * {
+        font-weight: normal;
+      }
+      select {
+        padding-left: 0.5em;
+      }
+    }
+    & > label {
+      flex-basis: 24%;
+    }
+    & > label:last-of-type {
+      flex-basis: 48%;
+      fieldset {
+        display: flex;
+        gap: 1em;
+        align-items: center;
+        justify-content: center;
+        input {
+          padding: 3px;
+          text-indent: 10px;
+        }
+      }
+    }
+
+    p.source-description {
+      flex-basis: 100%;
+      display: none;
+    }
+    p.source-description[data-source-selected] {
+      display: block;
+    }
+  }
+}
+</style>

--- a/web/frontend/pages/vue_app.js
+++ b/web/frontend/pages/vue_app.js
@@ -9,6 +9,7 @@ import AuditButton from "../components/AuditButton";
 import Dashboard from "../components/Dashboard";
 import ExportButton from "../components/ExportButton";
 import Globals from "../components/Globals";
+import LegalDocumentSearch from "../components/LegalDocumentSearch/LegalDocumentSearch";
 import PortalVue from "portal-vue";
 import QuickAdd from "../components/QuickAdd";
 import SectionCloner from "../components/SectionCloner";
@@ -50,18 +51,18 @@ document.addEventListener("DOMContentLoaded", () => {
     store,
     router,
     components: {
-        TheResource,
-        SectionCloner,
-        TakeNotesCloner,
         AddContent,
-        TheTableOfContents,
-        PortalVue,
-        QuickAdd,
-        Globals,
         AuditButton,
         Dashboard,
-        ExportButton
-
+        ExportButton,
+        Globals,
+        LegalDocumentSearch,
+        PortalVue,
+        QuickAdd,
+        SectionCloner,
+        TakeNotesCloner,
+        TheResource,
+        TheTableOfContents,
     }
   });
   if (window.sentry.USE_SENTRY) {

--- a/web/frontend/test/components/SearchForm.test.js
+++ b/web/frontend/test/components/SearchForm.test.js
@@ -1,0 +1,58 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+import SearchForm from "@/components/LegalDocumentSearch/SearchForm";
+import Vuex from "vuex";
+import sinon from "sinon";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe("SearchForm", () => {
+  let store;
+
+  beforeEach(() => {
+    const resp = {
+      json: sinon.fake.resolves({
+        results: [{ id: "fake-id1" }, { id: "fake-id2" }],
+      }),
+    };
+    global.fetch = sinon.fake.resolves(resp);
+
+    store = new Vuex.Store({
+      modules: {
+        case_search: {
+          getters: {
+            getSources: () => [
+              { url: "url1", name: "name1", id: "source-id1", order: 1 },
+              { url: "url2", name: "name2", id: "source-id2", order: 2 },
+            ],
+          },
+          namespaced: true,
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    global.fetch = undefined;
+  });
+
+  it("allows toggling the advanced search fields", async () => {
+    const wrapper = mount(SearchForm, { store, localVue });
+
+    const button = wrapper.find("button.advanced-search-toggle");
+    expect(button.text()).toContain("Advanced search");
+    expect(wrapper.find('input[type="date"]').exists()).toBe(false);
+    await button.trigger("click");
+    expect(button.text()).toContain("Basic search");
+    expect(wrapper.find('input[type="date"]').exists()).toBe(true);
+  });
+
+  it("triggers the results event when submitted", async () => {
+    const wrapper = mount(SearchForm, { store, localVue });
+    wrapper.find('input[type="text"]').setValue("test");
+    wrapper.find("form").trigger("submit");
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(wrapper.emitted()["search-results"].length).toBe(1); // Called once
+    // Expect 4 search results, 2 for each source
+    expect(wrapper.emitted()["search-results"][0][0].length).toBe(4); 
+  });
+});

--- a/web/frontend/test/mocha_setup.js
+++ b/web/frontend/test/mocha_setup.js
@@ -5,3 +5,4 @@ global.DOMParser = window.DOMParser;
 
 // https://github.com/vuejs/vue-test-utils/issues/936#issuecomment-415386167
 window.Date = Date;
+global.FRONTEND_URLS = {'search_sources': [], "search_using": []};

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -986,7 +986,7 @@ class LegalDocumentResourceView(APIView):
     @method_decorator(no_perms_test)
     @method_decorator(user_has_perm("casebook", "directly_editable_by"))
     @method_decorator(requires_csrf_token)
-    def post(self, request: Request, casebook: Casebook):
+    def post(self, request: Request, casebook: Casebook, **kwargs):
         """Given a legal document source ref, attempt to import the document if it doesn't exist or is too old, then
         create a corresponding resource in the given casebook"""
         source_id = request.data.get("source_id")

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,7 +41,6 @@
         "mixin-deep": "^1.3.2",
         "moment": "^2.24.0",
         "morphdom": "^2.3.2",
-        "pagedjs": "^0.4.0",
         "path-complete-extname": "^0.1.0",
         "portal-vue": "^2.1.7",
         "query-string": "^4.3.4",
@@ -76,7 +75,7 @@
         "null-loader": "^3.0.0",
         "sass": "^1.23.7",
         "sass-loader": "^8.0.0",
-        "sinon": "^7.3.2",
+        "sinon": "^15.0.3",
         "tinymce": "^5.10.2",
         "vue-loader": "^15.6.2",
         "vue-template-compiler": "^2.6.10",
@@ -1563,6 +1562,7 @@
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
       "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
+      "dev": true,
       "dependencies": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1573,6 +1573,7 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/@babel/preset-env": {
@@ -1683,6 +1684,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2152,39 +2154,56 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@soda/friendly-errors-webpack-plugin": {
@@ -3691,12 +3710,6 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
-    },
     "node_modules/array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -5012,11 +5025,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/clear-cut": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
-      "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg=="
     },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
@@ -7621,15 +7629,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/event-pubsub": {
@@ -10770,6 +10769,12 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -10852,12 +10857,6 @@
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
-    },
-    "node_modules/lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
     },
     "node_modules/loupe": {
       "version": "2.3.4",
@@ -12454,32 +12453,32 @@
       "dev": true
     },
     "node_modules/nise": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/nise/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
-    },
-    "node_modules/nise/node_modules/lolex": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
     },
     "node_modules/nise/node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -13131,43 +13130,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pagedjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0.tgz",
-      "integrity": "sha512-AkcG5W/O2sB/uVtfiIvl+ESyalHjecDLiOy1zJVOJIeUBRz+theiL2GHyeMTkgQHs76CGrt9w8vzsoaVKsC0Lw==",
-      "dependencies": {
-        "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.17.8",
-        "clear-cut": "^2.0.2",
-        "css-tree": "^1.1.3",
-        "event-emitter": "^0.3.5"
-      }
-    },
-    "node_modules/pagedjs/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/pagedjs/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
-    },
-    "node_modules/pagedjs/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pako": {
@@ -14543,7 +14505,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -15452,18 +15415,51 @@
       "dev": true
     },
     "node_modules/sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.3.tgz",
+      "integrity": "sha512-si3geiRkeovP7Iel2O+qGL4NrO9vbMf3KsrJEi0ghP1l5aBkB5UxARea5j0FUsSqH3HLBh0dQPAyQ8fObRUqHw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -19534,6 +19530,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -19542,7 +19539,8 @@
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
         }
       }
     },
@@ -19645,6 +19643,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -20012,39 +20011,60 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/commons": "^2.0.0"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
       }
     },
     "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@soda/friendly-errors-webpack-plugin": {
@@ -21299,12 +21319,6 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -22400,11 +22414,6 @@
           "dev": true
         }
       }
-    },
-    "clear-cut": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
-      "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg=="
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -24504,15 +24513,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
     },
     "event-pubsub": {
       "version": "4.3.0",
@@ -26969,6 +26969,12 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -27040,12 +27046,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
       "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
-      "dev": true
-    },
-    "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "loupe": {
@@ -28349,32 +28349,32 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       },
       "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
           "dev": true
-        },
-        "lolex": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
         },
         "path-to-regexp": {
           "version": "1.8.0",
@@ -28890,39 +28890,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
-    },
-    "pagedjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.0.tgz",
-      "integrity": "sha512-AkcG5W/O2sB/uVtfiIvl+ESyalHjecDLiOy1zJVOJIeUBRz+theiL2GHyeMTkgQHs76CGrt9w8vzsoaVKsC0Lw==",
-      "requires": {
-        "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.17.8",
-        "clear-cut": "^2.0.2",
-        "css-tree": "^1.1.3",
-        "event-emitter": "^0.3.5"
-      },
-      "dependencies": {
-        "css-tree": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-          "requires": {
-            "mdn-data": "2.0.14",
-            "source-map": "^0.6.1"
-          }
-        },
-        "mdn-data": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
     },
     "pako": {
       "version": "1.0.11",
@@ -30093,7 +30060,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -30787,18 +30755,40 @@
       }
     },
     "sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.3.tgz",
+      "integrity": "sha512-si3geiRkeovP7Iel2O+qGL4NrO9vbMf3KsrJEi0ghP1l5aBkB5UxARea5j0FUsSqH3HLBh0dQPAyQ8fObRUqHw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "slash": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit --require frontend/test/mocha_setup.js frontend/test/**/*.test.js",
+    "test-watch": "vue-cli-service test:unit --require frontend/test/mocha_setup.js frontend/test/**/*.test.js --watch",
     "lint": "vue-cli-service lint frontend/"
   },
   "dependencies": {
@@ -76,7 +77,7 @@
     "null-loader": "^3.0.0",
     "sass": "^1.23.7",
     "sass-loader": "^8.0.0",
-    "sinon": "^7.3.2",
+    "sinon": "^15.0.3",
     "tinymce": "^5.10.2",
     "vue-loader": "^15.6.2",
     "vue-template-compiler": "^2.6.10",


### PR DESCRIPTION
This is the frontend half of #1956 to complete #1933. 

There are two places in the code where users can add legal documents—from the "Add Content" button on the right, and from the "Quick Add" field in the table of contents. This is intended to replace both, ultimately, but this PR only includes the "Add Content" functionality.

Some of this code is duplicative of the existing legal doc flow. The final PR will make this work net-negative in terms of lines of code, but for now this is mostly additive.

This is a fairly big PR but the work was hard to roll out incrementally since it replaces a feature already there.

The UI looks very similar to before, with changes that are designed to aid readability and bring these results more in line with the presentation of the casebook search results.

## Before 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/19571/229216897-cf268695-4085-46ea-bde6-fc81759d5f6a.png">


## After 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/19571/229216865-b1c0b9af-3670-4489-9e01-03ec066f4586.png">

The most substantive UI change happens after a case is selected. Previously the page would do a full refresh and take them to the edit-resource page without any notification of what occurred (the legal doc was added to their casebook at the end or in the current section).

Now when they select a search result, they are notified about what happened and prompted to make a choice about what to do next:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/19571/229217849-a60e0c77-5f5d-40fe-ab7d-fc221e14f044.png">



## Full changelist

* The new code does not make use of the Vuex store. It does all its rendering and event bus management within the scope of the container, search form, and results components. The round-trip to the store seems to cause a lot of browser instability and may have been a source of the performance bottlenecks @cath9 was experiencing when demoing over Zoom. Since the search information is confined to these parent/child relationships, there's no need to use a store.
* This makes use of the new endpoint from #1956 to handle the addition of the legal doc in one HTTP request rather than 2 serial ones.
* When querying multiple sources (the default behavior), the existing code runs the queries serially. This runs them in parallel and waits for both to resolve (h/t @matteocargnelutti). 
* Supports full keyboard navigation, including result selection.
* For results without external links (see #1959), omits the hyperlink and external link icon.
* Avoids use of backwards-facing shims in favor of markup and APIs that are now solidly browser-native (a function of the time elapsed since this was first written). Specifically:
  * Uses `fetch()` rather than `Axios` (and since it uses a new API endpoint, it avoids any of the monkeypatching to handle Rails-compatible REST behavior)
  * Uses only the native `date` input rather than adding a shim
  * Uses flex rather than tabular layout for results
  * Includes only semantic markup (no divs!)
  * Uses `URLSearchParams` rather than a custom function

## TODO

There's explicitly no exception handling on the fetch requests right now. They should recover if the backend errors so the UI doesn't freeze, but still report up to Sentry. I'd like to research how best to do this.

There are unit tests for only one component. There should be some coverage for all three. (IMO this work is better suited for unit tests + mocks than Playwright tests, which would require a lot of backend fixtures when the backend is already covered by Python tests.)

I'd like to put this branch up on staging for some human testing before even considering merging, given the size of the PR.
