### PR TITLE
Allow membership in group Research Assistant to upload media

### DIFF
--- a/web/main/templates/base.html
+++ b/web/main/templates/base.html
@@ -10,9 +10,10 @@
     <script>
      {# frontend_urls is set by config.context_processors.frontend_urls #}
      const FRONTEND_URLS = {{ frontend_urls | safe}};
-     window.ENABLE_MEDIA_UPLOAD =  {% if request.user.is_superuser or request.user.verified_professor %}true{% else %}false{% endif %};
+     window.ENABLE_MEDIA_UPLOAD =  {% if request.user.is_superuser or request.user.verified_professor or request.user.groups.all.0.name == "Research Assistant" %}true{% else %}false{% endif %};
      window.VERIFIED = {% if request.user.verified_professor %}true{% else %}false{% endif %};
     </script>
+    
     {% include "includes/sentry.html" %}
     {% render_bundle 'main' %}
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Lora|Sorts+Mill+Goudy"/>


### PR DESCRIPTION
fixes #2016 

Simple change to the template to allow membership in the Django group "Research Assistant" to also upload media.

The group must exist in the environment with the hardcoded name. This has already been added to prod. If it doesn't exist this isn't an error; the check just won't pass.

As written this expects that a user will only belong to one Group. For this use case it will be fine as it would not make sense for RA users to also belong to other groups.

(Note that the existing check is already easy to bypass by a determined user.)


## With group membership

<img width="523" alt="image" src="https://github.com/harvard-lil/h2o/assets/19571/a9f95b15-7967-4a4d-af9b-9c65786a29b5">


## Without group membership (no "Upload" link)

<img width="523" alt="Screen Shot 2023-05-10 at 10 22 34 AM" src="https://github.com/harvard-lil/h2o/assets/19571/0afcffe4-23ca-4049-904c-78ddfa66d20c">



