### PR TITLE
Limit text input to appropriate URL types

### DIFF
--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -7,6 +7,7 @@
       <input
         @paste.prevent.stop="handlePaste"
         v-model="title"
+        required
         :placeholder="resourceInfo.description"
         :type="resourceInfo.resource_type === 'Clone' || resourceInfo.resource_type === 'Link' ? 'url' : 'text'"
         :pattern="resourceInfo.resource_type === 'Clone' ? `${origin}.*`: undefined"

--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -7,11 +7,12 @@
       <input
         @paste.prevent.stop="handlePaste"
         v-model="title"
-        type="text"
-        class="form-control"
         :placeholder="resourceInfo.description"
+        :type="resourceInfo.resource_type === 'Clone' || resourceInfo.resource_type === 'Link' ? 'url' : 'text'"
+        :pattern="resourceInfo.resource_type === 'Clone' ? `${origin}.*`: undefined"
+        :title="resourceInfo.resource_type === 'Clone' ? origin : undefined"
+        class="form-control"
       />
-
       <select v-model="resourceInfo" class="resource-type form-control">
         <option
           v-for="option in resourceInfoOptions"
@@ -177,6 +178,7 @@ export default {
         ? this.SEARCH
         : this.ADD;
     },
+    origin: () => window.location.origin,
   },
   watch: {
     lineInfo: function () {
@@ -186,7 +188,9 @@ export default {
           break;
         }
         case "Link": {
-          this.resourceInfo = optionTypes.LINK;
+          if (this.resourceInfo != optionTypes.CLONE) {
+            this.resourceInfo = optionTypes.LINK;
+          }
           break;
         }
         case "Clone": {
@@ -349,7 +353,7 @@ div {
     h3 {
       flex-basis: 65%;
     }
-    [type="text"] {
+    [type="text"], [type="url"] {
       flex: 1;
     }
     select {

--- a/web/frontend/test/components/QuickAdd.test.js
+++ b/web/frontend/test/components/QuickAdd.test.js
@@ -44,14 +44,14 @@ describe("QuickAdd", () => {
   it("loads the quick add form with expected defaults", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Section")
-    expect(wrapper.find("[type='text']").element.placeholder).toContain("Week One")
+    expect(wrapper.find("[type='text']").element.placeholder).toContain("e.g. 'John v. Smith' or 'Week 1: Introduction'")
   });
 
   it("updates the resource type dropdown if the user inputs an external link", () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     wrapper.find('[type="text"]').setValue("http://example.com")
     expect(wrapper.find(".resource-type option:checked").element.textContent).toContain("Link")
-    expect(wrapper.find("[type='text']").element.placeholder).toContain("example.com")
+    expect(wrapper.find("[type='url']").element.placeholder).toContain("example.com")
   });
 
   it("updates the resource type dropdown if the user inputs text that seems case-like", () => {
@@ -71,7 +71,7 @@ describe("QuickAdd", () => {
     expect(wrapper.vm.results.length).toBe(2);
   });
 
-  it.only("adds an error message if the search fails", async () => {
+  it("adds an error message if the search fails", async () => {
     const wrapper = mount(QuickAdd, { store, localVue });
     wrapper.find('[type="text"]').setValue("https://cite.case.law/example");
     

--- a/web/frontend/test/components/SearchForm.test.js
+++ b/web/frontend/test/components/SearchForm.test.js
@@ -14,6 +14,7 @@ describe("SearchForm", () => {
       json: sinon.fake.resolves({
         results: [{ id: "fake-id1" }, { id: "fake-id2" }],
       }),
+      ok: true,
     };
     global.fetch = sinon.fake.resolves(resp);
 


### PR DESCRIPTION
If the user selects type Link or Clone (a Clone is a link to another H2O resource), change the input type to `url` and let the browser validate.

For type Clone, applies the `pattern` attribute with the current origin so the browser handles client-side validation. (This pattern matches the internal check on whether a link is considered external or a clone.)

In Chrome and Firefox, the browser will make use of the `title` attribute to hint to the user what the required pattern is. In Safari, naturally, the validation is enforced but the pattern is not displayed. (This is impossible to screenshot.)

With some custom validation we could make this experience a little nicer, but this is almost all declarative markup and very much an edge case. If the user somehow blows past the client-side validation, they'll get the server-side error from #1985 anyway, rather than no response.