### PR TITLE
add first draft of CL search

### DIFF
--- a/web/main/case_xml_converter.py
+++ b/web/main/case_xml_converter.py
@@ -2,8 +2,6 @@
 Convert between XML and HTML versions of CAP's formatted case data.
 """
 
-from pprint import pprint
-
 import lxml.sax
 import lxml.html
 import xml.sax
@@ -81,7 +79,7 @@ class XmlToHtmlHandler(xml.sax.ContentHandler):
                         "a",
                         {
                             "id": "p" + label,
-                            "href": f"#p" + label,
+                            "href": f"#p{label}",
                             "data-label": label,
                             "data-citation-index": attrs["citation-index"],
                             "class": "page-label",

--- a/web/main/case_xml_converter.py
+++ b/web/main/case_xml_converter.py
@@ -67,8 +67,10 @@ class XmlToHtmlHandler(xml.sax.ContentHandler):
         elif name == "opinion":
             if self.head_matter_open:
                 self.close_head_matter()
+            # set opinion type to 'none' for opinions that don't have 'type' in source xml
+            attr_type = attrs.get("type", "none")
             self.tag_stack.append(
-                (sax_start, ("article", {"class": "opinion", "data-type": attrs["type"]}))
+                (sax_start, ("article", {"class": "opinion", "data-type": attr_type}))
             )
         elif name == "page-number":
             label = attrs["label"]
@@ -111,7 +113,9 @@ class XmlToHtmlHandler(xml.sax.ContentHandler):
             "blockquote",
         ):
             # content element
-            attrs = {"id": attrs["id"]}
+            # set id to 'none' for elements that don't have 'id' in source xml
+            attrs_id = attrs.get("id", "none")
+            attrs = {"id": attrs_id}
             if "data-blocks" in attrs:
                 attrs["data-blocks"] = attrs["data-blocks"]
             if name not in ("p", "blockquote"):

--- a/web/main/case_xml_converter.py
+++ b/web/main/case_xml_converter.py
@@ -1,0 +1,149 @@
+"""
+Convert between XML and HTML versions of CAP's formatted case data.
+"""
+
+from pprint import pprint
+
+import lxml.sax
+import lxml.html
+import xml.sax
+
+from lxml import etree
+
+# sax functions passed to render_sax_tags
+sax_start = lxml.sax.ElementTreeContentHandler.startElement
+sax_end = lxml.sax.ElementTreeContentHandler.endElement
+sax_chars = lxml.sax.ElementTreeContentHandler.characters
+
+mapping = {
+    "casebody": "section",
+    "parties": "h4",
+    "docketnumber": "p",
+    "court": "p",
+    "decisiondate": "p",
+    "otherdate": "p",
+    "attorneys": "p",
+    "opinion": "article",
+    "author": "p",
+    "page-number": "a",
+    "extracted-citation": "a",
+    "bracketnum": "a",
+    "footnotemark": "a",
+}
+
+
+def render_sax_tags(tag_stack):
+    # run all of our commands, like "sax_start(*args)", to actually build the xml tree
+    handler = lxml.sax.ElementTreeContentHandler()
+    for method, args in tag_stack:
+        method(handler, *args)
+    return handler._root
+
+
+class XmlToHtmlHandler(xml.sax.ContentHandler):
+    def __init__(self, case_id):
+        self.tag_stack = []
+        self.case_id = case_id
+        self.head_matter_open = False
+
+    def startElement(self, name, attrs):
+
+        if name == "casebody":
+            self.tag_stack.append(
+                (
+                    sax_start,
+                    (
+                        "section",
+                        {
+                            "class": "casebody",
+                            "data-case-id": self.case_id,
+                            "data-firstpage": attrs["firstpage"],
+                            "data-lastpage": attrs["lastpage"],
+                        },
+                    ),
+                )
+            )
+            self.tag_stack.append((sax_chars, ("\n  ",)))
+            self.tag_stack.append((sax_start, ("section", {"class": "head-matter"})))
+            self.head_matter_open = True
+        elif name == "opinion":
+            if self.head_matter_open:
+                self.close_head_matter()
+            self.tag_stack.append(
+                (sax_start, ("article", {"class": "opinion", "data-type": attrs["type"]}))
+            )
+        elif name == "page-number":
+            label = attrs["label"]
+            self.tag_stack.append(
+                (
+                    sax_start,
+                    (
+                        "a",
+                        {
+                            "id": "p" + label,
+                            "href": f"#p" + label,
+                            "data-label": label,
+                            "data-citation-index": attrs["citation-index"],
+                            "class": "page-label",
+                        },
+                    ),
+                )
+            )
+        elif name == "extracted-citation":
+            new_attrs = {"href": attrs["url"], "class": "citation", "data-index": attrs["index"]}
+            if "case-ids" in attrs:
+                new_attrs["data-case-ids"] = attrs["case-ids"]
+            self.tag_stack.append((sax_start, ("a", new_attrs)))
+        elif name in ("footnotemark", "bracketnum"):
+            new_attrs = {"class": name}
+            if "href" in attrs:
+                new_attrs["href"] = attrs["href"]
+            if "id" in attrs:
+                new_attrs["id"] = attrs["id"]
+            self.tag_stack.append((sax_start, ("a", new_attrs)))
+        elif name in (
+            "parties",
+            "docketnumber",
+            "court",
+            "decisiondate",
+            "otherdate",
+            "attorneys",
+            "author",
+            "p",
+            "blockquote",
+        ):
+            # content element
+            attrs = {"id": attrs["id"]}
+            if "data-blocks" in attrs:
+                attrs["data-blocks"] = attrs["data-blocks"]
+            if name not in ("p", "blockquote"):
+                attrs["class"] = name
+            new_name = "h4" if name == "parties" else "blockquote" if name == "blockquote" else "p"
+            if self.head_matter_open:
+                self.tag_stack.append((sax_chars, ("  ",)))
+            self.tag_stack.append((sax_start, (new_name, attrs)))
+        else:
+            # passthrough
+            self.tag_stack.append((sax_start, (name, attrs)))
+
+    def characters(self, text):
+        if self.head_matter_open and text == "    ":
+            text = "      "
+        self.tag_stack.append((sax_chars, (text,)))
+
+    def endElement(self, name):
+        if name == "casebody" and self.head_matter_open:
+            self.close_head_matter()
+        self.tag_stack.append((sax_end, (mapping.get(name, name),)))
+
+    def close_head_matter(self):
+        self.tag_stack.append((sax_end, ("section",)))
+        self.tag_stack.append((sax_chars, ("\n  ",)))
+        self.head_matter_open = False
+
+
+def xml_to_html(input, case_id):
+    handler = XmlToHtmlHandler(case_id)
+    xml.sax.parseString(input, handler)
+    tree = render_sax_tags(handler.tag_stack)
+    return etree.tostring(tree, encoding=str, method="html")

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -645,9 +645,7 @@ class CourtListener:
     @staticmethod
     def prepare_case_html(cluster, opinions_xml):
         xml_declaration = (
-            "<?xml version='1.0' encoding='utf-8'?>\n"
-            "<casebody xmlns='http://nrs.harvard.edu/urn-3:HLS.Libr.US_Case_Law.Schema.Case_Body:v1' "
-            "firstpage='0' lastpage='0'>"
+            "<?xml version='1.0' encoding='utf-8'?>\n<casebody firstpage='0' lastpage='0'>"
         )
         case_xml = f"{xml_declaration}\n{cluster['headmatter']}\n{opinions_xml}</casebody>"
         # 'mismatched br tag' and 'invalid attribute https:' error workarounds

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -581,6 +581,7 @@ class CourtListener:
             resp.raise_for_status()
             cluster = resp.json()
             cluster["html_info"] = {"source": "court listener"}
+            cluster["sub_opinions"].sort(key=lambda x: int(x.split("/")[-2]))
 
             if cluster["filepath_json_harvard"]:
                 harvard_xml_data = ""

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -537,11 +537,7 @@ class CourtListener:
         if not settings.COURTLISTENER_API_KEY:
             raise APICommunicationError("A CourtListener API key is required")
         try:
-            params = (
-                {"citation": search_params.q}
-                if looks_like_citation(search_params.q)
-                else {"q": search_params.q}
-            )
+            params = CourtListener.cl_params(search_params)
             resp = requests.get(
                 f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/search",
                 params,
@@ -647,6 +643,21 @@ class CourtListener:
         )
         case_xml = f"{xml_declaration}\n{cluster['headmatter']}\n{opinions_xml}</casebody>"
         return convert_case_xml_to_html(case_xml)
+
+    @staticmethod
+    def cl_params(search_params):
+        search_type_param = (
+            {"citation": search_params.q}
+            if looks_like_citation(search_params.q)
+            else {"q": search_params.q}
+        )
+        search_params = {
+            "filed_after": search_params.after_date,
+            "filed_before": search_params.before_date,
+            "court": search_params.jurisdiction,
+        }
+        params = {**search_type_param, **search_params}
+        return {k: params[k] for k in params.keys() if params[k] is not None}
 
 
 class LegacyNoSearch:

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -675,10 +675,10 @@ class CourtListener:
             "<otherdate": '<p class="otherdate"',
             "<decisiondate": '<p class="decisiondate"',
             "<attorneys": '<p class="attorneys"',
-            "</docketnumber>": "</h4>",
-            "</otherdate>": "</h4>",
-            "</decisiondate>": "</h4>",
-            "</attorneys>": "</h4>",
+            "</docketnumber>": "</p>",
+            "</otherdate>": "</p>",
+            "</decisiondate>": "</p>",
+            "</attorneys>": "</p>",
             "<br>": "",
         }
 

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -605,7 +605,7 @@ class CourtListener:
         cluster["html_info"] = {"source": "court listener"}
 
         # https://www.courtlistener.com/help/api/rest/#case-names
-        case_name = None
+        case_name = ""
         if cluster["case_name"]:
             case_name = cluster["case_name"]
         elif cluster["case_name_full"]:

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -13,7 +13,7 @@ from dateutil import parser
 from django.conf import settings
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from pyquery import PyQuery
-from .case_xml_converter import xml_to_html
+from main.case_xml_converter import xml_to_html
 
 from main.utils import (
     APICommunicationError,
@@ -537,7 +537,7 @@ class CourtListener:
         if not settings.COURTLISTENER_API_KEY:
             raise APICommunicationError("A CourtListener API key is required")
         try:
-            params = CourtListener.cl_params(search_params)
+            params = CourtListener.get_search_params(search_params)
             resp = requests.get(
                 f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/search",
                 params,
@@ -660,7 +660,7 @@ class CourtListener:
         return converted_case_html
 
     @staticmethod
-    def cl_params(search_params):
+    def get_search_params(search_params):
         search_type_param = (
             {"citation": search_params.q}
             if looks_like_citation(search_params.q)

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -641,8 +641,14 @@ class CourtListener:
             "<casebody xmlns='http://nrs.harvard.edu/urn-3:HLS.Libr.US_Case_Law.Schema.Case_Body:v1' "
             "firstpage='0' lastpage='0'>"
         )
-        case_xml = f"{xml_declaration}\n{cluster['headmatter']}\n{opinions_xml}</casebody>"
-        return convert_case_xml_to_html(case_xml)
+        case_xml = f"{xml_declaration}\n{opinions_xml}</casebody>"
+        converted_case_html = convert_case_xml_to_html(case_xml)
+        formatted_headmatter_html = CourtListener.format_headmatter(cluster["headmatter"])
+
+        if formatted_headmatter_html:
+            return formatted_headmatter_html + converted_case_html
+        else:
+            return converted_case_html
 
     @staticmethod
     def cl_params(search_params):
@@ -658,6 +664,33 @@ class CourtListener:
         }
         params = {**search_type_param, **search_params}
         return {k: params[k] for k in params.keys() if params[k] is not None}
+
+    @staticmethod
+    def format_headmatter(headmatter_str):
+        replacements = {
+            "\n": "",
+            "<parties": '<h4 class="parties"',
+            "</parties>": "</h4>",
+            "<docketnumber": '<p class="docketnumber"',
+            "<otherdate": '<p class="otherdate"',
+            "<decisiondate": '<p class="decisiondate"',
+            "<attorneys": '<p class="attorneys"',
+            "</docketnumber>": "</h4>",
+            "</otherdate>": "</h4>",
+            "</decisiondate>": "</h4>",
+            "</attorneys>": "</h4>",
+            "<br>": "",
+        }
+
+        try:
+            pattern = "|".join(replacements.keys())
+            cleaned_headmatter = re.sub(
+                pattern, lambda match: replacements[match.group(0)], headmatter_str
+            )
+        except TypeError:
+            cleaned_headmatter = None
+
+        return cleaned_headmatter
 
 
 class LegacyNoSearch:

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -580,7 +580,6 @@ class CourtListener:
             )
             resp.raise_for_status()
             cluster = resp.json()
-            cluster["html_info"] = {"source": "court listener"}
 
             if cluster["filepath_json_harvard"]:
                 harvard_xml_data = ""
@@ -603,6 +602,7 @@ class CourtListener:
         citations = [
             f"{x.get('volume')} {x.get('reporter')} {x.get('page')}" for x in cluster["citations"]
         ]
+        cluster["html_info"] = {"source": "court listener"}
         case = LegalDocument(
             source=legal_doc_source,
             short_name=cluster.get("case_name"),
@@ -642,13 +642,13 @@ class CourtListener:
             "firstpage='0' lastpage='0'>"
         )
         case_xml = f"{xml_declaration}\n{cluster['headmatter']}\n{opinions_xml}</casebody>"
-        # mismatched tag error workaround
-        case_xml = case_xml.replace("<br>", "")
+        # 'mismatched br tag' and 'invalid attribute https:' error workarounds
+        case_xml = case_xml.replace("<br>", "").replace('https:=""', "")
 
         try:
             converted_case_html = xml_to_html(case_xml, str(cluster["id"]))
         except Exception as e:
-            msg = f"Error converting xml to html: {e}"
+            msg = f"Error converting xml to html for case {cluster['id']}: {e}"
             raise Exception(msg)
 
         return converted_case_html

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -557,7 +557,7 @@ class CourtListener:
             results.append(
                 {
                     "fullName": r["caseName"],
-                    "shortName": r["caseName"],
+                    "shortName": truncate_name(r["caseName"]),
                     "fullCitations": ", ".join(r["citation"]) if r["citation"] else "",
                     "shortCitations": (
                         ", ".join(r["citation"][:3]) + ("..." if len(r["citation"]) > 3 else "")

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -13,12 +13,12 @@ from dateutil import parser
 from django.conf import settings
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from pyquery import PyQuery
+from .case_xml_converter import xml_to_html
 
 from main.utils import (
     APICommunicationError,
     looks_like_case_law_link,
     looks_like_citation,
-    convert_case_xml_to_html,
 )
 
 vs_check = re.compile(" [vV][sS]?[.]? ")
@@ -641,14 +641,17 @@ class CourtListener:
             "<casebody xmlns='http://nrs.harvard.edu/urn-3:HLS.Libr.US_Case_Law.Schema.Case_Body:v1' "
             "firstpage='0' lastpage='0'>"
         )
-        case_xml = f"{xml_declaration}\n{opinions_xml}</casebody>"
-        converted_case_html = convert_case_xml_to_html(case_xml)
-        formatted_headmatter_html = CourtListener.format_headmatter(cluster["headmatter"])
+        case_xml = f"{xml_declaration}\n{cluster['headmatter']}\n{opinions_xml}</casebody>"
+        # mismatched tag error workaround
+        case_xml = case_xml.replace("<br>", "")
 
-        if formatted_headmatter_html:
-            return formatted_headmatter_html + converted_case_html
-        else:
-            return converted_case_html
+        try:
+            converted_case_html = xml_to_html(case_xml, str(cluster["id"]))
+        except Exception as e:
+            msg = f"Error converting xml to html: {e}"
+            raise Exception(msg)
+
+        return converted_case_html
 
     @staticmethod
     def cl_params(search_params):
@@ -664,33 +667,6 @@ class CourtListener:
         }
         params = {**search_type_param, **search_params}
         return {k: params[k] for k in params.keys() if params[k] is not None}
-
-    @staticmethod
-    def format_headmatter(headmatter_str):
-        replacements = {
-            "\n": "",
-            "<parties": '<h4 class="parties"',
-            "</parties>": "</h4>",
-            "<docketnumber": '<p class="docketnumber"',
-            "<otherdate": '<p class="otherdate"',
-            "<decisiondate": '<p class="decisiondate"',
-            "<attorneys": '<p class="attorneys"',
-            "</docketnumber>": "</p>",
-            "</otherdate>": "</p>",
-            "</decisiondate>": "</p>",
-            "</attorneys>": "</p>",
-            "<br>": "",
-        }
-
-        try:
-            pattern = "|".join(replacements.keys())
-            cleaned_headmatter = re.sub(
-                pattern, lambda match: replacements[match.group(0)], headmatter_str
-            )
-        except TypeError:
-            cleaned_headmatter = None
-
-        return cleaned_headmatter
 
 
 class LegacyNoSearch:

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -524,8 +524,8 @@ class USCodeGPO:
 class CourtListener:
     details = {
         "name": "CourtListener",
-        "short_description": "hello",
-        "long_description": "CourtListener searches millions of opinions across hundreds of jurisdictions",
+        "short_description": "CourtListener contains millions of legal opinions.",
+        "long_description": "CourtListener searches millions of opinions across hundreds of jurisdictions.",
         "link": settings.COURTLISTENER_BASE_URL,
         "search_regexes": [],
         "footnote_regexes": [],
@@ -584,6 +584,7 @@ class CourtListener:
             )
             resp.raise_for_status()
             cluster = resp.json()
+            cluster["html_info"] = {"source": "court listener"}
 
             if cluster["filepath_json_harvard"]:
                 harvard_xml_data = ""
@@ -608,17 +609,17 @@ class CourtListener:
         ]
         case = LegalDocument(
             source=legal_doc_source,
-            short_name=cluster["case_name"],
-            name=cluster["case_name"],
+            short_name=cluster.get("case_name"),
+            name=cluster.get("case_name"),
             doc_class="Case",
             citations=citations,
-            jurisdiction="",
-            effective_date=cluster["date_filed"],
-            publication_date=cluster["date_filed"],
+            jurisdiction=cluster.get("court_id"),
+            effective_date=parser.parse(cluster.get("date_filed")),
+            publication_date=parser.parse(cluster.get("date_modified")),
             updated_date=datetime.now(),
             source_ref=str(id),
             content=case_html,
-            metadata=None,
+            metadata=cluster,
         )
         return case
 

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -603,10 +603,18 @@ class CourtListener:
             f"{x.get('volume')} {x.get('reporter')} {x.get('page')}" for x in cluster["citations"]
         ]
         cluster["html_info"] = {"source": "court listener"}
+
+        # https://www.courtlistener.com/help/api/rest/#case-names
+        case_name = None
+        if cluster["case_name"]:
+            case_name = cluster["case_name"]
+        elif cluster["case_name_full"]:
+            case_name = cluster["case_name_full"][:10000]
+
         case = LegalDocument(
             source=legal_doc_source,
             short_name=cluster.get("case_name"),
-            name=cluster.get("case_name"),
+            name=case_name,
             doc_class="Case",
             citations=citations,
             jurisdiction=cluster.get("court_id"),

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -588,7 +588,15 @@ class CourtListener:
                 sub_opinion_jsons.append(CourtListener.get_opinion_body(opinion))
 
             text_source = ""
-            for content_type in ("xml_harvard", "html", "plain_text"):
+            for content_type in (
+                "xml_harvard",
+                "html_with_citations",
+                "html_columbia",
+                "html_lawbox",
+                "html_anon_2020",
+                "html",
+                "plain_text",
+            ):
                 case_text = "".join(sub_opinion[content_type] for sub_opinion in sub_opinion_jsons)
                 if case_text:
                     case_text = case_text.replace('<?xml version="1.0" encoding="utf-8"?>', "")

--- a/web/main/templates/export/as_printable_html/node.html
+++ b/web/main/templates/export/as_printable_html/node.html
@@ -57,7 +57,11 @@
 
             {% if node.resource_type.lower == 'legaldocument' %}
               {% if node.resource.doc_class.lower == 'case' %}
-                {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
+                {% if node.resource.metadata.html_info.source == 'cap' %}
+                  {% include "includes/legal_doc_sources/cap_header.html" with legal_doc=node.resource %}
+                {% elif node.resource.metadata.html_info.source == 'court listener' %}
+                  {% include "includes/legal_doc_sources/court_listener_header.html" with legal_doc=node.resource %}
+                {% endif %}
               {% elif node.resource.doc_class.lower == 'code' %}
                 {% include "includes/legal_doc_sources/gpo_header.html" with legal_doc=node.resource %}
               {% endif %}

--- a/web/main/templates/includes/legal_doc_sources/cap_header.html
+++ b/web/main/templates/includes/legal_doc_sources/cap_header.html
@@ -1,8 +1,7 @@
 <header class="case-header legal-doc-header" >
     {% with md=legal_doc.metadata %}
-    <div class="court" data-custom-style="Case Header"> {{ md.court.name }}</div>
-    <div class="title" data-custom-style="Case Header">{{ legal_doc.get_title }}</div>
-    <div class="citation" data-custom-style="Case Header"> {{legal_doc.cite_string}} </div>
+    <div class="court" data-custom-style="Case Header">{{ md.court.name }}</div>
+    <div class="citation" data-custom-style="Case Header">{{ legal_doc.cite_string }}</div>
     {% if md.docket_number %}<div class="docketnumber" data-custom-style="Case Header">{{ md.docket_number }}</div>{% endif %}
     {% if md.decision_date %}<div class="decisiondate" data-custom-style="Case Header">{{ md.decision_date }}</div>{% endif %}
     {% endwith %}

--- a/web/main/templates/includes/legal_doc_sources/court_listener_header.html
+++ b/web/main/templates/includes/legal_doc_sources/court_listener_header.html
@@ -1,7 +1,7 @@
 <header class="case-header legal-doc-header" >
     {% with md=legal_doc.metadata %}
     <div class="court" data-custom-style="Case Header">{{ md.court.name }}</div>
-    <div class="citation" data-custom-style="Case Header">{{ legal_doc.cite_string }} </div>
+    <div class="citation" data-custom-style="Case Header">{{ legal_doc.cite_string }}</div>
     {% if md.docket_number %}<div class="docketnumber" data-custom-style="Case Header">{{ md.docket_number }}</div>{% endif %}
     {% if md.date_filed %}<div class="decisiondate" data-custom-style="Case Header">{{ md.date_filed }}</div>{% endif %}
     {% endwith %}

--- a/web/main/templates/includes/legal_doc_sources/court_listener_header.html
+++ b/web/main/templates/includes/legal_doc_sources/court_listener_header.html
@@ -1,0 +1,8 @@
+<header class="case-header legal-doc-header" >
+    {% with md=legal_doc.metadata %}
+    <div class="court" data-custom-style="Case Header"> {{ md.court.name }}</div>
+    <div class="citation" data-custom-style="Case Header"> {{legal_doc.cite_string}} </div>
+    {% if md.docket_number %}<div class="docketnumber" data-custom-style="Case Header">{{ md.docket_number }}</div>{% endif %}
+    {% if md.date_filed %}<div class="decisiondate" data-custom-style="Case Header">{{ md.date_filed }}</div>{% endif %}
+    {% endwith %}
+</header>

--- a/web/main/templates/includes/legal_doc_sources/court_listener_header.html
+++ b/web/main/templates/includes/legal_doc_sources/court_listener_header.html
@@ -1,7 +1,7 @@
 <header class="case-header legal-doc-header" >
     {% with md=legal_doc.metadata %}
-    <div class="court" data-custom-style="Case Header"> {{ md.court.name }}</div>
-    <div class="citation" data-custom-style="Case Header"> {{legal_doc.cite_string}} </div>
+    <div class="court" data-custom-style="Case Header">{{ md.court.name }}</div>
+    <div class="citation" data-custom-style="Case Header">{{ legal_doc.cite_string }} </div>
     {% if md.docket_number %}<div class="docketnumber" data-custom-style="Case Header">{{ md.docket_number }}</div>{% endif %}
     {% if md.date_filed %}<div class="decisiondate" data-custom-style="Case Header">{{ md.date_filed }}</div>{% endif %}
     {% endwith %}

--- a/web/main/utils.py
+++ b/web/main/utils.py
@@ -745,10 +745,3 @@ def validate_image(file, formats=None):
         Image.open(file, formats=formats)
     except UnidentifiedImageError:
         raise BadFiletypeError(f"Only {', '.join(formats)} are supported at this time.")
-
-
-def convert_case_xml_to_html(xml):
-    """
-    The script to convert xml to html will go here
-    """
-    return "html"

--- a/web/main/utils.py
+++ b/web/main/utils.py
@@ -745,3 +745,10 @@ def validate_image(file, formats=None):
         Image.open(file, formats=formats)
     except UnidentifiedImageError:
         raise BadFiletypeError(f"Only {', '.join(formats)} are supported at this time.")
+
+
+def convert_case_xml_to_html(xml):
+    """
+    The script to convert xml to html will go here
+    """
+    return "html"


### PR DESCRIPTION
This is a WIP PR for the CL case XML -> HTML conversion integration.

### **Things that were done:**

- Activated the CourtListener legal document source in Django admin.
- Added logic to grab `xml_harvard` fields from the opinions endpoint if the cluster has a `filepath_json_harvard`, otherwise the `html` field will be used (with `plain_text` as worst case scenario).
- Enabled advanced search for CourtListener source by adding additional params logic to the source calls.
- Added Jack's xml to html conversion script.
- Ran the script against 4000 clusters/cases grabbed from CL API (2000 with source `U`, 2000 with source `CU`). Source descriptions [here](https://www.courtlistener.com/api/rest/v3/clusters/).
- Made a change to the conversion script to handle cases where elements might be missing `type` and `id` attributes in the source xml.

### **A few bug fixes were made:**

- Handle cases where clusters might not have any citations. This was causing the search to error.
- Update the format citations are being added to the legal doc. Previously they were being added in a json format instead of a list which didn't match how we display citations for other legal doc sources. Sample diff: 

![image](https://github.com/harvard-lil/h2o/assets/156083782/8e7e6d11-5212-4d90-94aa-35fae3fa44c9)

- Made an update to the `effectiveDate` to prevent errors that are thrown if the CL API returns a date string longer than 25 chars, I saw that was the case for some clusters with the time offset including seconds.
- Updated the search result `id`s with the `cluster_id`s. Because the ids and the cluster_ids do not match in the search endpoint results, the subsequent clusters endpoint call with id was erroring out.
- Updated the opinions endpoint calls to use `opinion id`s (grabbed from cluster endpoint response `sub_opinions` field) since we need to look at all sub_opinions to construct the Harvard xml. Previously the search result id was being used. 
- I saw some cases where there wasn't any `xml_harvard` data, and no `html`, so I defaulted to use the `plain_text` field of the opinion.


### **Things to consider:**

- I mapped the cluster call response json to the metadata field like we do for other search sources. One thing I see Cap does is add the footnote regexes to metadata. Is this needed for CL? 
- I noticed we are hiding some elements like .parties, .decisiondate and .docketnumber in case-text class. What's the reasoning behind this? 
- I saw that some opinions don't have either of the content fields (xml_harvard, plain_text). Think about what to do in this case. Can we fall back on other html fields? Or disable importing for those documents?
- Any edge cases that I should consider? Do some more testing around those. 

### **Sample converted legal doc (chopped):**
<img width="670" alt="Screenshot 2024-06-12 at 10 26 44 AM" src="https://github.com/harvard-lil/h2o/assets/156083782/af8c1629-6581-4c1c-81c4-6f368acd96fb">


### **This is how it would look like if the elements I mentioned above weren't set to `display: none`.**
<img width="866" alt="Screenshot 2024-06-12 at 10 43 33 AM" src="https://github.com/harvard-lil/h2o/assets/156083782/11480700-81aa-414f-88ab-207dbe2d7e05">

### **A case that both CAP and CL return, and this is how they look like when imported (both chopped):**

**CAP (with `display: none` removed from `.case-text .syllabus`):**

![CAP](https://github.com/harvard-lil/h2o/assets/156083782/dfa10821-1d28-4139-851f-4bb0a293002c)



**CourtListener (with `display: none` removed from elements in headmatter):**

![CL](https://github.com/harvard-lil/h2o/assets/156083782/65f6c99c-0c83-4b68-9ffb-f37a7d4592c5)





