### PR TITLE
Improve attribution and appearance of credits tab

### DIFF
--- a/web/frontend/styles/casebook.scss
+++ b/web/frontend/styles/casebook.scss
@@ -1,6 +1,7 @@
 @import 'content/dragging';
 @import 'content/annotations';
 @import 'content/modals';
+@import 'credits';
 
 main > .casebook .casebook-inner {
   @include centered-md-column(9);
@@ -740,100 +741,6 @@ form.edit_content_resource, form.edit_content_section, form.edit_content_caseboo
   .search-bar-container {
     width: 100%;
   }
-}
-
-#credits {
-    section.credits {
-        background-color:$white;
-        border-top: 1px solid $light-gray;
-        padding: 0 30px 4rem 30px;
-        h3 {
-            @include sans-serif($bold, 20px, 24px);
-            color: $dark-gray;
-
-        }
-        .author-rider {
-            margin-top: 1rem;
-        }
-        .author-list {
-            display:inline;
-            list-style: none;
-            padding-left: 2rem;
-
-            li {
-                display:inline;
-                white-space: nowrap;
-                &:after {
-                    content: ","
-                }
-                &:last-child:after {
-                    content: ""
-                }
-                @include verified-professor();
-            }
-
-            display: inline;
-            padding-left: 0;
-
-
-            ul {
-                display:inline;
-                list-style:none;
-                padding:0;
-            }
-            .immediate-author-list {
-                padding-right: 0.5rem;
-            }
-        }
-
-        ul.casebook-list {
-            list-style: none;
-            display:flex;
-            flex-direction: column;
-            padding: 0px 0 4rem 0;
-            >li {
-                padding-bottom:3rem;
-                border-bottom: 1px solid black;
-                margin-bottom:3rem;
-                &:last-child {
-                    border-bottom:none;
-                    padding-bottom:0rem;
-                    margin-bottom: 0;
-                }
-            }
-            .casebook-credit-header {
-                padding: 1rem 0;
-
-            }
-            .cloned-content-list {
-                list-style:none;
-                padding-left: 0;
-                display:flex;
-                flex-direction:column;
-                flex-wrap: wrap;
-                li {
-                    padding-top:6px;
-                    @for $depth from 1 to 16 {
-                        &.nesting-depth-#{$depth} {
-                            padding-left: #{(2*$depth)}rem
-                        }
-                    }
-                    .section-title {
-                        padding-right:0.5rem;
-                    }
-                    .og-node-link {
-                        &:before {
-                            content: "(";
-                        }
-                        &:after {
-                            content: ")"
-                        }
-                    }
-                }
-            }
-
-        }
-    }
 }
 
 ul.settings-section {

--- a/web/frontend/styles/credits.scss
+++ b/web/frontend/styles/credits.scss
@@ -1,0 +1,64 @@
+#credits section.credits {
+  background-color: $white;
+  border-top: 1px solid $light-gray;
+  padding: 0 30px 4rem 30px;
+  header {
+
+    h3 {
+        @include sans-serif($bold, 20px, 24px);
+        color: $dark-gray;
+    }
+  }
+
+  .author-list {
+    display: inline;
+    list-style: none;
+    padding-left: 2rem;
+    display: inline;
+    padding-left: 0;
+    
+    .user {
+      font-weight: bold;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+      line-height: 1.8em;
+      li {
+        @include verified-professor();
+
+      }
+    }
+    .immediate-author-list {
+      padding-right: 0.5rem;
+      columns: 2;
+    }
+  }
+
+  ul.casebook-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    padding: 0px 0 4rem 0;
+
+    .casebook-credit-header {
+      padding: 1rem 0;
+    }
+    .cloned-content-list {
+      list-style: none;
+      padding-left: 0;
+      columns: 2;
+      li {
+        padding-top: 6px;
+        @for $depth from 1 to 16 {
+          &.nesting-depth-#{$depth} {
+            padding-left: #{(2 * $depth)}rem;
+          }
+        }
+        .section-title {
+          padding-right: 0.5rem;
+        }
+      }
+    }
+  }
+}

--- a/web/main/models.py
+++ b/web/main/models.py
@@ -2941,7 +2941,7 @@ class ContentNode(
                 self.in_edit_state and self.editable_by(user) and self.annotatable,
             ),
             (read_tab, reverse("section", args=[self.casebook, self]), True),
