### PR TITLE
Improve appearance of credits page with multi-source work

### DIFF
--- a/web/frontend/styles/credits.scss
+++ b/web/frontend/styles/credits.scss
@@ -11,28 +11,29 @@
   }
 
   .author-list {
-    display: inline;
     list-style: none;
-    padding-left: 2rem;
-    display: inline;
-    padding-left: 0;
-    
-    .user {
-      font-weight: bold;
-    }
+    padding: 1rem 0 0 0;
+    clear: both;
+
     ul {
       list-style: none;
       padding: 0;
       line-height: 1.8em;
       li {
         @include verified-professor();
-
       }
     }
     .immediate-author-list {
       padding-right: 0.5rem;
       columns: 2;
     }
+    .incidental-author-list {
+      margin-top: 1em;
+      li.user {
+        margin-left: 2em;
+      }
+    }
+
   }
 
   ul.casebook-list {
@@ -40,6 +41,23 @@
     display: flex;
     flex-direction: column;
     padding: 0px 0 4rem 0;
+    
+
+    .cover-outline {
+      height: 60px;
+      width: 50px;
+      border-left: 5px solid $light-blue;
+      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+      float: left;
+      margin: 0 2rem 1rem 0;
+      background: url('~static/images/logo-icon-white-on-blue.svg') no-repeat center;
+      background-size: 50%;
+    }
+
+    & > li + li {
+      border-top: 1px solid gray;
+      margin-top: 1rem;
+    }
 
     .casebook-credit-header {
       padding: 1rem 0;

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -61,11 +61,13 @@
                                             (first published {{ clone.first_published.entry_date | date:"M Y" }}) 
                                         {% endif %}
                                         with contributions from: 
+                                        <ul>
                                         {% for user in authors %}
                                             <li class="user {% if user.verified_professor %} verified{% endif %}">
                                                 <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
                                             </li>
                                         {% endfor %}
+                                        </ul>
                                     </li>
                                 </ul>
 

--- a/web/main/templates/includes/credits.html
+++ b/web/main/templates/includes/credits.html
@@ -9,6 +9,7 @@
             <li>
                 <div class="casebook-credit-header">
                     <header>
+                        <div class="cover-outline"></div>
                         <h3><a href="{{ row.casebook.get_absolute_url }}">{{ row.casebook.title }}</a></h3>
                         {% if row.casebook.first_published  %}
                             <span>(First published {{ row.casebook.first_published.entry_date | date:"M Y" }})</span>
@@ -45,23 +46,30 @@
 
                             {% if row.incidental_authors %}
                             <br>
-                            <h4>Incorporating additional material from:</h4>
-                            <ul class="incidental-author-list">
-                                {% for user, clone in row.incidental_authors %}
-                                <li class="{% if user.verified_professor %} verified{% endif %}">
-                                    <a class="user" href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
-                                    from 
-                                    {% if clone.is_public %}
-                                        <a href="{{ clone.get_absolute_url }}">{{ clone.title }}</a> 
-                                    {% else %}
-                                        {{ clone.title }}
-                                    {% endif %}
-                                    {% if clone.first_published.entry_date %}
-                                      (first published {{ clone.first_published.entry_date | date:"M Y" }}) 
-                                    {% endif %}
-                                </li>
+                            <h4 class="incidental-author-title"><em>{{ row.casebook.title }}</em> incorporates additional material from:</h4>
+
+                                {% for clone, authors in row.grouped_incidental_authors.items %}
+                                <ul class="incidental-author-list">
+                                    <li>
+
+                                        {% if clone.is_public %}
+                                            <a href="{{ clone.get_absolute_url }}">{{ clone.title }}</a> 
+                                        {% else %}
+                                            {{ clone.title }}
+                                        {% endif %}
+                                        {% if clone.first_published.entry_date %}
+                                            (first published {{ clone.first_published.entry_date | date:"M Y" }}) 
+                                        {% endif %}
+                                        with contributions from: 
+                                        {% for user in authors %}
+                                            <li class="user {% if user.verified_professor %} verified{% endif %}">
+                                                <a href="{% url 'dashboard' user.id %}">{{ user.display_name }}</a>
+                                            </li>
+                                        {% endfor %}
+                                    </li>
+                                </ul>
+
                                 {% endfor %}
-                            </ul>
                             {% endif %}
                         </div>
                     {% endif %}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1311,6 +1311,16 @@ def show_credits(request: HttpRequest, casebook: Casebook):
 
         casebook_mapping[immediate_clone.id]["nodes"].append((node, prior_node, nesting_depth))
 
+    # Loop back and group by casebook in the incidental authors section
+    for c in casebook_mapping.keys():
+        authors = casebook_mapping[c]["incidental_authors"]
+        grouped: dict[Casebook, list] = {}
+        for author, clone in authors:
+            if clone not in grouped:
+                grouped[clone] = []
+            grouped[clone].append(author)
+        casebook_mapping[c]["grouped_incidental_authors"] = grouped
+
     params = {
         "contributing_casebooks": [v for v in casebook_mapping.values()],
         "casebook": casebook,


### PR DESCRIPTION
Part of #2012 

Further refinements to the credits page based on feedback:

* Adds a small book cover icon to clarify that the source is a book
* Groups ancestor casebook contributions by casebook

## Example

<img width="882" alt="image" src="https://user-images.githubusercontent.com/19571/235714330-3ed0950f-71a9-4e32-9c1a-08131accfc65.png">
