### PR TITLE
Disable export of sections and resources

### DIFF
--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -215,8 +215,8 @@ urlpatterns = format_suffix_patterns(drf_urlpatterns) + [
     path("casebooks/new", views.new_casebook, name="new_casebook"),
     # export
     path("casebooks/<casebook:node>/export.<file_type>", views.export, name="export_casebook"),
-    path("sections/<section:node>/export.<file_type>", views.export, name="export_section"),
-    path("resources/<resource:node>/export.<file_type>", views.export, name="export_resource"),
+    # path("sections/<section:node>/export.<file_type>", views.export, name="export_section"),
+    # path("resources/<resource:node>/export.<file_type>", views.export, name="export_resource"),
     # Reading mode
     path(
         "casebooks/<idslug:casebook_param>/as-printable-html/",

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -267,43 +267,74 @@ def actions(request, context):
     # These pages allow the same actions regardless of node types
     ##
 
-    When a logged out user visits casebooks, sections, and resources:
-    >>> for o in [published, published_section, published_resource]:
+    When a logged out user visits casebooks:
+    >>> for o in [published]:
     ...     check_response(
     ...         client.get(o.get_absolute_url()),
-    ...         content_includes='actions="exportable"'
+    ...         content_includes='data-actions="exportable"'
     ...     )
 
-    When a collaborator views a published casebook WITHOUT a draft, or
-    any of that casebook's sections or resources:
-    >>> for o in [published, published_section, published_resource]:
+    When a logged out user visits sections and resources:
+    >>> for o in [published_section, published_resource]:
+    ...     check_response(
+    ...         client.get(o.get_absolute_url()),
+    ...         content_includes='data-actions=""'
+    ...     )
+
+    When a collaborator views a published casebook WITHOUT a draft
+    >>> for o in [published]:
     ...     check_response(
     ...         client.get(o.get_absolute_url(), as_user=published.testing_editor),
-    ...         content_includes='actions="exportable,cloneable,can_create_draft"'
+    ...         content_includes='data-actions="exportable,cloneable,can_create_draft"'
     ...     )
 
-    When a collaborator views a published casebook WITH a draft, or
-    any of that casebook's sections or resources:
-    >>> for o in [with_draft, with_draft_section, with_draft_resource]:
+    When a collaborator views the sections or resources of a published casebook WITHOUT a draft:
+    >>> for o in [published_section, published_resource]:
+    ...     check_response(
+    ...         client.get(o.get_absolute_url(), as_user=published.testing_editor),
+    ...         content_includes='data-actions="cloneable,can_create_draft"'
+    ...     )
+
+    When a collaborator views a published casebook WITH a draft:
+    >>> for o in [with_draft]:
     ...     check_response(
     ...         client.get(o.get_absolute_url(), as_user=with_draft.testing_editor),
     ...         content_includes='actions="exportable,cloneable,publishable,can_view_existing_draft"'
     ...     )
 
-    When a collaborator views the "preview" page of a private, never published casebook, or
-    the preview pages of any of that casebook's sections or resources:
-    >>> for o in [private, private_section, private_resource]:
+    When a collaborator views the sections or resources of a published casebook WITH a draft:
+    >>> for o in [with_draft_section, with_draft_resource]:
+    ...     check_response(
+    ...         client.get(o.get_absolute_url(), as_user=with_draft.testing_editor),
+    ...         content_includes='actions="cloneable,publishable,can_view_existing_draft"'
+    ...     )
+
+    When a collaborator views the "preview" page of a private, never published casebook:
+    >>> for o in [private]:
     ...     check_response(
     ...         client.get(o.get_absolute_url(), as_user=private.testing_editor),
     ...         content_includes='actions="exportable,cloneable,publishable,can_be_directly_edited"'
     ...     )
 
-    When a collaborator views the "preview" page of a draft of an already-published casebook, or
-    the preview pages of any of that casebook's sections or resources:
-    >>> for o in [draft, draft_section, draft_resource]:
+    When a collaborator views the "preview" page of the sections or resources of a private, never published casebook:
+    >>> for o in [private_section, private_resource]:
+    ...     check_response(
+    ...         client.get(o.get_absolute_url(), as_user=private.testing_editor),
+    ...         content_includes='actions="cloneable,publishable,can_be_directly_edited"'
+    ...     )
+
+    When a collaborator views the "preview" page of a draft of an already-published casebook:
+    >>> for o in [draft]:
     ...     check_response(
     ...         client.get(o.get_absolute_url(), as_user=draft.testing_editor),
     ...         content_includes='actions="exportable,publishable,can_be_directly_edited"'
+    ...     )
+
+    When a collaborator views the "preview" page of the sections or resources of a draft of an already-published casebook:
+    >>> for o in [draft_section, draft_resource]:
+    ...     check_response(
+    ...         client.get(o.get_absolute_url(), as_user=draft.testing_editor),
+    ...         content_includes='actions="publishable,can_be_directly_edited"'
     ...     )
 
     ##
@@ -329,13 +360,13 @@ def actions(request, context):
     When a collaborator views the "edit" page of a section in a private, never-published casebook
     >>> check_response(
     ...     client.get(private_section.get_edit_url(), as_user=private.testing_editor),
-    ...     content_includes='actions="exportable,previewable,can_save_nodes,can_add_nodes"'
+    ...     content_includes='actions="previewable,can_save_nodes,can_add_nodes"'
     ... )
 
     When a collaborator views the "edit" page of a section in draft of an already-published casebook
     >>> check_response(
     ...     client.get(draft_section.get_edit_url(), as_user=draft.testing_editor),
-    ...     content_includes='actions="exportable,previewable,publishable,can_save_nodes,can_add_nodes"'
+    ...     content_includes='actions="previewable,publishable,can_save_nodes,can_add_nodes"'
     ... )
 
     # Resource
@@ -343,25 +374,25 @@ def actions(request, context):
     When a collaborator views the "edit" page of a resource in a private, never-published casebook
     >>> check_response(
     ...     client.get(private_resource.get_edit_url(), as_user=private.testing_editor),
-    ...     content_includes='actions="exportable,previewable,can_save_nodes"'
+    ...     content_includes='actions="previewable,can_save_nodes"'
     ... )
 
     When a collaborator views the "edit" page of a resource in draft of an already-published casebook
     >>> check_response(
     ...     client.get(draft_resource.get_edit_url(), as_user=draft.testing_editor),
-    ...     content_includes='actions="exportable,previewable,publishable,can_save_nodes"'
+    ...     content_includes='actions="previewable,publishable,can_save_nodes"'
     ... )
 
     When a collaborator views the "annotate" page of a resource in a private, never-published casebook
     >>> check_response(
     ...     client.get(private_resource.get_annotate_url(), as_user=private.testing_editor),
-    ...     content_includes='actions="exportable,previewable"'
+    ...     content_includes='actions="previewable"'
     ... )
 
     When a collaborator views the "annotate" page of a resource in draft of an already-published casebook
     >>> check_response(
     ...     client.get(draft_resource.get_annotate_url(), as_user=draft.testing_editor),
-    ...     content_includes='actions="exportable,previewable,publishable"'
+    ...     content_includes='actions="previewable,publishable"'
     ... )
 
     """

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -393,7 +393,7 @@ def actions(request, context):
 
     actions = OrderedDict(
         [
-            ("exportable", True),
+            ("exportable", view in ["edit_casebook", "casebook"]),
             ("cloneable", cloneable),
             ("previewable", context.get("editing", False)),
             ("publishable", publishable),


### PR DESCRIPTION
See ENG-300 and ENG-414.

DOCX export of sections is sometimes not coming out right: headings are sometimes displayed in odd and misleading locations.

We believe it's something about [reference.docx](https://github.com/harvard-lil/h2o/blob/51c4b7c54f1b4b55789f003f907758d5a4c0a935/docker/pandoc-lambda/function/README.md#L4), some kind of absolute positioning gone wrong... but we aren't sure.

We don't love this but... for now, disable the exporting of individual sections and resources so that people don't encounter mixed up exports: they can always export the entire casebook, and delete the pages they don't need.