### PR TITLE
Suppress error for non-UUID in image route

### DIFF
--- a/web/main/views.py
+++ b/web/main/views.py
@@ -3280,5 +3280,10 @@ def view_image(request, image_uuid):
     Redirect to S3 with temp creds.
 
     """
-    saved_image = get_object_or_404(SavedImage.objects.filter(external_id=image_uuid))
-    return redirect(saved_image.image.url)
+    try:
+        assert uuid.UUID(image_uuid)
+        saved_image = get_object_or_404(SavedImage.objects.filter(external_id=image_uuid))
+        return redirect(saved_image.image.url)
+    except ValueError:
+        # image_uuid is not a UUID
+        raise Http404


### PR DESCRIPTION
This suppresses errors that occur when someone tries to get routes like `/image/png`, which should 404 instead. The slightly non-idiomatic use of the assertion is in order to have the same effect in the dev environment as in deployments; a bare try-except does not catch the error in dev, where I think the storage abstraction behaves differently -- the error just looks like
```
Traceback:

File "" in
```