### PR TITLE
Make Matomo usage reporting async

### DIFF
--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -24,7 +24,8 @@
             const start_date = document.querySelector('input[name="start_date"]').value;
             const end_date = document.querySelector('input[name="end_date"]').value;
             const published = document.querySelector('input[name="published"]').checked;
-            const resp = await fetch('{% url "matomo-stats" %}?' + 
+            const statsEndpoint = '{% url "matomo-stats" %}'; // Django-generated URL to the Matomo API collection endpoint
+            const resp = await fetch(`${statsEndpoint}?` + 
                 new URLSearchParams({
                 start_date, end_date, published
                 }));

--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -11,14 +11,63 @@
 
     {{ date_form.media }}
 
-    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/base.css' %}" />
-    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
-    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/base.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
 
     <script>
         function updateDate (start_date, end_date) {
-            document.getElementById('id_start_date').value=start_date;
-            document.getElementById('id_end_date').value=end_date;
+            document.querySelector('#id_start_date').value = start_date;
+            document.querySelector('#id_end_date').value = end_date;
+        }
+        addEventListener('load', async () => {
+            const start_date = document.querySelector('input[name="start_date"]').value;
+            const end_date = document.querySelector('input[name="end_date"]').value;
+            const published = document.querySelector('input[name="published"]').checked;
+            const resp = await fetch('{% url "matomo-stats" %}?' + 
+                new URLSearchParams({
+                start_date, end_date, published
+                }));
+            if (resp.ok) {
+                const stats = await resp.json();
+                renderStats(stats)
+            }
+        })
+        function renderStats(stats) {
+            const div = document.querySelector("#casebooks-by-usage");
+            div.innerHTML = `
+            <h2>Top casebooks by usage</h2>
+            <p>Results between ${stats.start_date} and ${stats.end_date}</p>
+            <ol></ol>
+            `;
+            const ol = div.querySelector('ol');
+            for (const cb of stats.items) {
+                const li = document.createElement('li');
+                if (cb.title) {
+                    const authors = document.createElement('p');
+                    for (const [i, author] of cb.authors.entries()) {
+                        authors.innerHTML = authors.innerHTML + `
+                            <a href="${author.url}">${author.name}</a> ${author.verified_professor ? '(prof)' : ''}
+                            ${author.affiliation ? 'at' : ''} ${author.affiliation}${i < cb.authors.length - 1? ',': ''}
+                        `;
+                    }
+                    li.innerHTML = `
+                    <h3><a href="${cb.url}">${cb.title}</a></h3>
+                    <span class="is-public">
+                        ${cb.is_public ? '✅ published' : '❌ not published'}
+                    </span>
+                    ` + authors.outerHTML + `
+                    <p>
+                        ${cb.visits.toLocaleString()} visit${cb.visits !== 1 ? 's': ''}
+                    </p>
+                    `    
+                }
+                else {
+                    li.innerHTML = cb.slug;
+                }
+                ol.append(li);
+            }
+
         }
     </script>
 {% endblock extrahead %}
@@ -268,45 +317,12 @@
         </aside>
     </div>
 
+
     <div id="casebooks-by-usage">
-        <h2>Top casebooks by usage</h2
-        <p>Results between {{ web_usage.start_date }} and {{ web_usage.end_date }}</p>
+        <h2>Loading stats...</h2>
 
-        {% if web_usage.status %}
-           <p><strong>{{ web_usage.status }}</strong></p>
-        {% endif %}
-
-        <ol>
-        {% for result in web_usage.items %}
-            {% with result.instance as casebook %}
-           <li>{% if casebook %}
-                <h3><a href="{{ casebook.get_absolute_url }}">{{ casebook.title }}</a></h3>
-                <span class="is-public">{% if casebook.is_public %}
-                    ✅ published
-                {% else %}
-                    ❌ not published
-                {% endif %}
-                </span>
-                <p>
-                    {% for author in casebook.primary_authors %}
-                        <a href="{% url "admin:main_user_change" author.id %}">{{ author }}</a> {% if author.verified_professor %}(prof){% endif %}
-                        {% if author.affiliation %} at {{ author.affiliation }} {% endif %}
-                        {% if not forloop.last%}, {% endif %}
-                    {% endfor %}
-
-                </p>
-                <p>
-                    {{ result.visits | intcomma }} visit{{ result.visits| pluralize }}
-                </p>
-            {% else %}
-                {{ result.slug }}
-            {% endif %}
-            {% endwith %}
-        </li>
-        {% endfor %}
-        </ol>
     </div>
-    </div>
+
 </div>
 
 {% endblock %}

--- a/web/main/test/test_permissions.py
+++ b/web/main/test/test_permissions.py
@@ -35,6 +35,10 @@ def get_permissions_tests():
 
         view_func = path.callback
 
+        # don't run tests on anything that's not a pattern (like an include)
+        if not hasattr(view_func, "__name__"):
+            continue
+
         # don't run tests on built-in views:
         if view_func.__name__ in ["RedirectView", "TemplateView"]:
             continue

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -285,6 +285,7 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
         no_perms_test(lambda request: redirect(settings.FAQ_URL, permanent=True)),
         name="faq",
     ),
