### PR TITLE
Fix export of newly-uploaded images

### DIFF
--- a/web/frontend/libs/tinymce_extensions.js
+++ b/web/frontend/libs/tinymce_extensions.js
@@ -436,6 +436,10 @@ export function getInitConfig(selector, enhanced, code) {
     paste_remove_styles: true,
     paste_remove_styles_if_webkit: true,
     paste_strip_class_attributes: "all",
+    // image URLs
+    relative_urls: false,
+    convert_urls: false,
+    remove_script_host : false,
     media_dimensions: false,
     extended_valid_elements: extend_valid_elements,
     setup: (editor) => {

--- a/web/main/test/test_export.py
+++ b/web/main/test/test_export.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import itertools
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -366,3 +367,39 @@ def test_annotated_export_invalid_clamped(annotations_factory):
     resource = annotations_factory("LegalDocument", input)[1]
     resource.annotations.update(global_end_offset=1000)  # move end offset past end of text
     assert annotated_content_for_export(resource) == expected
+
+
+def test_disallowed_images_stripped(rf, text_block_factory, resource_factory):
+    request = rf.get('/spoof-export-request')
+
+    disallowed_srcs = [
+        '/etc/hosts',
+        '../../images/foo',
+        'http://example.com'
+    ]
+
+    allowed_srcs = [
+        f"http://{request.get_host()}/foo",
+        f"https://{request.get_host()}/foo",
+    ]
+
+    text = ''
+    for src in itertools.chain(disallowed_srcs, allowed_srcs):
+        text = text + f'<img src="{src}">'
+
+    text_block = text_block_factory(content=text)
+    resource = resource_factory(resource=text_block, resource_type='TextBlock')
+
+    # Establish that all images are present in the unaltered HTML
+    unaltered_html = resource.export(False, None, file_type='html')
+    for src in itertools.chain(disallowed_srcs, allowed_srcs):
+        assert src in unaltered_html
+
+    # Provide a spoofed `request` object which is a required argument for proper export of rich text
+    # https://github.com/harvard-lil/h2o/blob/dd67276720fe3a7af7e110da958448399a92399f/web/main/utils.py#L282
+    # Then, establish that only allowed image sources are present.
+    html = resource.export(False, None, file_type='html', export_options={"request": request})
+    for src in disallowed_srcs:
+        assert src not in html
+    for src in allowed_srcs:
+        assert src in html

--- a/web/main/test/test_export.py
+++ b/web/main/test/test_export.py
@@ -370,35 +370,31 @@ def test_annotated_export_invalid_clamped(annotations_factory):
 
 
 def test_disallowed_images_stripped(rf, text_block_factory, resource_factory):
-    request = rf.get('/spoof-export-request')
+    request = rf.get("/spoof-export-request")
 
-    disallowed_srcs = [
-        '/etc/hosts',
-        '../../images/foo',
-        'http://example.com'
-    ]
+    disallowed_srcs = ["/etc/hosts", "../../images/foo", "http://example.com"]
 
     allowed_srcs = [
         f"http://{request.get_host()}/foo",
         f"https://{request.get_host()}/foo",
     ]
 
-    text = ''
+    text = ""
     for src in itertools.chain(disallowed_srcs, allowed_srcs):
         text = text + f'<img src="{src}">'
 
     text_block = text_block_factory(content=text)
-    resource = resource_factory(resource=text_block, resource_type='TextBlock')
+    resource = resource_factory(resource=text_block, resource_type="TextBlock")
 
     # Establish that all images are present in the unaltered HTML
-    unaltered_html = resource.export(False, None, file_type='html')
+    unaltered_html = resource.export(False, None, file_type="html")
     for src in itertools.chain(disallowed_srcs, allowed_srcs):
         assert src in unaltered_html
 
     # Provide a spoofed `request` object which is a required argument for proper export of rich text
     # https://github.com/harvard-lil/h2o/blob/dd67276720fe3a7af7e110da958448399a92399f/web/main/utils.py#L282
     # Then, establish that only allowed image sources are present.
-    html = resource.export(False, None, file_type='html', export_options={"request": request})
+    html = resource.export(False, None, file_type="html", export_options={"request": request})
     for src in disallowed_srcs:
         assert src not in html
     for src in allowed_srcs:


### PR DESCRIPTION
I _think_ this PR arranges so that images newly uploaded by verified professors to casebooks will appear in DOCX exports of those casebooks.

It turns off all the [URL munging](https://www.tiny.cloud/docs/tinymce/latest/url-handling/) that TinyMCE, the rich text editor, does on save. It is unclear to me why it munges URLs by default. The docs say:
> This option enables you to control whether TinyMCE is to be smart and restore URLs to their original values. URLs are automatically converted (messed up) by default because the browser’s built-in logic works this way. There is no way to get the real URL unless you store it away.

But I do not know what that means.

The route that handles uploads [returns the absolute URL](https://github.com/harvard-lil/h2o/blob/develop/web/main/views.py#L3278) of the upload: so, without any munging, we should get what we want.

Testing locally manually, it works. Adding a functional test to actually try it out as part of the test suite is _way_ hard, so I'm not going to, at this point. 

If for some reason this does not work in prod the same way it does locally, we can try again, this time configuring TinyMCE to use [custom logic](https://www.tiny.cloud/docs/tinymce/latest/url-handling/#urlconverter_callback) to force all image URLs to be absolute links to H2O, while leaving non-image links untouched. Fingers crossed it doesn't come to that 🤞. 

I added a basic test so that I could feel less worried that we are exposed to exfiltration, or similar, if relative paths are manually added to the TextBlock source by accident or by a mischievous user.

As a followup, I plan to spend a little time finding all the image tags in H2O casebooks text, and a) clean up any that I can, so that their export works retroactively, and b) possibly, deal with any other bad ones that turn up.

I am resisting the urge to do any further refactoring... which is extremely tempting.
