### PR TITLE
Add new timestamps for recent casebooks in reporting

### DIFF
--- a/web/reporting/admin/views.py
+++ b/web/reporting/admin/views.py
@@ -103,8 +103,10 @@ class ProfessorExportMixin(CsvResponseMixin):
             "attribution",
             "email_address",
             "affiliation",
-            "most_recent_casebook_title",
-            "most_recent_casebook_modified",
+            "most_recently_created_casebook_title",
+            "most_recently_created_casebook_creation_date",
+            "most_recently_modified_casebook_title",
+            "most_recently_modified_casebook_modification_date",
             "last_login_at",
         )
 

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -27,8 +27,8 @@ class Professor(User):
         return None
 
     @property
-    def most_recently_modified_casebook(self) -> tuple[Casebook, datetime]:
-        most_recent_casebook: Casebook
+    def most_recently_modified_casebook(self) -> tuple[Optional[Casebook], datetime]:
+        most_recent_casebook: Optional[Casebook] = None
         most_recent_modification_date = datetime(1900, 1, 1)
         for casebook in self.casebooks.all():
             try:

--- a/web/reporting/models.py
+++ b/web/reporting/models.py
@@ -21,14 +21,14 @@ class Professor(User):
         return ""
 
     @property
-    def most_recently_created_casebook_creation_date(self) -> Optional[datetime]:
+    def most_recently_created_casebook_creation_date(self) -> Optional[str]:
         if casebook := self.most_recently_created_casebook:
             return casebook.created_at.strftime("%Y-%m-%d")
         return None
 
     @property
     def most_recently_modified_casebook(self) -> tuple[Casebook, datetime]:
-        most_recent_casebook = None
+        most_recent_casebook: Casebook
         most_recent_modification_date = datetime(1900, 1, 1)
         for casebook in self.casebooks.all():
             try:
@@ -42,7 +42,7 @@ class Professor(User):
                 pass
         # Compare against the modification date of the casebook itself too; it may be newer than its contents
         try:
-            most_recently_modified_casebook_obj = self.casebooks.latest("updated_at")
+            most_recently_modified_casebook_obj: Casebook = self.casebooks.latest("updated_at")
             if most_recently_modified_casebook_obj.updated_at > most_recent_modification_date:
                 most_recent_modification_date = most_recently_modified_casebook_obj.updated_at
                 most_recent_casebook = most_recently_modified_casebook_obj
@@ -58,7 +58,7 @@ class Professor(User):
         return ""
 
     @property
-    def most_recently_modified_casebook_modification_date(self) -> Optional[datetime]:
+    def most_recently_modified_casebook_modification_date(self) -> Optional[str]:
         if self.most_recently_modified_casebook[0]:
             if date := self.most_recently_modified_casebook[1]:
                 return date.strftime("%Y-%m-%d")


### PR DESCRIPTION
@cath9 wanted to see which authors had recent activity on casebooks in reporting. 

This modifies all professor-level reports to include two new columns:

* `most_recently_modified_casebook_title`: the casebook that was most recently modified
* `most_recently_modified_casebook_modification_date`: the date on which it was modified

This is distinct from the most recently _created_ casebook, which may be an obsolete or unused clone and while technically be more recent, actually not have more recent activity.

"most recently modified" here means any modification to any of the `ContentNode` objects (so, the content of the chapter or resource) OR any modification to the `Casebook` object itself. It doesn't include any annotations added to it, including elisions, though the method could be modified to do that. (Ideally H2O would track last-mod date at the casebook level holistically through signals or some other method.)

(Also changed these methods to return strings rather than datetime objects to force Excel to default to understanding them as dates.)

