### PR TITLE
Clear search form when new search is selected; fixes #1972

### DIFF
--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <search-form @search-results="onSearchResults" />
+    <search-form @search-results="onSearchResults" :toggle-reset="toggleReset" />
     <results-form
       @add-doc="onAddDoc"
       @reset-search="resetSearch"
@@ -35,6 +35,7 @@ export default {
     results: undefined,
     added: undefined,
     selectedResult: undefined,
+    toggleReset: false
   }),
   methods: {
     ...mapActions(["fetch"]),
@@ -43,6 +44,7 @@ export default {
       this.results = undefined;
       this.added = undefined;
       this.selectedResult = undefined;
+      this.toggleReset = !this.toggleReset;
     },
     onSearchResults: function (res) {
       this.resetSearch();

--- a/web/frontend/components/LegalDocumentSearch/SearchForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/SearchForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="form-group case-search" @submit.prevent="search">
+  <form class="form-group case-search" ref="form" @submit.prevent="search">
     <input
       type="text"
       class="form-control"
@@ -81,6 +81,9 @@ const { mapGetters } = createNamespacedHelpers("case_search");
 const api = url.url("search_using");
 
 export default {
+  props: {
+    toggleReset: Boolean
+  },
   data: () => ({
     pending: false,
     query: "",
@@ -159,6 +162,11 @@ export default {
   },
   mounted() {
     this.$refs.queryText.focus();
+  },
+  watch: {
+    toggleReset: function() {
+      this.$refs.form.reset()
+    }
   },
   methods: {
     search: async function () {


### PR DESCRIPTION
This calls `reset()` on the form when the `reset-form` event is emitted, as when the user clicks the "New Search" button. This clears the text field for a different search query.


