### PR TITLE
Don't invent a new resource type out of thin air; fixes #1988

### DIFF
--- a/web/frontend/components/QuickAdd.vue
+++ b/web/frontend/components/QuickAdd.vue
@@ -110,7 +110,7 @@ const optionTypes = {
   OUTLINE: {
     description:
       "1. Week One: Introduction to Criminal Law",
-    resource_type: "Outline",
+    resource_type: "TextBlock",
   },
 };
 const options = [


### PR DESCRIPTION
If the user types a single item into the Quick Add in Outline mode, previously the item was invalid because it was coming along with a resource type that doesn't exist. The item would appear to work up to a point but there are many places in the code where this is expected to come from a set of known values that have database representations. There's apparently no server-side validation around this, but probably not worth adding at this point. 

This sets the default resource type for a single-item outline to Custom Content. The usual mode for outline content is unaffected here (each outline item will get an assigned type asynchronously).