-            ("Credits", reverse("show_resource_credits", args=[self.casebook, self]), True),
+            ("Credits", reverse("show_credits", args=[self.casebook]), True),
         ]
         return [(n, l, n == current_tab) for n, l, c in tabs if c]
 
@@ -4426,6 +4426,11 @@ class User(NullableTimestampedModel, PermissionsMixin, AbstractBaseUser):
             )
             followed_casebooks.append(cb)
         return followed_casebooks
+
+    @property
+    def is_attributable(self) -> bool:
+        """An author will be displayed in a credits list if they pass this test"""
+        return self.attribution != "Anonymous"
 
     @staticmethod
     def user_can_view_instructional_material(user: Union[AnonymousUser, User]) -> bool:

--- a/web/main/templates/casebook_page_credits.html
+++ b/web/main/templates/casebook_page_credits.html
@@ -9,7 +9,7 @@
 
 {% block mainContent %}
 {% include 'includes/casebook_page_tabs.html' %}
-<section id="credits" class="casebook {{casebook_color_class}}">
+<section id="credits" class="casebook {{ casebook_color_class }}">
     <div class="content">
         <div class="casebook-inner">
             <div class="top-strip"></div>

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -1,15 +1,26 @@
 <section class="credits">
     <div>
         {% if contributing_casebooks %}
-        <h3>Content from the following sources has been used in the creation of this {{type}}:</h3>
+        <h3>Content from the following sources has been used in the creation of this casebook</h3>
+
+        </p>
         <ul class="casebook-list">
             {% for row in contributing_casebooks %}
             <li>
                 <div class="casebook-credit-header">
-                    <a href="{{row.casebook.get_absolute_url}}"><h4> {{ row.casebook.title }} </h4></a>
+                    <header>
+                        <h3><a href="{{ row.casebook.get_absolute_url }}">{{ row.casebook.title }}</a></h3>
+                        {% if row.casebook.first_published  %}
+                            <span>(First published {{ row.casebook.first_published.entry_date | date:"M Y" }})</span>
+                        {% else %}
+                            <span>(First created {{ row.casebook.created_at | date:"M Y"}})</span>
+                        {% endif %}
+                    </header>
+
+
                     {% if row.immediate_authors or row.incidental_authors %}
                         <div class="author-list">
-                            <span>Authors: </span>
+                            <h4>Authors:</h4>
                             <ul class="immediate-author-list">
                                 {% for user in row.immediate_authors %}
                                 <li class="user {% if user.verified_professor %} verified{% endif %}">
@@ -17,27 +28,43 @@
                                 </li>
                                 {% endfor %}
                             </ul>
+                            <br>
+                            <p>Including material from the following sections:</p>
+
+                            <div class="casebook-credit-nodes">
+                                <ul class="cloned-content-list">
+                                    {% for node, prior, nesting_depth in row.nodes %}
+                                        {% if nesting_depth == 0 %}
+                                            <li class="nesting-depth-{{ nesting_depth }}">
+                                                <span class="section-title"><a href="{{ prior.get_absolute_url }}">{{ node.ordinal_string }}{% if node.ordinal_string %}:{% endif %} {{ node.title }}</a></span>
+                                            </li>
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            </div>
+
                             {% if row.incidental_authors %}
-                            <span> with additional contributions by:</span>
+                            <br>
+                            <h4>Incorporating additional material from:</h4>
                             <ul class="incidental-author-list">
-                                {% for user in row.incidental_authors %}
-                                <li class="user {% if user.verified_professor %} verified{% endif %}">
-                                    <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
+                                {% for user, clone in row.incidental_authors %}
+                                <li class="{% if user.verified_professor %} verified{% endif %}">
+                                    <a class="user" href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
+                                    from 
+                                    {% if clone.is_public %}
+                                        <a href="{{ clone.get_absolute_url }}">{{ clone.title }}</a> 
+                                    {% else %}
+                                        {{ clone.title }}
+                                    {% endif %}
+                                    {% if clone.first_published.entry_date %}
+                                      (first published {{ clone.first_published.entry_date | date:"M Y" }}) 
+                                    {% endif %}
                                 </li>
                                 {% endfor %}
                             </ul>
                             {% endif %}
                         </div>
                     {% endif %}
