### PR TITLE
Fix some minor state refreshes in Add Content

### DIFF
--- a/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
+++ b/web/frontend/components/LegalDocumentSearch/LegalDocumentSearch.vue
@@ -47,6 +47,8 @@ export default {
       this.toggleReset = !this.toggleReset;
     },
     onSearchResults: function (res) {
+      this.selectedResult = undefined;
+      this.added = undefined;
       this.results = res;
     },
     onAddDoc: async function (sourceRef, sourceId) {
@@ -57,6 +59,7 @@ export default {
         this.message = this.added.error;
       }
       this.fetch({ casebook: this.casebook, subsection: this.section });
+      this.toggleReset = !this.toggleReset;
     },
   },
 };


### PR DESCRIPTION
Noticed in testing #1994 that there were some bugs in Add Content when running multiple searches in a row. These changes do a better job of resetting the state appropriately after each event:

* After a document is added to a casebook, clear the search box so the user doesn't have to delete the previous term before re-searching.
* Previously, if a search was performed and no document was selected, a subsequent search would appear to have no results. This is fixed.