### PR TITLE
Prevent duplicative merge attempts.

### DIFF
--- a/web/main/test/test_drafts.py
+++ b/web/main/test/test_drafts.py
@@ -67,7 +67,6 @@ def test_merge_drafts(reset_sequences, full_casebook, assert_num_queries, legal_
 
 @pytest.mark.django_db(transaction=True)
 def test_duplicative_merge_prevented(full_casebook_with_draft):
-    """ Fetch two jobs at the same time in threads and make sure same job isn't returned to both. """
     draft = full_casebook_with_draft.draft
 
     def attempt_merge(i):
@@ -84,5 +83,6 @@ def test_duplicative_merge_prevented(full_casebook_with_draft):
         results = e.map(attempt_merge, range(2))
 
     first, second = list(results)
-    assert (first is True and "already being merged" in str(second)) or \
-           (second is True and "already being merged" in str(first))
+    assert (first is True and "already being merged" in str(second)) or (
+        second is True and "already being merged" in str(first)
+    )

--- a/web/main/test/test_drafts.py
+++ b/web/main/test/test_drafts.py
@@ -34,7 +34,7 @@ def test_merge_drafts(reset_sequences, full_casebook, assert_num_queries, legal_
         resource_id=ld.id,
         resource_type="LegalDocument",
     ).save()
-    with assert_num_queries(select=10, update=3, insert=4):
+    with assert_num_queries(select=12, update=3, insert=4):
         new_casebook = draft.merge_draft()
     assert new_casebook == full_casebook
     expected = [


### PR DESCRIPTION
If you attempt to "publish" the same draft multiple times and make your requests quickly enough, multiple attempts may pass [this test](https://github.com/harvard-lil/h2o/blob/develop/web/main/models.py#L2968) and proceed through the merging code.

That is never desirable.

And I have not yet definitively proved, but am quite convinced that this occasionally completely corrupts the casebook involved.

This PR uses `select_for_update` to ensure that only one publication attempt is ever in progress at once.

The user experience could still use some polishing: right now, on prod, if something goes wrong with the "publish" modal (for instance, you open two tabs with a draft, and click publish in one, wait a few seconds, and then click publish in the other), the modal just stays open. Your request gets a 400... but unless the dev tools are open, you don't see any notification.

I tried to fix that in this PR too, so that I could add an error message for THAT situation AND for the situation this PR fixes. But I couldn't figure it out... 

But, I think this is worth it even without that: a weirdly not-closing modal is better than a potentially corrupted book!