### PR TITLE
Generate time-series reports for casebooks and professors 

### DIFF
--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -196,18 +196,17 @@
     <tr>
         <th>Casebooks from verified professors
             <small>
-                <a href="{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}">View as list »</a>
-
-                <a href="{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+                <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}'>View as list »</a>
+                <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}&_csv=True'>Export as csv »</a>
+                <a href='{% url "reporting-casebook-timeseries" %}'>Time series csv »</a>
             </small>
         </th>
         <td>{{ stats.casebooks_prof | intcomma }}</td>
     </tr>
     <tr>
-        <th>Casebooks including content from Capstone
+        <th>Casebooks including content from CAP
             <small>
                 <a href="{% url "admin:reporting_casebookcap_changelist" %}?{{ query }}">View as list »</a>
-
                 <a href="{% url "admin:reporting_casebookcap_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
 
             </small>
@@ -225,7 +224,7 @@
         <td> {{ stats.casebooks_gpo | intcomma }}</td>
     </tr>
     <tr>
-        <th>Casebooks including content from Capstone with at least one professor as contributor
+        <th>Casebooks including content from CAP with at least one professor as contributor
 
             <small>
                 <a href="{% url "admin:reporting_casebookcapprof_changelist" %}?{{ query }}">View as list »</a>
@@ -316,6 +315,7 @@
                 may be omitted.
             </p>
         </aside>
+
     </div>
 
 

--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -171,8 +171,9 @@
     <tr>
         <th>Professors with published casebooks
             <small>
-                <a href="{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}">View as list »</a>
-                <a href="{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}&_csv=True">Export as csv »</a>
+                <a href='{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}''>View as list »</a>
+                <a href='{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}&_csv=True'>Export as csv »</a>
+                <a href='{% url "reporting-professor-casebook-timeseries" %}'>Casebooks by professor and year csv »</a>
 
             </small>
 
@@ -198,7 +199,7 @@
             <small>
                 <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}'>View as list »</a>
                 <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}&_csv=True'>Export as csv »</a>
-                <a href='{% url "reporting-casebook-timeseries" %}'>Time series csv »</a>
+                <a href='{% url "reporting-professor-casebook-timeseries" %}'>Published casebooks by year csv »</a>                
             </small>
         </th>
         <td>{{ stats.casebooks_prof | intcomma }}</td>

--- a/web/main/templates/admin/reporting/index.html
+++ b/web/main/templates/admin/reporting/index.html
@@ -173,8 +173,10 @@
             <small>
                 <a href='{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}''>View as list »</a>
                 <a href='{% url "admin:reporting_professorwithcasebooks_changelist" %}?{{ query }}&_csv=True'>Export as csv »</a>
-                <a href='{% url "reporting-professor-casebook-timeseries" %}'>Casebooks by professor and year csv »</a>
-
+                <br>
+                <a href='{% url "reporting-professor-casebook-timeseries" %}'>Casebooks by professor and year as csv »</a>
+                <br>
+                <a href='{% url "reporting-professors-published-timeseries" %}'>Cumulative count of published professors as csv »</a>                
             </small>
 
 
@@ -199,7 +201,8 @@
             <small>
                 <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}'>View as list »</a>
                 <a href='{% url "admin:reporting_casebookprofessors_changelist" %}?{{ query }}&_csv=True'>Export as csv »</a>
-                <a href='{% url "reporting-professor-casebook-timeseries" %}'>Published casebooks by year csv »</a>                
+                <br>
+                <a href='{% url "reporting-casebook-timeseries" %}'>Published casebooks by year as csv »</a>                
             </small>
         </th>
         <td>{{ stats.casebooks_prof | intcomma }}</td>

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -285,7 +285,7 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
         no_perms_test(lambda request: redirect(settings.FAQ_URL, permanent=True)),
         name="faq",
     ),
-    path("reporting/", include("reporting.urls")),
+    path("django-admin/reporting/", include("reporting.urls")),
 ]
 fix_after_rails("some routes don't have end slashes for rails compatibility")
 

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -250,7 +250,6 @@ def view(request: HttpRequest):
         )
         stats["series_by_prof"] = cursor.fetchone()[0]
 
