### PR TITLE
Prevent multiple resubmits of result selection in legal-doc add flow; fix #1964

### DIFF
--- a/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
@@ -63,7 +63,7 @@ export default {
       location.href = this.added.redirectUrl;
     },
     add: function (row, id, sourceId) {
-      if (row.getAttribute("disabled")) {
+      if (this.selectedResult) {
         return;
       }
       row.classList.toggle("adding");


### PR DESCRIPTION
I anticipated that multiple clicks could happen here but was relying on the presence or absence of the `disabled` attribute on the clickable element, in an earlier UI where non-selected results remained on-screen but greyed out. Later we decided to hide all non-selected results so I removed the `disabled` attribute, but that left this check orphaned.

This updates the check to more directly reflect whether a search result has been clicked.

(I'll add test coverage for this as part of #1966)