### PR TITLE
Suppress error for non-existent page

### DIFF
--- a/web/main/views.py
+++ b/web/main/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.views import PasswordResetView, redirect_to_login
 from django.core.exceptions import PermissionDenied
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, EmptyPage
 from django.core.validators import URLValidator
 from django.db import transaction
 from django.db.models import Q
@@ -2818,7 +2818,10 @@ def as_printable_html(
     logger.info(f"Rendering Casebook {casebook.id}, starting from page {page}: serializing to HTML")
 
     paginator = Paginator(top_level_nodes, 1)
-    page = paginator.page(page)
+    try:
+        page = paginator.page(page)
+    except EmptyPage:
+        raise Http404
     section = page[0]
 
     node_filter = {} if whole_book else {"ordinals__0": section.ordinals[0]}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -2821,6 +2821,7 @@ def as_printable_html(
     try:
         page = paginator.page(page)
     except EmptyPage:
+        logger.info(f"Page {page} of Casebook {casebook.id} not found")
         raise Http404
     section = page[0]
 


### PR DESCRIPTION
This changes an error to a 404 when the paginator is asked for a page that doesn't exist. Currently, the error looks like
```
Internal Server Error: /casebooks/11306-abortion-guns-and-climate-change-reading-group-spring-2024/as-printable-html/17/

EmptyPage at /casebooks/11306-abortion-guns-and-climate-change-reading-group-spring-2024/as-printable-html/17/
That page contains no results
```