-        # Time series queries
 
     return render(
         request,

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -11,8 +11,7 @@ from django.http import HttpRequest
 from django.shortcuts import render
 
 from main.models import Casebook
-from reporting.create_reporting_views import (ALL_STATES, OLDEST_YEAR,
-                                              PUBLISHED_CASEBOOKS)
+from reporting.create_reporting_views import ALL_STATES, OLDEST_YEAR, PUBLISHED_CASEBOOKS
 
 
 class DateForm(forms.Form):
@@ -21,6 +20,7 @@ class DateForm(forms.Form):
     published = forms.BooleanField(
         required=False, initial=True, help_text="Published casebooks only"
     )
+
 
 @staff_member_required
 def view(request: HttpRequest):
@@ -251,9 +251,6 @@ def view(request: HttpRequest):
         stats["series_by_prof"] = cursor.fetchone()[0]
 
         # Time series queries
-
-        
-
 
     return render(
         request,

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -250,7 +250,6 @@ def view(request: HttpRequest):
         )
         stats["series_by_prof"] = cursor.fetchone()[0]
 
-
     return render(
         request,
         "admin/reporting/index.html",

--- a/web/reporting/admin/usage_dashboard.py
+++ b/web/reporting/admin/usage_dashboard.py
@@ -1,21 +1,18 @@
 from datetime import date
-
 from typing import Dict
 from urllib.parse import urlencode
+
+from dateutil.relativedelta import relativedelta
 from django import forms
+from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.admin.widgets import AdminDateWidget
+from django.db import connection
 from django.http import HttpRequest
 from django.shortcuts import render
-from django.db import connection
-from django.contrib.admin.widgets import AdminDateWidget
-from dateutil.relativedelta import relativedelta
-from django.contrib.admin.views.decorators import staff_member_required
 
-from reporting.create_reporting_views import (
-    ALL_STATES,
-    OLDEST_YEAR,
-    PUBLISHED_CASEBOOKS,
-)
 from main.models import Casebook
+from reporting.create_reporting_views import (ALL_STATES, OLDEST_YEAR,
+                                              PUBLISHED_CASEBOOKS)
 
 
 class DateForm(forms.Form):
@@ -24,7 +21,6 @@ class DateForm(forms.Form):
     published = forms.BooleanField(
         required=False, initial=True, help_text="Published casebooks only"
     )
-
 
 @staff_member_required
 def view(request: HttpRequest):
@@ -124,7 +120,7 @@ def view(request: HttpRequest):
         )
         stats["casebooks_prof"] = cursor.fetchone()[0]
 
-        # Casebooks including content from Capstone
+        # Casebooks including content from CAP
         cursor.execute(
             """--sql
             select count(*) from reporting_casebooks_including_source_cap
@@ -253,6 +249,11 @@ def view(request: HttpRequest):
             [state, start_date, end_date],
         )
         stats["series_by_prof"] = cursor.fetchone()[0]
+
+        # Time series queries
+
+        
+
 
     return render(
         request,

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -2,6 +2,10 @@ from datetime import date, datetime
 from typing import Optional
 from main.models import Casebook, User
 
+# Proxy models for generating changelist pages in the reporting admin. While these superficially match
+# the reporting views, they are Django mdoels based on the real models in main and so 
+# have all the same fields as their `main` equivalents, rather than the columns synthesized
+# in the reporting views.
 
 class Professor(User):
     @property

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -3,9 +3,10 @@ from typing import Optional
 from main.models import Casebook, User
 
 # Proxy models for generating changelist pages in the reporting admin. While these superficially match
-# the reporting views, they are Django mdoels based on the real models in main and so 
+# the reporting views, they are Django mdoels based on the real models in main and so
 # have all the same fields as their `main` equivalents, rather than the columns synthesized
 # in the reporting views.
+
 
 class Professor(User):
     @property

--- a/web/reporting/sql/reporting.sql
+++ b/web/reporting/sql/reporting.sql
@@ -27,6 +27,7 @@ where is_active is true
 create materialized view if not exists reporting_professors as
 select
     user_id,
+    attribution,
     created_at,
     last_login_at
 from reporting_users
@@ -81,8 +82,8 @@ select
     c.created_at,
     c.updated_at
 from main_contentcollaborator
-inner join reporting_professors
-    on main_contentcollaborator.user_id = reporting_professors.user_id
+inner join reporting_professors p
+    on main_contentcollaborator.user_id = p.user_id
 inner join
     reporting_casebooks c on main_contentcollaborator.casebook_id = c.casebook_id
 group by main_contentcollaborator.casebook_id, c.state, c.created_at, c.updated_at;
@@ -161,4 +162,21 @@ select
     c.updated_at
 from main_commontitle
     inner join reporting_casebooks_from_professors c on c.casebook_id = main_commontitle.current_id;
+
+-- Casebooks by verified professors over time
+
+create materialized view if not exists reporting_professors_with_casebooks_over_time as
+select 
+    p.user_id, 
+    p.attribution,
+    p.created_at,
+    p.last_login_at,
+    extract(year from c.created_at) as created_year,
+    count(*) as num_casebooks
+from reporting_casebooks c 
+    inner join main_contentcollaborator cc on cc.casebook_id = c.casebook_id 
+    inner join reporting_professors p on p.user_id = cc.user_id
+where c.state in ('Public', 'Revising')
+group by p.user_id, p.attribution, p.created_at, p.last_login_at, extract(year from c.created_at);
+
 

--- a/web/reporting/urls.py
+++ b/web/reporting/urls.py
@@ -4,5 +4,14 @@ from . import views
 
 urlpatterns = [
     path("stats/", views.matomo_stats, name="matomo-stats"),
-    path("time-series/casebooks", views.casebook_timeseries, name="reporting-casebook-timeseries"),
+    path(
+        "time-series/professor-casebooks",
+        views.professor_casebook_timeseries,
+        name="reporting-professor-casebook-timeseries",
+    ),
+    path(
+        "time-series/casebooks",
+        views.casebook_timeseries,
+        name="reporting-casebook-timeseries",
+    ),
 ]

--- a/web/reporting/urls.py
+++ b/web/reporting/urls.py
@@ -14,4 +14,9 @@ urlpatterns = [
         views.casebook_timeseries,
         name="reporting-casebook-timeseries",
     ),
+    path(
+        "time-series/professors-published",
+        views.professor_cumulative_publication_timeseries,
+        name="reporting-professors-published-timeseries",
+    ),
 ]

--- a/web/reporting/urls.py
+++ b/web/reporting/urls.py
@@ -1,5 +1,8 @@
-from . import views
-
 from django.urls import path
 
-urlpatterns = [path("stats/", views.matomo_stats, name="matomo-stats")]
+from . import views
+
+urlpatterns = [
+    path("stats/", views.matomo_stats, name="matomo-stats"),
+    path("time-series/casebooks", views.casebook_timeseries, name="reporting-casebook-timeseries"),
+]

--- a/web/reporting/views.py
+++ b/web/reporting/views.py
@@ -1,12 +1,21 @@
+import csv
 import dataclasses
+from datetime import date
+from io import StringIO
 
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import *
 from django.contrib.admin.views.decorators import staff_member_required
-from django.http import HttpRequest, JsonResponse
+from django.db import connection
+from django.http import HttpRequest, HttpResponse, JsonResponse
 
-from reporting.matomo import usage
 from main.test.test_permissions_helpers import no_perms_test
+from reporting.create_reporting_views import OLDEST_YEAR
+from reporting.matomo import usage
 
 from .admin.usage_dashboard import DateForm
+
+
 
 
 @no_perms_test
@@ -22,3 +31,39 @@ def matomo_stats(request: HttpRequest):
         )
         return JsonResponse(dataclasses.asdict(web_usage))
     return JsonResponse("")
+
+
+@no_perms_test
+@staff_member_required
+def casebook_timeseries(request: HttpRequest):
+    """Return the output of the casebook timeseries query, as a csv"""
+    with connection.cursor() as cursor:
+        # These do not respect date filters because they're cumulative over all time
+        year_qs = []
+        for year in rrule(
+            YEARLY, until=date.today(), dtstart=date.today() - relativedelta(years=10)
+        ):
+            year_qs.append(
+                f'case when created_year = {year.year} then num_casebooks else 0 end as "year_{year.year}"\n'
+            )
+        sql = f"""--sql
+            select distinct user_id, attribution,
+            {', '.join([yq for yq in year_qs])}
+            from reporting_professors_with_casebooks_over_time
+            """
+        cursor.execute(sql)
+
+        output = StringIO()
+        export = []
+        export.append([col.name.replace('_', ' ') for col in cursor.description])
+        for row in cursor.fetchall():
+            export.append(row)
+        csv.writer(output).writerows(export)
+
+        return HttpResponse(
+            output.getvalue().encode(),
+            headers={
+                "Content-Type": "text/csv",
+                "Content-Disposition": f'attachment; filename="{"casebooks-published-over-time"}-{date.today().isoformat()}.csv',
+            },
+        )

--- a/web/reporting/views.py
+++ b/web/reporting/views.py
@@ -7,15 +7,35 @@ from dateutil.relativedelta import relativedelta
 from dateutil.rrule import *
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db import connection
+from django.db.models import Count
+from django.db.models.functions import ExtractYear
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
 from main.test.test_permissions_helpers import no_perms_test
-from reporting.create_reporting_views import OLDEST_YEAR
+from reporting.create_reporting_views import PUBLISHED_CASEBOOKS
 from reporting.matomo import usage
 
 from .admin.usage_dashboard import DateForm
 
 
+def sql_to_csv_response(sql: str, filename: str) -> HttpResponse:
+    """Given a blob of SQL, execute it, set the row headers to the column names, and return a downloadable CSV"""
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        output = StringIO()
+        export = []
+        export.append([col.name.replace("_", " ") for col in cursor.description])
+        export.extend(cursor.fetchall())
+        csv.writer(output).writerows(export)
+
+        return HttpResponse(
+            output.getvalue().encode(),
+            headers={
+                "Content-Type": "text/csv",
+                "Content-Disposition": f'attachment; filename="{filename}-{date.today().isoformat()}.csv"',
+            },
+        )
 
 
 @no_perms_test
@@ -35,35 +55,42 @@ def matomo_stats(request: HttpRequest):
 
 @no_perms_test
 @staff_member_required
-def casebook_timeseries(request: HttpRequest):
+def professor_casebook_timeseries(request: HttpRequest) -> HttpResponse:
     """Return the output of the casebook timeseries query, as a csv"""
-    with connection.cursor() as cursor:
-        # These do not respect date filters because they're cumulative over all time
-        year_qs = []
-        for year in rrule(
-            YEARLY, until=date.today(), dtstart=date.today() - relativedelta(years=10)
-        ):
-            year_qs.append(
-                f'case when created_year = {year.year} then num_casebooks else 0 end as "year_{year.year}"\n'
-            )
-        sql = f"""--sql
-            select distinct user_id, attribution,
-            {', '.join([yq for yq in year_qs])}
-            from reporting_professors_with_casebooks_over_time
-            """
-        cursor.execute(sql)
 
-        output = StringIO()
-        export = []
-        export.append([col.name.replace('_', ' ') for col in cursor.description])
-        for row in cursor.fetchall():
-            export.append(row)
-        csv.writer(output).writerows(export)
-
-        return HttpResponse(
-            output.getvalue().encode(),
-            headers={
-                "Content-Type": "text/csv",
-                "Content-Disposition": f'attachment; filename="{"casebooks-published-over-time"}-{date.today().isoformat()}.csv',
-            },
+    # These do not respect date filters because they're cumulative over all time
+    year_qs = []
+    for year in rrule(YEARLY, until=date.today(), dtstart=date.today() - relativedelta(years=10)):
+        year_qs.append(
+            f'case when created_year = {year.year} then num_casebooks else 0 end as "year_{year.year}"\n'
         )
+    sql = f"""--sql
+        select distinct user_id, attribution,
+        {', '.join([yq for yq in year_qs])}
+        from reporting_professors_with_casebooks_over_time
+        """
+    return sql_to_csv_response(sql, "professor-casebooks-published-over-time")
+
+
+@no_perms_test
+@staff_member_required
+def casebook_timeseries(request: HttpRequest) -> HttpResponse:
+    """Return the number of casebooks created in a given year and currently in the published state or have ever been published"""
+    sql = """--sql
+
+    with ever_published as (
+        select distinct casebook_id, entry_date from main_casebookeditlog 
+        where change = 'First'
+    ) -- edit log was backfilled 
+
+    select 
+        count(c.casebook_id) as "Casebook count", 
+        extract(year from log.entry_date)::text as Year 
+    from reporting_casebooks_from_professors c
+    join ever_published log 
+        on log.casebook_id = c.casebook_id
+    group by 
+        extract(year from log.entry_date)
+    order by year
+    """
+    return sql_to_csv_response(sql, "casebooks-published-over-time")


### PR DESCRIPTION
This generates three new CSV-only reports that compute casebook and professor counts of three types over a period of the last 10 years:

* A count of how many casebooks were published each year by verified professors [#1978] 
* A cumulative running total of how many verified professors have published casebooks by each year [#1979] 
* For each verified professor, a count by year of their published casebooks.

The last item was not requested; I just misread one of the tickets. But perhaps it'll be useful! 

I did some spot-checking of the counts and compared them across each other and against counts from the search page, and I think this is broadly correct. It's impossible to know when a casebook was not in the published state historically. As mentioned in the ticket, only 16 casebooks by verified professors have since been unpublished, so hopefully the absence of this information is not material. Also prior to 2021 we have only guesstimate dates for first-published dates—in reality some of this casebooks were likely published one year later than reported, because we only have creation date for that period.

## Casebooks published by verified professors by year

year | Casebook count
-- | --
2012 | 4
2013 | 9
2014 | 25
2015 | 33
2016 | 35
2017 | 16
2018 | 34
2019 | 31
2020 | 81
2021 | 53
2022 | 79
2023 | 17

This sums to 417—which is close to but doesn't exactly match the count of currently published casebooks because:

* This data is slightly stale
* It does not exclude casebooks in series
* It does not exclude casebooks which were published but have been unpublished

## Cumulative professors with published casebooks

Year | Casebooks by professors
-- | --
2012 | 3
2013 | 11
2014 | 35
2015 | 56
2016 | 77
2017 | 90
2018 | 106
2019 | 128
2020 | 173
2021 | 205
2022 | 259
2023 | 271

* Does not drop out unpublished casebooks because tracking that by date is unreliable.


