### PR TITLE
add banner for CL API announcement

### DIFF
--- a/web/frontend/pages/main.scss
+++ b/web/frontend/pages/main.scss
@@ -21,6 +21,7 @@
 @import 'footer';
 @import 'mockups';
 @import 'spinner';
+@import 'announcement_banner';
 
 // view semantic styles
 @import 'landing';

--- a/web/frontend/styles/announcement_banner.scss
+++ b/web/frontend/styles/announcement_banner.scss
@@ -1,0 +1,12 @@
+body {
+  .announcement-banner {
+    background-color: $tinted-light-blue;
+    font-size: 14px;
+    padding: 10px 15px;
+    @include make-row();
+
+    p {
+      margin: 0px;
+    }
+  }
+}

--- a/web/frontend/styles/announcement_banner.scss
+++ b/web/frontend/styles/announcement_banner.scss
@@ -6,7 +6,13 @@ body {
     @include make-row();
 
     p {
-      margin: 0px;
+      margin: 0;
+      a {
+        color: inherit;
+      }
+      a.standout-link {
+        color: $light-blue;
+      }
     }
   }
 }

--- a/web/frontend/styles/variables.scss
+++ b/web/frontend/styles/variables.scss
@@ -20,6 +20,7 @@ $light-orange: lighten($orange, 20%);
 $yellow: #F8BA1C;
 $light-yellow: lighten($yellow, 40%);
 $green: #17AC10;
+$tinted-light-blue: lighten($light-blue, 35%);
 
 $highlight: #f8e71c;
 

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -634,7 +634,7 @@ class CourtListener:
             name=case_name,
             doc_class="Case",
             citations=citations,
-            jurisdiction=cluster.get("court_id"),
+            jurisdiction=additional_metadata.get("court_id"),
             effective_date=parser.parse(cluster.get("date_filed")),
             publication_date=parser.parse(cluster.get("date_modified")),
             updated_date=datetime.now(),

--- a/web/main/templates/base.html
+++ b/web/main/templates/base.html
@@ -28,6 +28,7 @@
       <a href="#main" class="skip-link">Skip to main content</a>
       <a href="#footer" class="skip-link">Skip to footer</a>
       <div class="modal-overlay"></div> <!--bizarrely, something is swapping out the class overlay -> modal-overlay in the Rails app... to be investigated -->
+      {% include 'includes/announcement_banner.html' %}
       {% block banner %}{% endblock banner %}
       <header id="main-header">
         {% include 'includes/header.html' %}

--- a/web/main/templates/includes/announcement_banner.html
+++ b/web/main/templates/includes/announcement_banner.html
@@ -1,3 +1,6 @@
 <div class="announcement-banner">
-    <p>Increased access to caselaw via CourtListener API lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam. Yay!</p>
+    <p>New! H2O now has access to <b>new and up-to-date cases</b> via
+        <a href="https://www.courtlistener.com">CourtListener</a> and the <a href="https://case.law">Caselaw Access Project</a>. 
+        <a class="standout-link" href="">Click here for more info.</a>
+    </p>
 </div>

--- a/web/main/templates/includes/announcement_banner.html
+++ b/web/main/templates/includes/announcement_banner.html
@@ -1,6 +1,6 @@
 <div class="announcement-banner">
     <p>New! H2O now has access to <b>new and up-to-date cases</b> via
         <a href="https://www.courtlistener.com">CourtListener</a> and the <a href="https://case.law">Caselaw Access Project</a>. 
-        <a class="standout-link" href="">Click here for more info.</a>
+        <a class="standout-link" href="https://lil.law.harvard.edu/blog/2024/08/27/adding-fresher-caselaw-to-open-casebooks/">Click here for more info.</a>
     </p>
 </div>

--- a/web/main/templates/includes/announcement_banner.html
+++ b/web/main/templates/includes/announcement_banner.html
@@ -1,0 +1,3 @@
+<div class="announcement-banner">
+    <p>Increased access to caselaw via CourtListener API lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam. Yay!</p>
+</div>


### PR DESCRIPTION
This PR adds a banner to announce the CL API integration. It will stay in draft status until the language is finalized, and added in.

It also includes a bug fix for the `jurisdiction` attribute of CL legal documents. 

---

Edit: I decided that this could get reviewed at any time, so I am changing its status. I will add the banner text before merging.

<img width="1711" alt="Screenshot 2024-08-01 at 10 52 21 AM" src="https://github.com/user-attachments/assets/fad3ab7a-9ec3-4d79-8bdc-77cd3e552481">
