### PR TITLE
css update for printable view and href base url update

### DIFF
--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -599,7 +599,8 @@ class CourtListener:
             ):
                 case_text = "".join(sub_opinion[content_type] for sub_opinion in sub_opinion_jsons)
                 if case_text:
-                    case_text = case_text.replace('<?xml version="1.0" encoding="utf-8"?>', "")
+                    case_text = (case_text.replace('<?xml version="1.0" encoding="utf-8"?>', "")
+                                 .replace('href="/opinion', f'href="{settings.COURTLISTENER_BASE_URL}/opinion'))
                     text_source = content_type
                     break
 

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -599,8 +599,9 @@ class CourtListener:
             ):
                 case_text = "".join(sub_opinion[content_type] for sub_opinion in sub_opinion_jsons)
                 if case_text:
-                    case_text = (case_text.replace('<?xml version="1.0" encoding="utf-8"?>', "")
-                                 .replace('href="/opinion', f'href="{settings.COURTLISTENER_BASE_URL}/opinion'))
+                    case_text = case_text.replace(
+                        '<?xml version="1.0" encoding="utf-8"?>', ""
+                    ).replace('href="/opinion', f'href="{settings.COURTLISTENER_BASE_URL}/opinion')
                     text_source = content_type
                     break
 

--- a/web/static/as_printable_html/all.css
+++ b/web/static/as_printable_html/all.css
@@ -39,6 +39,11 @@
     margin: 0;
   }
 
+
+  pre {
+    white-space: pre-wrap;
+  }
+
   h1.casebook.title {
     font-size: 300%;
   }


### PR DESCRIPTION
- Add base URL to CL relative URLs in the CL case HTML so we don't return a 404, and instead take the user to the CL website. PS: If there is a strong preference for us to use or not to use `target="_blank"`, let me know and I can make an update accordingly. 
Sample casebook doc that would be fixed by this change: https://h2o-stage.lil.tools/casebooks/8195-test-casebook/resources/1-anderson-v-welding-testing-laboratory-inc/

- Add a CSS attribute to `all.css` so the text inside `<pre>` tags do not overflow in the printable-html view. I used the same attribute here that we use for the regular view. This was impacting CAP-sourced legal docs as well. 

**CL case before:**

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/dbd473d8-c027-487e-9260-f095343703c4">

**CL case after:**

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/5cfcf2b1-f41a-4871-9460-e0b65c7fef0c">

