### PR TITLE
Refactor Quick Add to require fewer clicks and reduce boilerplate

### DIFF
--- a/web/frontend/components/LegalDocumentSearch/AdvancedSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/AdvancedSearch.vue
@@ -1,0 +1,126 @@
+<template>
+  <fieldset class="advanced-search">
+    <label>
+      Source:
+      <select class="form-control" v-model="formData.source">
+        <option :value="undefined">All sources</option>
+        <option v-for="source in sources" :value="source.id" :key="source.id">
+          {{ source.name }}
+        </option>
+      </select>
+    </label>
+    <label>
+      Jurisdiction:
+      <select
+        class="form-control"
+        v-model="formData.jurisdiction"
+        name="jurisdiction"
+      >
+        <option :value="undefined">All jurisdictions</option>
+        <option v-for="j in jurisdictions" :value="j.val" :key="j.val">
+          {{ j.name }}
+        </option>
+      </select>
+    </label>
+    <label>
+      Decision Date
+      <fieldset>
+        <input
+          v-model="formData.afterDate"
+          name="after_date"
+          type="date"
+          class="form-control"
+          placeholder="YYYY-MM-DD"
+        />
+        <span> - </span>
+        <input
+          v-model="formData.beforeDate"
+          name="before_date"
+          type="date"
+          class="form-control"
+          placeholder="YYYY-MM-DD"
+        />
+      </fieldset>
+    </label>
+    <p
+      v-for="s in sources"
+      :key="s.id"
+      :data-source-selected="formData.source === s.id"
+      class="source-description"
+    >
+      {{ s.long_description }}
+    </p>
+  </fieldset>
+</template>
+
+<script>
+import { jurisdictions } from "../../libs/legal_document_search";
+
+export default {
+  props: {
+    sources: {
+      type: Array,
+    },
+    formData: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: () => ({
+    jurisdictions,
+  }),
+  watch: {
+    formData() {
+      this.$emit("update", this.formData);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scope>
+.advanced-search {
+  display: flex;
+  gap: 1em;
+  flex-wrap: wrap;
+  margin: 1em 0;
+  flex-basis: 100%;
+
+  label {
+    width: 100%;
+    line-height: 2em;
+
+    & * {
+      font-weight: normal;
+    }
+    select {
+      padding-left: 0.5em;
+    }
+  }
+  & > label {
+    flex-basis: 24%;
+  }
+  & > label:last-of-type {
+    flex-basis: 48%;
+    fieldset {
+      display: flex;
+      gap: 1em;
+      align-items: center;
+      justify-content: center;
+      input {
+        padding: 3px;
+        text-indent: 10px;
+      }
+    }
+  }
+  .form-control {
+    font-size: 16px;
+  }
+  p.source-description {
+    flex-basis: 100%;
+    display: none;
+  }
+  p.source-description[data-source-selected] {
+    display: block;
+  }
+}
+</style>

--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -15,11 +15,9 @@
 <script>
 import SearchForm from "./SearchForm";
 import ResultsForm from "./ResultsForm";
-import url from "../../libs/urls";
-import { get_csrf_token } from "../../legacy/lib/helpers";
 import { createNamespacedHelpers } from "vuex";
+import { add } from "../../libs/legal_document_search";
 
-const api = url.url("legal_document_resource_view");
 const { mapActions } = createNamespacedHelpers("table_of_contents");
 
 export default {
@@ -53,24 +51,7 @@ export default {
     onAddDoc: async function (sourceRef, sourceId) {
       this.added = undefined;
       this.selectedResult = sourceRef.toString();
-      const resp = await fetch(api({ casebookId: this.casebook }), {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": get_csrf_token(),
-        },
-        body: JSON.stringify({
-          source_id: sourceId,
-          source_ref: sourceRef,
-          section_id: this.section,
-        }),
-      });
-      const body = await resp.json();
-      this.added = {
-        resourceId: body.resource_id,
-        redirectUrl: body.redirect_url,
-        sourceRef,
-      };
+      this.added = await add(this.casebook, this.section, sourceRef, sourceId)
       this.fetch({ casebook: this.casebook, subsection: this.section });
     },
   },

--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -45,7 +45,6 @@ export default {
       this.toggleReset = !this.toggleReset;
     },
     onSearchResults: function (res) {
-      this.resetSearch();
       this.results = res;
     },
     onAddDoc: async function (sourceRef, sourceId) {

--- a/web/frontend/components/LegalDocumentSearch/SearchForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/SearchForm.vue
@@ -15,7 +15,7 @@
     />
 
     <button
-      @click.prevent="toggleAdvanced"    
+      @click.prevent="showAdvanced = !showAdvanced"
       class="advanced-search-toggle"
       type="button"
     >
@@ -23,80 +23,37 @@
       <span v-else>Advanced search</span>
     </button>
 
-    <fieldset v-if="showAdvanced" class="advanced-search">
-      <label>
-        Source:
-        <select class="form-control" v-model="source">
-          <option :value="undefined">All sources</option>
-          <option
-            v-for="source in getSources"
-            :value="source.id"
-            :key="source.id"
-          >
-            {{ source.name }}
-          </option>
-        </select>
-      </label>
-      <label>
-        Jurisdiction:
-        <select class="form-control" v-model="jurisdiction" name="jurisdiction">
-          <option :value="undefined">All jurisdictions</option>
-          <option v-for="j in jurisdictions" :value="j.val" :key="j.val">
-            {{ j.name }}
-          </option>
-        </select>
-      </label>
-      <label>
-        Decision Date
-        <fieldset>
-          <input
-            v-model="after_date"
-            name="after_date"
-            type="date"
-            class="form-control"
-            placeholder="YYYY-MM-DD"
-          />
-          <span> - </span>
-          <input
-            v-model="before_date"          
-            name="before_date"
-            type="date"
-            class="form-control"
-            placeholder="YYYY-MM-DD"
-          />
-        </fieldset>
-      </label>
-      <p
-        v-for="s in getSources"
-        :key="s.id"
-        :data-source-selected="source === s.id"
-        class="source-description"
-      >
-        {{ s.long_description }}
-      </p>
-    </fieldset>
+    <advanced-search
+      v-if="showAdvanced"
+      @update="(searchData) => (advancedSearch = searchData)"
+      :sources="getSources"
+      :form-data="advancedSearch"
+    ></advanced-search>
   </form>
 </template>
 
 <script>
 import { createNamespacedHelpers } from "vuex";
-import { search, jurisdictions } from "../../libs/legal_document_search";
+import { search } from "../../libs/legal_document_search";
+import AdvancedSearch from "./AdvancedSearch.vue";
 
 const { mapGetters } = createNamespacedHelpers("case_search");
 
 export default {
+  components: { AdvancedSearch },
   props: {
-    toggleReset: Boolean
+    toggleReset: Boolean,
   },
   data: () => ({
     pending: false,
     query: "",
-    jurisdictions,
     showAdvanced: false,
-    jurisdiction: undefined,
-    before_date: undefined,
-    after_date: undefined,
-    source: undefined,
+    advancedSearch: {
+      jurisdiction: undefined,
+      beforeDate: undefined,
+      afterDate: undefined,
+      source: undefined,
+    },
   }),
   computed: {
     ...mapGetters(["getSources"]),
@@ -106,7 +63,10 @@ export default {
   },
   watch: {
     toggleReset: function () {
-      this.$refs.form.reset();
+      this.query = "";
+      Object.keys(this.advancedSearch).forEach(
+        (k) => (this.advancedSearch[k] = undefined)
+      );
     },
   },
   methods: {
@@ -115,23 +75,20 @@ export default {
         return;
       }
       this.pending = true;
-
       const searchResults = await search(
         this.query,
         this.getSources,
-        this.source,
-        this.jurisdiction,
-        this.before_date,
-        this.after_date
+        this.advancedSearch.source,
+        this.advancedSearch.jurisdiction,
+        this.advancedSearch.beforeDate,
+        this.advancedSearch.afterDate
       );
 
       this.pending = false;
-      
+
       this.$emit("search-results", searchResults.flat());
     },
-    toggleAdvanced: function () {
-      this.showAdvanced = !this.showAdvanced;
-    },
+
   },
 };
 </script>
@@ -158,59 +115,8 @@ form {
     text-decoration: underline;
     text-underline-offset: 4px;
     padding: 0;
-  }
-
-  button.advanced-search-toggle {
-    background: none;
-    border: none;
-    text-decoration: underline;
-    text-underline-offset: 4px;
-    padding: 0;
     flex-basis: 100%;
     text-align: left;
-  }
-  .advanced-search {
-    display: flex;
-    gap: 1em;
-    flex-wrap: wrap;
-    margin: 1em 0;
-    flex-basis: 100%;
-
-    label {
-      width: 100%;
-      line-height: 2em;
-
-      & * {
-        font-weight: normal;
-      }
-      select {
-        padding-left: 0.5em;
-      }
-    }
-    & > label {
-      flex-basis: 24%;
-    }
-    & > label:last-of-type {
-      flex-basis: 48%;
-      fieldset {
-        display: flex;
-        gap: 1em;
-        align-items: center;
-        justify-content: center;
-        input {
-          padding: 3px;
-          text-indent: 10px;
-        }
-      }
-    }
-
-    p.source-description {
-      flex-basis: 100%;
-      display: none;
-    }
-    p.source-description[data-source-selected] {
-      display: block;
-    }
   }
 }
 </style>

--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -1,27 +1,18 @@
 <template>
   <div>
-    <h3>
-      {{ resourceInfo.description }}, or select a different option from the
-      dropdown for other types of content to add.
-    </h3>
-
     <form @submit.stop.prevent="handleSubmit" class="form-control-group">
+      <h3>
+        Add an individual resource or a list of items by pasting them into the
+        field below.
+      </h3>
+
       <input
         @paste.prevent.stop="handlePaste"
         v-model="title"
         type="text"
         class="form-control"
-        placeholder="Enter case, heading, link, or outline here"
+        placeholder="'Chapter 1' or 'http://example.com' or 'John v. Smith'"
       />
-      <select v-model="resourceInfo" class="resource-type form-control">
-        <option
-          v-for="option in resourceInfoOptions"
-          :key="option.name"
-          :value="option.value"
-        >
-          {{ option.name }}
-        </option>
-      </select>
 
       <input
         @submit="handleSubmit"
@@ -29,6 +20,31 @@
         type="submit"
         class="form-control btn btn-primary create-button"
       />
+
+      <section>
+        <p class="resource-type-description">{{ resourceInfo.description }}</p>
+
+        <p>
+          To learn more, review our
+          <a href="https://about.opencasebook.org/making-casebooks/#quick-add"
+            >quick add documentation.</a
+          >
+        </p>
+      </section>
+
+      <fieldset class="resource-type-group">
+        <fieldset v-for="option in resourceInfoOptions" :key="option.name">
+          <input
+            v-model="resourceInfo"
+            :value="option.value"
+            :id="option.value.resource_type"
+            type="radio"
+          />
+          <label :for="option.value">{{ option.name }}</label>
+        </fieldset>
+      </fieldset>
+
+
       <button
         v-if="mode === SEARCH"
         @click.prevent="
@@ -56,13 +72,6 @@
     ></results-form>
 
     <p>{{ waitingFor }}</p>
-
-    <p>
-      To learn more, review our
-      <a href="https://about.opencasebook.org/making-casebooks/#quick-add"
-        >quick add documentation.</a
-      >
-    </p>
   </div>
 </template>
 
@@ -85,29 +94,29 @@ const optionTypes = {
   SECTION: {
     resource_type: "Section",
     description:
-      "Group your casebook into discrete sections to organize the material",
+      "Group your casebook into discrete sections to organize the material.",
   },
   LEGAL_DOCUMENT: {
     description:
-      "Search our library of US case law and code for documents to automatically import",
+      "Search our library of US case law and code for documents to automatically import.",
     resource_type: "LegalDocument",
   },
   CUSTOM_CONTENT: {
-    description: "Add your own written commentary or chapters",
+    description: "Add your own written commentary or chapters.",
     resource_type: "TextBlock",
   },
   LINK: {
-    description: "Paste a link to an external resource or article",
+    description: "Paste a link to an external resource or article.",
     resource_type: "Link",
   },
   CLONE: {
     description:
-      "Paste a link to a resource in another casebook to automatically import it into your own",
+      "Paste a link to a resource in another casebook to automatically import it into your own.",
     resource_type: "Clone",
   },
   OUTLINE: {
     description:
-      "Paste an outline of your table of contents and H2O will automatically create a draft casebook based on it",
+      "Paste an outline of your table of contents and H2O will automatically create a draft casebook based on it.",
     resource_type: "Outline",
   },
 };
@@ -208,6 +217,7 @@ export default {
       this.results = undefined;
     },
     handleSearch: async function () {
+      console.log("hi");
       const searchResults = await search(
         this.title,
         this.getSources,
@@ -230,11 +240,33 @@ export default {
       this.fetch({ casebook: this.casebook(), subsection: this.section() });
       this.resetForm();
     },
-    
     handleAdd: function () {
+      const {
+        casebookId,
+        ordSlug,
+        sectionId,
+        sectionOrd,
+        titleSlug,
+        url,
+        userSlug,
+      } = this.lineInfo;
+      const { title } = this;
+      const { resource_type } = this.resourceInfo;
       const data = {
         section: this.section(),
-        data: [this.lineInfo],
+        data: [
+          {
+            casebookId,
+            ordSlug,
+            resource_type,
+            sectionId,
+            sectionOrd,
+            title,
+            titleSlug,
+            url,
+            userSlug,
+          },
+        ],
       };
       this.postData(data);
     },
@@ -287,20 +319,16 @@ export default {
 
 <style lang="scss" scoped>
 div {
-  * {
-    margin: 0.5em 0;
-  }
   border: 1px dashed black;
   padding: 4rem;
 
-  h3 {
-    margin-top: 0;
-    font-size: 130%;
-    line-height: 1.6em;
-  }
-
   p:last-of-type {
     margin-bottom: 0;
+  }
+  h3 {
+    margin: 0;
+    font-size: 130%;
+    line-height: 1.6em;
   }
 
   form {
@@ -309,12 +337,31 @@ div {
     flex-direction: row;
     margin-bottom: 1em;
     justify-content: space-between;
+    gap: 2em;
 
     [type="text"] {
-      flex-basis: 45%;
+      flex-basis: 75%;
     }
-    select {
-      flex-basis: 30%;
+    label {
+      padding: 0 0 0 1rem;
+      font-size: 14px;
+      font-weight: normal;
+    }
+
+    fieldset {
+      margin: 0;
+    }
+    .resource-type-group {
+      columns: 2;
+    }
+    section {
+      flex: 2;
+    }
+    h4 {
+      width: 100%;
+      font-size: 14px;
+
+      text-align: center;
     }
     [type="submit"] {
       text-transform: capitalize;

--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -1,50 +1,34 @@
 <template>
   <div>
+
+    <h2>Build your outline.</h2>
     <form @submit.stop.prevent="handleSubmit" class="form-control-group">
-      <h3>
-        Add an individual resource or a list of items by pasting them into the
-        field below.
-      </h3>
 
       <input
         @paste.prevent.stop="handlePaste"
         v-model="title"
         type="text"
         class="form-control"
-        placeholder="'Chapter 1' or 'http://example.com' or 'John v. Smith'"
+        :placeholder="resourceInfo.description"
       />
 
+      <select v-model="resourceInfo" class="resource-type form-control">
+        <option
+          v-for="option in resourceInfoOptions"
+          :key="option.name"
+          :value="option.value"
+        >
+          {{ option.name }}
+        </option>
+      </select>
+      
       <input
         @submit="handleSubmit"
         :value="mode"
         type="submit"
         class="form-control btn btn-primary create-button"
       />
-
-      <section>
-        <p class="resource-type-description">{{ resourceInfo.description }}</p>
-
-        <p>
-          To learn more, review our
-          <a href="https://about.opencasebook.org/making-casebooks/#quick-add"
-            >quick add documentation.</a
-          >
-        </p>
-      </section>
-
-      <fieldset class="resource-type-group">
-        <fieldset v-for="option in resourceInfoOptions" :key="option.name">
-          <input
-            v-model="resourceInfo"
-            :value="option.value"
-            :id="option.value.resource_type"
-            type="radio"
-          />
-          <label :for="option.value">{{ option.name }}</label>
-        </fieldset>
-      </fieldset>
-
-
+      
       <button
         v-if="mode === SEARCH"
         @click.prevent="
@@ -72,6 +56,13 @@
     ></results-form>
 
     <p>{{ waitingFor }}</p>
+
+    <p>
+      Use the field above to add section headings, titles for interstitial material, case names, or links to quickly build the outline of your book.
+    </p>
+    <p>
+      You can also paste an outline, or import content from another H2O casebook by pasting a link.
+    </p>
   </div>
 </template>
 
@@ -94,29 +85,29 @@ const optionTypes = {
   SECTION: {
     resource_type: "Section",
     description:
-      "Group your casebook into discrete sections to organize the material.",
+      "Week One: Introduction to Criminal Law",
   },
   LEGAL_DOCUMENT: {
     description:
-      "Search our library of US case law and code for documents to automatically import.",
+      "John v. Smith",
     resource_type: "LegalDocument",
   },
   CUSTOM_CONTENT: {
-    description: "Add your own written commentary or chapters.",
+    description: "Chapter 1",
     resource_type: "TextBlock",
   },
   LINK: {
-    description: "Paste a link to an external resource or article.",
+    description: "http://example.com",
     resource_type: "Link",
   },
   CLONE: {
     description:
-      "Paste a link to a resource in another casebook to automatically import it into your own.",
+      "https://opencasebook.org/casebooks/1/example",
     resource_type: "Clone",
   },
   OUTLINE: {
     description:
-      "Paste an outline of your table of contents and H2O will automatically create a draft casebook based on it.",
+      "1. Week One: Introduction to Criminal Law",
     resource_type: "Outline",
   },
 };
@@ -217,7 +208,7 @@ export default {
       this.results = undefined;
     },
     handleSearch: async function () {
-      console.log("hi");
+      console.log('hi')
       const searchResults = await search(
         this.title,
         this.getSources,
@@ -319,17 +310,20 @@ export default {
 
 <style lang="scss" scoped>
 div {
+  * {
+    margin: 0.5em 0;
+  }
   border: 1px dashed black;
   padding: 4rem;
 
   p:last-of-type {
     margin-bottom: 0;
   }
-  h3 {
-    margin: 0;
-    font-size: 130%;
-    line-height: 1.6em;
-  }
+  h2 {
+      margin-top: 0;
+      font-size: 130%;
+      line-height: 1.6em;
+   }
 
   form {
     display: flex;
@@ -337,31 +331,16 @@ div {
     flex-direction: row;
     margin-bottom: 1em;
     justify-content: space-between;
-    gap: 2em;
-
+    gap: 1em;
+    
     [type="text"] {
-      flex-basis: 75%;
+      flex: 1;
     }
-    label {
-      padding: 0 0 0 1rem;
-      font-size: 14px;
-      font-weight: normal;
+    select {
+      flex-basis: 30%;
     }
-
-    fieldset {
-      margin: 0;
-    }
-    .resource-type-group {
-      columns: 2;
-    }
-    section {
-      flex: 2;
-    }
-    h4 {
-      width: 100%;
-      font-size: 14px;
-
-      text-align: center;
+    h3 {
+      flex-basis: 65%;
     }
     [type="submit"] {
       text-transform: capitalize;

--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -1,14 +1,11 @@
 <template>
   <div>
     <h3>
-      {{ resource_info.description }}, or select a different option from the
+      {{ resourceInfo.description }}, or select a different option from the
       dropdown for other types of content to add.
     </h3>
 
-    <form
-      @submit.stop.prevent="handleSubmit"
-      class="form-control-group"
-    >
+    <form @submit.stop.prevent="handleSubmit" class="form-control-group">
       <input
         @paste.prevent.stop="handlePaste"
         v-model="title"
@@ -16,10 +13,10 @@
         class="form-control"
         placeholder="Enter case, heading, link, or outline here"
       />
-      <select v-model="resource_info" class="resource-type form-control">
+      <select v-model="resourceInfo" class="resource-type form-control">
         <option
-          v-for="option in resource_info_options"
-          :key="option.k"
+          v-for="option in resourceInfoOptions"
+          :key="option.name"
           :value="option.value"
         >
           {{ option.name }}
@@ -72,12 +69,12 @@
 <script>
 import { createNamespacedHelpers } from "vuex";
 
-import ResultsForm from "./LegalDocumentSearch/ResultsForm";
-
 import { get_csrf_token } from "../legacy/lib/helpers";
 import pp from "libs/text_outline_parser";
 import urls from "libs/urls";
 import { search, add } from "libs/legal_document_search";
+
+import ResultsForm from "./LegalDocumentSearch/ResultsForm";
 import AdvancedSearch from "./LegalDocumentSearch/AdvancedSearch.vue";
 
 const globals = createNamespacedHelpers("globals");
@@ -88,7 +85,7 @@ const optionTypes = {
   SECTION: {
     resource_type: "Section",
     description:
-      "Group your casebook into discrete sections to organize the materal",
+      "Group your casebook into discrete sections to organize the material",
   },
   LEGAL_DOCUMENT: {
     description:
@@ -114,44 +111,38 @@ const optionTypes = {
     resource_type: "Outline",
   },
 };
-const optionsWithoutCloning = [
+const options = [
   {
     name: "Section",
     value: optionTypes.SECTION,
-    k: 0,
   },
   {
     name: "Legal Document",
     value: optionTypes.LEGAL_DOCUMENT,
-    k: 1,
   },
   {
     name: "Custom Content",
     value: optionTypes.CUSTOM_CONTENT,
-    k: 2,
   },
   {
     name: "Link",
     value: optionTypes.LINK,
-    k: 3,
   },
   {
     name: "Clone",
     value: optionTypes.CLONE,
-    k: 4,
   },
   {
     name: "Outline",
     value: optionTypes.OUTLINE,
-    k: 5,
   },
 ];
 
 const initial = function () {
   return {
     title: "",
-    resource_info: optionsWithoutCloning[0].value,
-    resource_info_options: optionsWithoutCloning,
+    resourceInfo: options[0].value,
+    resourceInfoOptions: options,
     waitingFor: undefined,
     results: undefined,
     selectedResult: undefined,
@@ -182,7 +173,7 @@ export default {
       return pp.guessLineType(this.title, this.getSources);
     },
     mode: function () {
-      return this.resource_info.resource_type === "LegalDocument"
+      return this.resourceInfo.resource_type === "LegalDocument"
         ? this.SEARCH
         : this.ADD;
     },
@@ -191,15 +182,15 @@ export default {
     lineInfo: function () {
       switch (this.lineInfo.resource_type) {
         case "Temp": {
-          this.resource_info = optionTypes.LEGAL_DOCUMENT;
+          this.resourceInfo = optionTypes.LEGAL_DOCUMENT;
           break;
         }
         case "Link": {
-          this.resource_info = optionTypes.LINK;
+          this.resourceInfo = optionTypes.LINK;
           break;
         }
         case "Clone": {
-          this.resource_info = optionTypes.CLONE;
+          this.resourceInfo = optionTypes.CLONE;
           break;
         }
       }
@@ -209,8 +200,9 @@ export default {
     ...mapActions(["fetch"]),
 
     bulkAddUrl: urls.url("new_from_outline"),
+
     resetForm: function () {
-      Object.keys(initial()).forEach(k => this[k] = initial()[k])
+      Object.keys(initial()).forEach((k) => (this[k] = initial()[k]));
       this.waitingFor = undefined;
       this.selectedResult = undefined;
       this.results = undefined;
@@ -238,6 +230,7 @@ export default {
       this.fetch({ casebook: this.casebook(), subsection: this.section() });
       this.resetForm();
     },
+    
     handleAdd: function () {
       const data = {
         section: this.section(),
@@ -252,7 +245,6 @@ export default {
       return this.handleAdd();
     },
     postData: async function (data) {
-      console.log(this.bulkAddUrl({ casebookId: this.casebook() }));
       const resp = await fetch(
         this.bulkAddUrl({ casebookId: this.casebook() }),
         {

--- a/web/frontend/libs/legal_document_search.js
+++ b/web/frontend/libs/legal_document_search.js
@@ -1,0 +1,153 @@
+import url from "./urls";
+import { get_csrf_token } from "../legacy/lib/helpers";
+
+export const jurisdictions = [
+    { val: "ala", name: "Alabama" },
+    { val: "alaska", name: "Alaska" },
+    { val: "am-samoa", name: "American Samoa" },
+    { val: "ariz", name: "Arizona" },
+    { val: "ark", name: "Arkansas" },
+    { val: "cal", name: "California" },
+    { val: "colo", name: "Colorado" },
+    { val: "conn", name: "Connecticut" },
+    { val: "dakota-territory", name: "Dakota Territory" },
+    { val: "dc", name: "District of Columbia" },
+    { val: "del", name: "Delaware" },
+    { val: "fla", name: "Florida" },
+    { val: "ga", name: "Georgia" },
+    { val: "guam", name: "Guam" },
+    { val: "haw", name: "Hawaii" },
+    { val: "idaho", name: "Idaho" },
+    { val: "ill", name: "Illinois" },
+    { val: "ind", name: "Indiana" },
+    { val: "iowa", name: "Iowa" },
+    { val: "kan", name: "Kansas" },
+    { val: "ky", name: "Kentucky" },
+    { val: "la", name: "Louisiana" },
+    { val: "mass", name: "Massachusetts" },
+    { val: "md", name: "Maryland" },
+    { val: "me", name: "Maine" },
+    { val: "mich", name: "Michigan" },
+    { val: "minn", name: "Minnesota" },
+    { val: "miss", name: "Mississippi" },
+    { val: "mo", name: "Missouri" },
+    { val: "mont", name: "Montana" },
+    { val: "native-american", name: "Native American" },
+    { val: "navajo-nation", name: "Navajo Nation" },
+    { val: "nc", name: "North Carolina" },
+    { val: "nd", name: "North Dakota" },
+    { val: "neb", name: "Nebraska" },
+    { val: "nev", name: "Nevada" },
+    { val: "nh", name: "New Hampshire" },
+    { val: "nj", name: "New Jersey" },
+    { val: "nm", name: "New Mexico" },
+    { val: "n-mar-i", name: "Northern Mariana Islands" },
+    { val: "ny", name: "New York" },
+    { val: "ohio", name: "Ohio" },
+    { val: "okla", name: "Oklahoma" },
+    { val: "or", name: "Oregon" },
+    { val: "pa", name: "Pennsylvania" },
+    { val: "pr", name: "Puerto Rico" },
+    { val: "ri", name: "Rhode Island" },
+    { val: "sc", name: "South Carolina" },
+    { val: "sd", name: "South Dakota" },
+    { val: "tenn", name: "Tennessee" },
+    { val: "tex", name: "Texas" },
+    { val: "tribal", name: "Tribal jurisdictions" },
+    { val: "uk", name: "United Kingdom" },
+    { val: "us", name: "United States" },
+    { val: "utah", name: "Utah" },
+    { val: "va", name: "Virginia" },
+    { val: "vi", name: "Virgin Islands" },
+    { val: "vt", name: "Vermont" },
+    { val: "wash", name: "Washington" },
+    { val: "wis", name: "Wisconsin" },
+    { val: "w-va", name: "West Virginia" },
+    { val: "wyo", name: "Wyoming" },
+  ];
+
+/**
+ * Accepts a query for a legal document and returns the result list
+ *
+ * @param {string} query the query to pass long to the search
+ * @param {array} allSources all available sources
+ * @param {?number} sourceId the id of the only source to query
+ * @param {?string} jurisdiction code for the state/jurisdiction to limit the search
+ * @param {?string} beforeDate YYYY-MM-DD date string
+ * @param {?string} afterDate YYYY-MM-DD date string *
+ *
+ * @returns {array} the list of results by source
+ */
+export const search = async (
+  query,
+  allSources,
+  sourceId,
+  jurisdiction,
+  beforeDate,
+  afterDate
+) => {
+  const api = url.url("search_using");
+
+  const sources = [];
+  const sourceDetail = allSources.filter((s) =>
+    sourceId ? s.id === sourceId : true
+  );
+
+  let order = 0; // Sources will come back ordered in "priority order", which we want to retain
+
+  for (const { id, name } of sourceDetail) {
+    const url =
+      api({ sourceId: id }) +
+      "?" +
+      new URLSearchParams({
+        q: query,
+        jurisdiction: jurisdiction || "",
+        before_date: beforeDate || "",
+        after_date: afterDate || "",
+      });
+    sources.push({ url, id, name, order });
+    order += 1;
+  }
+  return await Promise.all(
+    sources.map(async (source) => {
+      const { url, id, name, order } = source;
+      return fetch(url)
+        .then((r) => r.json())
+        .then((r) => {
+          const { results } = r;
+          return results.map((row) => {
+            row.id = row.id.toString(); // normalize IDs from the API to strings
+            return {
+              name,
+              sourceId: id,
+              sourceOrder: order,
+              ...row,
+            };
+          });
+        });
+    })
+  );
+};
+
+export const add = async (casebookId, sectionId, sourceRef, sourceId) => {
+  const api = url.url("legal_document_resource_view");
+
+  const resp = await fetch(api({ casebookId }), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": get_csrf_token(),
+    },
+    body: JSON.stringify({
+      source_id: sourceId,
+      source_ref: sourceRef,
+      section_id: sectionId,
+    }),
+  });
+  const body = await resp.json();
+  return {
+    resourceId: body.resource_id,
+    redirectUrl: body.redirect_url,
+    sourceRef,
+  };
+};

--- a/web/frontend/libs/legal_document_search.js
+++ b/web/frontend/libs/legal_document_search.js
@@ -128,7 +128,18 @@ export const search = async (
     })
   );
 };
-
+/**
+ * Given a casebook and optional section ID, add a legal document
+ * from the identified source to the casebook and return the location of the 
+ * resource in the book.
+ * 
+ * @param {string} casebookId the ID of the casebook
+ * @param {?string} sectionId the optional ID of the section in which to nest it
+ * @param {string} sourceRef the foreign identifier of the legal document
+ * @param {number} sourceId the local identifier of the source (e.g. CAP)
+ * 
+ * @returns {Object}
+ */
 export const add = async (casebookId, sectionId, sourceRef, sourceId) => {
   const api = url.url("legal_document_resource_view");
 

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 
 import Vuex from "vuex";
+import sinon from "sinon";
 
 import QuickAdd from "@/components/QuickAdd";
 
@@ -16,17 +17,55 @@ describe("QuickAdd", () => {
         case_search: {
           getters: {
             getSources: () => [
-              { url: "url1", name: "name1", id: "source-id1", order: 1, search_regexes: [] },
-              { url: "url2", name: "name2", id: "source-id2", order: 2, search_regexes: [] },
+              { url: "url1", name: "name1", id: "source-id1", order: 1, search_regexes: [{name: "name1", "regex" : new RegExp("https://cite.case.law/.*"), fuzzy: false}] },
             ],
           },
           namespaced: true,
         },
       },
     });
+    const resp = {
+        json: sinon.fake.resolves({
+          results: [{ id: "fake-id1" }, { id: "fake-id2" }],
+        }),
+      };
+      global.fetch = sinon.fake.resolves(resp);
+
   });
+
+  afterEach(() => {
+    global.fetch = undefined;
+  });
+
   it("loads the quick add form with expected defaults", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
-    expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Section")
-  })
+    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("Section")
+    expect(wrapper.find(".resource-type-description").text()).toContain("section");
+  });
+
+  it("updates the resource type dropdown if the user inputs an external link", () => {
+    const wrapper = mount(QuickAdd, { store, localVue });
+    wrapper.find('[type="text"]').setValue("http://example.com")
+    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("Link")
+    expect(wrapper.find(".resource-type-description").text()).toContain("link");
+  });
+
+  it("updates the resource type dropdown if the user inputs text that seems case-like", () => {
+    const wrapper = mount(QuickAdd, { store, localVue });
+    wrapper.find('[type="text"]').setValue("https://cite.case.law/example");
+    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("LegalDocument")
+    expect(wrapper.find(".resource-type-description").text()).toContain("Search");
+
+  });
+
+  it("submits a search request if the inputted item is thought to be a legal document", async () => {
+    const wrapper = mount(QuickAdd, { store, localVue });
+    wrapper.find('[type="text"]').setValue("https://cite.case.law/example");
+    await wrapper.find("form").trigger('submit');
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(wrapper.vm.mode).toBe("search");
+    expect(wrapper.vm.results.length).toBe(2);
+
+  });
 });  

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -29,4 +29,4 @@ describe("QuickAdd", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Section")
   })
-}); 
+});  

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -1,0 +1,32 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+
+import Vuex from "vuex";
+
+import QuickAdd from "@/components/QuickAdd";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe("QuickAdd", () => {
+ let store;
+
+  beforeEach(() => {
+    store = new Vuex.Store({
+      modules: {
+        case_search: {
+          getters: {
+            getSources: () => [
+              { url: "url1", name: "name1", id: "source-id1", order: 1, search_regexes: [] },
+              { url: "url2", name: "name2", id: "source-id2", order: 2, search_regexes: [] },
+            ],
+          },
+          namespaced: true,
+        },
+      },
+    });
+  });
+  it("loads the quick add form with expected defaults", () => {
+    const wrapper = mount(QuickAdd, { store, localVue });
+    expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Section")
+  })
+}); 

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -39,23 +39,22 @@ describe("QuickAdd", () => {
 
   it("loads the quick add form with expected defaults", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
-    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("Section")
-    expect(wrapper.find(".resource-type-description").text()).toContain("section");
+    expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Section")
+    expect(wrapper.find("[type='text']").element.placeholder).toContain("Week One")
   });
 
   it("updates the resource type dropdown if the user inputs an external link", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     wrapper.find('[type="text"]').setValue("http://example.com")
-    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("Link")
-    expect(wrapper.find(".resource-type-description").text()).toContain("link");
+    expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Link")
+    expect(wrapper.find("[type='text']").element.placeholder).toContain("example.com")
   });
 
   it("updates the resource type dropdown if the user inputs text that seems case-like", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     wrapper.find('[type="text"]').setValue("https://cite.case.law/example");
-    expect(wrapper.find("input[type='radio']:checked").element.id).toBe("LegalDocument")
-    expect(wrapper.find(".resource-type-description").text()).toContain("Search");
-
+    expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Legal Document")
+    expect(wrapper.find("[type='text']").element.placeholder).toContain(" v. ")
   });
 
   it("submits a search request if the inputted item is thought to be a legal document", async () => {

--- a/web/frontend/test/mocha_setup.js
+++ b/web/frontend/test/mocha_setup.js
@@ -1,8 +1,12 @@
-require('jsdom-global')();
+require("jsdom-global")();
 
-global.expect = require('expect');
+global.expect = require("expect");
 global.DOMParser = window.DOMParser;
 
 // https://github.com/vuejs/vue-test-utils/issues/936#issuecomment-415386167
 window.Date = Date;
-global.FRONTEND_URLS = {'search_sources': [], "search_using": []};
+global.FRONTEND_URLS = {
+  search_sources: [],
+  search_using: [],
+  new_from_outline: [],
+};


### PR DESCRIPTION
This is another somewhat monolithic change to the frontend, to rewrite the Quick Add component that appears at the bottom of the table of contents.

Includes the following issues: 

* #1968 
* #1975 
* #1976 
* #1977 

## Before

Status quo is the user enters a case name in the Quick Add, then a temporary item is added, then they click "Specify Document", then they click "Search", then they pick the results (they have to click directly on the title, not the row), then the item is changed in place.

https://user-images.githubusercontent.com/19571/230987676-05cdcfad-0c69-40e1-b71c-7ac311c07ee4.mov

## After

Now the search form is embedded in the Quick Add, so when either automatically (by a matching regular expression) or manually (by pulling the dropdown to Legal Documents), the search happens inline, and the matching item is inserted in place. This reduces the number of clicks from at least 4 to 2.

https://user-images.githubusercontent.com/19571/230987720-74c6b7d3-8395-4bb1-aada-612c0fb38a70.mov

The other functionality is unchanged: users can still paste links from within H2O to auto-clone, paste whole outlines, or add sections or custom content as before.

## Under the hood changes

* Advanced search from Add Content has been refactored into a discrete component and is used in both places. Similarly the actual search API call is now its own function.
* Dropped unnecessary external libraries like lodash and Axios in favor of native browser calls.
* QuickAdd now has some unit tests (it had none before)
* Before, the Clone and Outline options were implicit and then mutated the resource type model in confusing ways. They are now first-class citizens which makes user-facing documentation more straightforward.
* Dropped some dead code (`unWait()`?)


@cath9 and I will probably iterate on this on staging before it gets to prod.