### PR TITLE
Add three packages to playwright deps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,9 @@ RUN  apt-get update && apt install -y --no-install-recommends libdbus-glib-1-2 \
     libgbm1 \
     libasound2 \
     libatspi2.0-0 \
-    libwayland-client0
+    libwayland-client0 \
+    libx11-xcb1 \
+    libxcursor1 \
+    libgtk-3-0
 
 RUN playwright install chromium firefox


### PR DESCRIPTION
Although tests are passing, I see
```
#57 44.39 ╔══════════════════════════════════════════════════════╗
#57 44.39 ║ Host system is missing dependencies to run browsers. ║
#57 44.39 ║ Missing libraries:                                   ║
#57 44.39 ║     libX11-xcb.so.1                                  ║
#57 44.39 ║     libXcursor.so.1                                  ║
#57 44.39 ║     libgtk-3.so.0                                    ║
#57 44.39 ║     libgdk-3.so.0                                    ║
#57 44.39 ╚══════════════════════════════════════════════════════╝
```
in the build logs; these three packages supply the four libraries in question.