### PR TITLE
Handle non-HTTP 200 responses in fetch calls; fixes #1981

### DIFF
--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -9,6 +9,7 @@
       :added="added"
       :selected-result="selectedResult"
     />
+    <p class="message" v-if="message">{{ message }}</p>
   </section>
 </template>
 
@@ -33,7 +34,8 @@ export default {
     results: undefined,
     added: undefined,
     selectedResult: undefined,
-    toggleReset: false
+    toggleReset: false,
+    message: undefined,
   }),
   methods: {
     ...mapActions(["fetch"]),
@@ -51,8 +53,19 @@ export default {
       this.added = undefined;
       this.selectedResult = sourceRef.toString();
       this.added = await add(this.casebook, this.section, sourceRef, sourceId)
+      if (Object.keys(this.added).includes('error')) {
+        this.message = this.added.error;
+      }
       this.fetch({ casebook: this.casebook, subsection: this.section });
     },
   },
 };
 </script>
+<style lang="scss" scoped>
+  .message {
+    padding: 1em;
+    margin: 2em 0;
+    background: lightyellow;
+    font-weight: bold;
+  }
+</style>

--- a/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
+++ b/web/frontend/components/LegalDocumentSearch/ResultsForm.vue
@@ -37,9 +37,12 @@
         <button class="btn btn-default btn-close" @click="$emit('close')">Close</button>
       </span>
     </li>
-  </ol>
+  </ol>  
   <p v-if="Array.isArray(searchResults) && searchResults.length === 0">
     No legal documents were found matching your search.
+  </p>
+  <p v-if="Array.isArray(searchResults) && searchResults.length > 1 && Object.keys(searchResults[0]).includes('error')" class="warning">
+    {{ searchResults[0].error }}
   </p>
   </section>
 </template>

--- a/web/frontend/libs/legal_document_search.js
+++ b/web/frontend/libs/legal_document_search.js
@@ -111,10 +111,10 @@ export const search = async (
   return await Promise.all(
     sources.map(async (source) => {
       const { url, id, name, order } = source;
-      return fetch(url)
-        .then((r) => r.json())
-        .then((r) => {
-          const { results } = r;
+      const resp = await fetch(url);
+      if (resp.ok) {
+        const json = await resp.json()
+        const { results } = json;
           return results.map((row) => {
             row.id = row.id.toString(); // normalize IDs from the API to strings
             return {
@@ -123,8 +123,12 @@ export const search = async (
               sourceOrder: order,
               ...row,
             };
-          });
         });
+      }
+      else {
+        console.error(resp.status)
+        return [{error: "The search is not currently working, but our team has been notified. Please retry later."}];
+      }
     })
   );
 };
@@ -155,10 +159,18 @@ export const add = async (casebookId, sectionId, sourceRef, sourceId) => {
       section_id: sectionId,
     }),
   });
-  const body = await resp.json();
-  return {
-    resourceId: body.resource_id,
-    redirectUrl: body.redirect_url,
-    sourceRef,
-  };
+  if (resp.ok) {
+    const body = await resp.json();
+    return {
+      resourceId: body.resource_id,
+      redirectUrl: body.redirect_url,
+      sourceRef,
+    };
+  }
+  else {
+    console.error(resp.status);
+    return {
+      error: "The legal document could not be added because of an error. Our team has been notified. Please retry later."
+    }
+  }
 };

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -24,12 +24,16 @@ describe("QuickAdd", () => {
         },
       },
     });
+
     const resp = {
-        json: sinon.fake.resolves({
-          results: [{ id: "fake-id1" }, { id: "fake-id2" }],
-        }),
-      };
-      global.fetch = sinon.fake.resolves(resp);
+      json: sinon.fake.resolves({
+        results: [{ id: "fake-id1" }, { id: "fake-id2" }],
+      }),
+      ok: true,
+      status: 200
+    };
+    
+    global.fetch = sinon.fake.resolves(resp);
 
   });
 
@@ -65,6 +69,24 @@ describe("QuickAdd", () => {
 
     expect(wrapper.vm.mode).toBe("search");
     expect(wrapper.vm.results.length).toBe(2);
-
   });
+
+  it.only("adds an error message if the search fails", async () => {
+    const wrapper = mount(QuickAdd, { store, localVue });
+    wrapper.find('[type="text"]').setValue("https://cite.case.law/example");
+    
+    global.fetch = sinon.fake.resolves({
+      json: sinon.fake.resolves({
+    
+      }),
+      ok: false,
+      status: 500
+    });
+
+    await wrapper.find("form").trigger('submit');
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(wrapper.vm.mode).toBe("search");
+    expect(wrapper.vm.results[0].error).toBeTruthy();
+  })
 });  

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1019,7 +1019,7 @@ class LegalDocumentResourceView(APIView):
         else:
             parent = casebook
         ordinals, display_ordinals = parent.content_tree__get_next_available_child_ordinals()
-    
+
         resource = ContentNode.objects.create(
             title=legal_doc.get_name(),
             casebook=casebook,
@@ -1027,7 +1027,7 @@ class LegalDocumentResourceView(APIView):
             display_ordinals=display_ordinals,
             resource_id=legal_doc.id,
             resource_type="LegalDocument",
-        )        
+        )
 
         return Response(
             data={

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1019,7 +1019,7 @@ class LegalDocumentResourceView(APIView):
         else:
             parent = casebook
         ordinals, display_ordinals = parent.content_tree__get_next_available_child_ordinals()
-
+    
         resource = ContentNode.objects.create(
             title=legal_doc.get_name(),
             casebook=casebook,
@@ -1027,7 +1027,8 @@ class LegalDocumentResourceView(APIView):
             display_ordinals=display_ordinals,
             resource_id=legal_doc.id,
             resource_type="LegalDocument",
-        )
+        )        
+
         return Response(
             data={
                 "resource_id": resource.id,
@@ -3093,8 +3094,9 @@ def search_sources(request):
 def search_using(request, source):
     src = get_object_or_404(LegalDocumentSource.objects.filter(id=source))
     params = LegalDocumentSearchParamsSerializer(data=request.GET)
+
     if not params.is_valid():
-        return JsonResponse(params.errors, status=500)
+        return JsonResponse(params.errors, status=400)
     results = src.api_model().search(params.save())
     return JsonResponse({"results": results}, status=200)
 


### PR DESCRIPTION
For the three new API calls that have been added using `fetch()`, handle cases where the response that comes back is not OK. 

In most cases this just passes along an error message. In the case of search results, because this expects a list of lists, the error message will be inside the results data structure. 

The error message gets displayed to the user under the text box in most places.