### PR TITLE
Correct case ingestion to never pull an existing case from upstream

### DIFF
--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1013,7 +1013,7 @@ class LegalDocumentResourceView(APIView):
             final_legal_doc = potential_legal_doc
         else:
             if legal_doc.updated_date and legal_doc.updated_date >= datetime.now() - MAX_AGE_BEFORE_REFRESH:
-                # If the copy is potentially stale, check CAP for a more recent copy
+                # If the copy is potentially stale, check upstream for a more recent copy
                 updated_legal_doc = source.pull(id=source_ref)
                 if not updated_legal_doc:
                     raise Http404 


### PR DESCRIPTION
I made some erroneous assumptions about how the case ingestion code had been working prior to some recent updates and introduced a problem where H2O is now pulling new copies of cases it already has as existing `LegalDocuments`. When I went to patch the logic I realized that status quo had been that cases were always been checked in CAP, but then rarely pulled, because the date field being checked was `effective_date`, which maps to `decision_date`, a value I suspect is meant to be immutable? (It's possible this was added to catch cases where the decision date was _corrected_, but the code wasn't commented either way and there weren't unit tests that touched that logic.)

Our conclusion is:

* Prior to the PR referenced in #2004, cases weren't generally being updated with new versions (other than a spate of them in 2021). 
* There doesn't seem to be a good timestamp, at least in CAP, to use to indicate meaningful changes.

So this PR removes any checks with the upstream provider if the legal document _already_ exists, and if it does, uses our most-recent version.

I'm open to restoring the check on `effective_date`, but I'd feel better about doing that if we could document why it might exist, and if we expect those dates to actually be changed upstream.