### PR TITLE
Never return a null value as a link title; fixes #2005

### DIFF
--- a/web/main/utils.py
+++ b/web/main/utils.py
@@ -593,7 +593,7 @@ Harvard Law School Library"""
     )
 
 
-def get_link_title(url) -> str:
+def get_link_title(url: str) -> str:
     file_name_re = re.compile("/([^/]*)(?:[.].{1,4})$")
     last_slug_re = re.compile("/([^/]*)/$")
     file_name = file_name_re.search(url)
@@ -617,6 +617,7 @@ def get_link_title(url) -> str:
     if not title or not title[0].text:
         return default_title
     return title[0].text
+
 
 class LambdaExportTooLarge(RuntimeError):
     pass

--- a/web/main/utils.py
+++ b/web/main/utils.py
@@ -593,7 +593,7 @@ Harvard Law School Library"""
     )
 
 
-def get_link_title(url):
+def get_link_title(url) -> str:
     file_name_re = re.compile("/([^/]*)(?:[.].{1,4})$")
     last_slug_re = re.compile("/([^/]*)/$")
     file_name = file_name_re.search(url)
@@ -614,10 +614,9 @@ def get_link_title(url):
     if not body:
         return default_title
     title = body.find("title")
-    if not title:
+    if not title or not title[0].text:
         return default_title
     return title[0].text
-
 
 class LambdaExportTooLarge(RuntimeError):
     pass


### PR DESCRIPTION
If a link requested from the frontend has an empty HTML title element, `None` was returned from this function and an exception would be thrown when trying to serialize that to the database where the resource title field is non-nullable. This ensures that what comes back is a string (by default, the URL becomes the title).

(This is the kind of thing that type annotations could catch if you declare that the function should always return a string, but PyQuery just always returns a PyQuery object and `pyquery.text` is typed as `Any`.) 

Tested against the actual failure case in #2005.