+    path("reporting/", include("reporting.urls")),
 ]
 fix_after_rails("some routes don't have end slashes for rails compatibility")
 

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -16,7 +16,6 @@ from reporting.create_reporting_views import (
     PUBLISHED_CASEBOOKS,
 )
 from main.models import Casebook
-from reporting.matomo import usage
 
 
 class DateForm(forms.Form):
@@ -56,9 +55,6 @@ def view(request: HttpRequest):
         )
 
     state = PUBLISHED_CASEBOOKS if published_casebooks_only else ALL_STATES
-
-    # Get the usage data from Matomo:
-    web_usage = usage(start_date, end_date, published_casebooks_only)
 
     with connection.cursor() as cursor:
 
@@ -263,7 +259,6 @@ def view(request: HttpRequest):
         "admin/reporting/index.html",
         {
             "stats": stats,
-            "web_usage": web_usage,
             "date_form": form,
             "query": urlencode(
                 {

--- a/web/reporting/tests/test_matomo_integration.py
+++ b/web/reporting/tests/test_matomo_integration.py
@@ -15,8 +15,8 @@ def test_matomo_api(casebook_factory, mock_successful_matomo_response):
     c1 = casebook_factory()
     c2 = casebook_factory()
     res = api("http://example.com", "", "", date.today(), date.today())
-    assert res.items[0].instance.id == c1.id
-    assert res.items[1].instance.id == c2.id
+    assert res.items[0].title == c1.title
+    assert res.items[1].title == c2.title
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)
@@ -29,8 +29,8 @@ def test_matomo_api_filter(casebook_factory, mock_successful_matomo_response):
     res = api(
         "http://example.com", "", "", date.today(), date.today(), published_casebooks_only=True
     )
-    assert res.items[0].instance.id == c1.id
-    assert res.items[1].instance is None
+    assert res.items[0].title == c1.title
+    assert res.items[1].title is None
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)
@@ -39,7 +39,7 @@ def test_matomo_api_no_match(mock_successful_matomo_response):
 
     res = api("http://example.com", "", "", date.today(), date.today())
     assert res.items[0].slug == "1-some-title"
-    assert res.items[0].instance is None
+    assert res.items[0].title is None
 
 
 def test_matomo_api_error(requests_mock):

--- a/web/reporting/urls.py
+++ b/web/reporting/urls.py
@@ -1,0 +1,5 @@
+from . import views
+
+from django.urls import path
+
+urlpatterns = [path("stats/", views.matomo_stats, name="matomo-stats")]

--- a/web/reporting/views.py
+++ b/web/reporting/views.py
@@ -1,11 +1,15 @@
 import dataclasses
 
+from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, JsonResponse
 
 from reporting.matomo import usage
+from main.test.test_permissions_helpers import no_perms_test
+
 from .admin.usage_dashboard import DateForm
 
-
+@no_perms_test
+@staff_member_required
 def matomo_stats(request: HttpRequest):
     """When requested as on page load, retrieve Matomo analytics for the given time period"""
     form = DateForm(request.GET)

--- a/web/reporting/views.py
+++ b/web/reporting/views.py
@@ -8,6 +8,7 @@ from main.test.test_permissions_helpers import no_perms_test
 
 from .admin.usage_dashboard import DateForm
 
+
 @no_perms_test
 @staff_member_required
 def matomo_stats(request: HttpRequest):

--- a/web/reporting/views.py
+++ b/web/reporting/views.py
@@ -1,0 +1,19 @@
+import dataclasses
+
+from django.http import HttpRequest, JsonResponse
+
+from reporting.matomo import usage
+from .admin.usage_dashboard import DateForm
+
+
+def matomo_stats(request: HttpRequest):
+    """When requested as on page load, retrieve Matomo analytics for the given time period"""
+    form = DateForm(request.GET)
+    if form.is_valid():
+        web_usage = usage(
+            form.cleaned_data["start_date"],
+            form.cleaned_data["end_date"],
+            form.cleaned_data["published"],
+        )
+        return JsonResponse(dataclasses.asdict(web_usage))
+    return JsonResponse("")


### PR DESCRIPTION
Something I should've done a long time ago for @cath9 but fortunately for her now it was annoying me, so I'm improving this.

In the H2O reporting dashboard, high-level stats from Matomo were being fetched synchronously during the request cycle, which made the dashboard page load slowly. For awhile I was considering having the stats fetched and cached via a recurring celery job, but this is simpler, if more ridiculous.

Now the page loads instantly, which gives you immediate access to the Django-side reports, while the Matomo reporting is fetched async and pops in after a few seconds. 

This involved writing some wee little Django scaffolding for the endpoint, and porting the Django template code to JS which modifies the DOM once the response comes back. There are also a few mechanical changes to make the Matomo results pickleable; before they could be Django model instances.

Two small functional changes:

* This reports casebook authorship with the newer controlled-vocabulary of the `Institution` model rather than the older user-supplied `affiliation` field; this should help identify where authors might need an institution applied.
* Changed the messaging when Matomo returns no results to a warning which should hopefully avoid Sentry noise.