-                </div>
-                <div class="casebook-credit-nodes">
-                    <ul class="cloned-content-list">
-                        {% for node,prior,nesting_depth in row.nodes %}
-                        <li class="nesting-depth-{{nesting_depth}}">
-                            <span class="section-title">{{ node.ordinal_string }}{% if node.ordinal_string %}:{% endif %} {{ node.title }} </span> <a class="og-node-link" href="{{ prior.get_absolute_url }}">original</a>
-                        </li>
-                        {% endfor %}
-                    </ul>
                 </div>
             </li>
             {% endfor %}

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -1,7 +1,7 @@
 <section class="credits">
     <div>
         {% if contributing_casebooks %}
-        <h3>Content from the following sources has been used in the creation of this casebook</h3>
+        <h3>Content from the following sources has been used in the creation of this casebook:</h3>
 
         </p>
         <ul class="casebook-list">

--- a/web/main/templates/includes/resource_tabs.html
+++ b/web/main/templates/includes/resource_tabs.html
@@ -29,11 +29,7 @@
                 {% else %}
                     <a class="tab" href="{{ resource.get_absolute_url }}">Preview</a>
                 {% endif %}
-                {% if credits_tab %}
-                    <span class="tab disabled active">Credits</span>
-                {% else %}
-                    <a class="tab" href="{% url 'show_resource_credits' resource.casebook resource %}">Credits</a>
-                {% endif %}
+                <a class="tab" href="{% url 'show_credits' resource.casebook %}">Credits</a>
             </div>
         </div>
     </div>

--- a/web/main/templates/includes/section_tabs.html
+++ b/web/main/templates/includes/section_tabs.html
@@ -24,11 +24,7 @@
                         <a class="tab" href="{{ section.get_edit_url }}">Edit</a>
                     {% endif %}
                 {% endif %}
-                {% if credits_tab %}
-                    <span class="tab disabled active">Credits</span>
-                {% else %}
-                    <a class="tab" href="{% url 'show_resource_credits' casebook.id section %}">Credits</a>
-                {% endif %}
+                <a class="tab" href="{% url 'show_credits' casebook.id %}">Credits</a>
             </div>
       </div>
     </div>

--- a/web/main/test/test_credits.py
+++ b/web/main/test/test_credits.py
@@ -1,0 +1,75 @@
+from django.urls import reverse
+
+from main.models import Casebook
+
+
+def test_credits_no_parent(full_casebook, client):
+    """The credits page should be displayed for a casebook that was directly authored"""
+    resp = client.get(reverse("show_credits", args=[full_casebook]))
+    assert resp.status_code == 200
+    assert len(resp.context["contributing_casebooks"]) == 0
+
+
+def test_credits_parent(full_casebook, client):
+    """The credits page should indicate that a cloned casebook has a parent"""
+    clone = full_casebook.clone(current_user=full_casebook.testing_editor)
+    client.post(reverse("publish", args=[clone]), as_user=full_casebook.testing_editor)
+    resp = client.get(reverse("show_credits", args=[clone]))
+    assert len(resp.context["contributing_casebooks"]) == 1
+    assert full_casebook == resp.context["contributing_casebooks"][0]["casebook"]
+
+    # Show the nodes for the parent casebook
+    assert full_casebook.children.first().id in [
+        n[1].id for n in resp.context["contributing_casebooks"][0]["nodes"]
+    ]
+
+
+def test_credits_ancestors(full_casebook, user_factory, client):
+    """The credits page should indicate that a cloned casebook has previous ancestors"""
+    other_user = user_factory()
+    clone = full_casebook.clone(current_user=other_user)
+    client.post(reverse("publish", args=[clone]), as_user=other_user)
+
+    clone_of_clone = clone.clone(current_user=full_casebook.testing_editor)
+    client.post(reverse("publish", args=[clone_of_clone]), as_user=full_casebook.testing_editor)
+
+    resp = client.get(reverse("show_credits", args=[clone_of_clone]))
+    assert len(resp.context["contributing_casebooks"]) == 1
+    assert len(resp.context["contributing_casebooks"][0]["incidental_authors"]) == 1
+
+
+def test_credits_omit_drafts(full_casebook, client):
+    """The credits page should canonicalize revised ancestors to their published drafts"""
+    grandparent = full_casebook
+    parent = full_casebook.clone(current_user=full_casebook.testing_editor)
+    assert parent.state != Casebook.LifeCycle.PUBLISHED.value
+    child = parent.clone(current_user=full_casebook.testing_editor)
+    client.post(reverse("publish", args=[child]), as_user=full_casebook.testing_editor)
+    resp = client.get(reverse("show_credits", args=[child]))
+    assert len(resp.context["contributing_casebooks"]) == 1
+
+    # If the immediate parent is a draft, we should only show the grandparent as a contributor
+    assert resp.context["contributing_casebooks"][0]["casebook"].id == grandparent.id
+
+    # Publish the draft and now this should be the direct parent
+    client.post(reverse("publish", args=[parent]), as_user=full_casebook.testing_editor)
+
+    resp = client.get(reverse("show_credits", args=[child]))
+    assert resp.context["contributing_casebooks"][0]["casebook"].id == parent.id
+
+
+def test_credits_omit_private(full_casebook_parts_with_prof_only_resource, client):
+    """The credits page should omit listing sections that are professor-only if the user cannot see them"""
+    casebook, *parts = full_casebook_parts_with_prof_only_resource
+    assert parts[2].is_instructional_material
+
+    clone = casebook.clone(current_user=casebook.testing_editor)
+    client.post(reverse("publish", args=[clone]), as_user=casebook.testing_editor)
+
+    resp = client.get(reverse("show_credits", args=[clone]))
+    assert parts[0] in [n[1] for n in resp.context["contributing_casebooks"][0]["nodes"]]
+    assert parts[2] not in [n[1] for n in resp.context["contributing_casebooks"][0]["nodes"]]
+
+    # As the author, this instructional content is available
+    resp = client.get(reverse("show_credits", args=[clone]), as_user=casebook.testing_editor)
+    assert parts[2] in [n[1] for n in resp.context["contributing_casebooks"][0]["nodes"]]

