### PR TITLE
Comment out pandoc lambda build for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,24 +58,24 @@ jobs:
       # this requires that AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION,
       # and AWS_ACCOUNT_ID be set.
       # TODO: this could potentially use existing built image
-      - name: Publish pandoc-lambda image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: |
-          aws --version
-          cd docker/pandoc-lambda/
-          IMG=pandoc-lambda
-          TAG=`git rev-parse --short HEAD`
-          ACCT=${AWS_ACCOUNT_ID}
-          REGION=${AWS_DEFAULT_REGION}
-          ARN=arn:aws:lambda:${REGION}:${ACCT}:function:h2o-export-stage
-          aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ACCT}.dkr.ecr.${REGION}.amazonaws.com
-          docker buildx build --push --platform linux/amd64 --tag ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} .
-          aws lambda update-function-code --function-name ${ARN} --image-uri ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} --region ${REGION}
+      # - name: Publish pandoc-lambda image
+      #   if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #   run: |
+      #     aws --version
+      #     cd docker/pandoc-lambda/
+      #     IMG=pandoc-lambda
+      #     TAG=`git rev-parse --short HEAD`
+      #     ACCT=${AWS_ACCOUNT_ID}
+      #     REGION=${AWS_DEFAULT_REGION}
+      #     ARN=arn:aws:lambda:${REGION}:${ACCT}:function:h2o-export-stage
+      #     aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ACCT}.dkr.ecr.${REGION}.amazonaws.com
+      #     docker buildx build --push --platform linux/amd64 --tag ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} .
+      #     aws lambda update-function-code --function-name ${ARN} --image-uri ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} --region ${REGION}
 
       # Commit built assets if necessary, then deploy via Salt reactor
       - name: Deploy


### PR DESCRIPTION
This disables the failing build step for the pandoc-lambda image for the moment; the error is `An error occurred (InvalidParameterValueException) when calling the UpdateFunctionCode operation: The image manifest or layer media type for the source image ***.dkr.ecr.***.amazonaws.com/pandoc-lambda:74e2139 is not supported.`