--- a/web/main/test/test_publishing.py
+++ b/web/main/test/test_publishing.py
@@ -9,7 +9,7 @@ def test_publish_new_casebook(private_casebook, client):
 
     response = client.post(
         reverse("publish", args=[private_casebook]),
-        as_user=private_casebook.contentcollaborator_set.first().user,
+        as_user=private_casebook.testing_editor,
     )
     assert response.status_code == 200
     private_casebook.refresh_from_db()
@@ -27,7 +27,7 @@ def test_publish_draft(casebook, client):
 
     response = client.post(
         reverse("publish", args=[draft]),
-        as_user=casebook.contentcollaborator_set.first().user,
+        as_user=casebook.testing_editor,
     )
     assert response.status_code == 200
     casebook.refresh_from_db()

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -160,11 +160,6 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
         views.new_from_outline,
         name="new_from_outline",
     ),
-    path(
-        "casebooks/<idslug:casebook_param>/sections/<ordslug:section_param>/credits/",
-        views.show_credits,
-        name="show_resource_credits",
-    ),
     # reordering nodes
     path(
         "casebooks/<idslug:casebook_param>/sections/<ordslug:section_param>/reorder/<ordslug:node_param>",


### PR DESCRIPTION
fixes #2012 

The Credits page on production has the following limitations:

* Authors who contributed to casebooks further back in the ancestry tree get limited credit.
* Casebook TOCs are expanded in full depth, making for a cluttered display that does not add information.
* Oftentimes the immediate parent of a casebook (the one that was cloned from) is a non-public draft, leading to links that 404 or return permission denied.
* The labeling can be confusing (#1814).
* Depending on the user's context, the Credits tab may apply to the whole casebook or just the last-viewed section, but this distinction is opaque.

In addition, the Credits view has some complex business logic but no tests.

This PR:

* More clearly assigns credit to earlier authors.
* Clarifies and links the original document sources from which those contributions were drawn.
* Limits the the information to only the most relevant resource pages.
* Always apply at the Casebook level.
* Better handle cases where previous revisions were drafts that were subsequently published, or were never published drafts.
* Adds a test suite.

I'm sure there are still some edge cases here but I think this smooths over some of the most common flaws in the status quo.

## Before

Casebooks with lots of contributors generated hugely long lists, and obscured individual contributions. Many of these links 404 or lead to login pages because they refer to now-private drafts.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19571/234358575-9ce68a33-537d-40e3-8535-dd66ef29e799.png"><img width="70"  alt="image" src="https://user-images.githubusercontent.com/19571/234358475-494fa4f7-aa88-43f7-b033-b46cf0d726a0.png">

## After 

This shows the immediate parent casebook, plus an additional section below for earlier contributors that includes the top-level casebook or sections that were cloned:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/19571/234361626-e01aa0f7-5fe5-45d1-9220-03dc531444ad.png">

If we explore the n-1 casebook, the immediate parent, now the two earlier contributors are foregrounded, and the specific resources are listed:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/19571/234362143-0685c558-08cc-4f1b-9ec1-5417d310132f.png">




