### PR TITLE
switch to using cl api v4

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -246,6 +246,7 @@ GPO_BASE_URL = "https://api.govinfo.gov/"
 GPO_API_KEY = ""
 
 COURTLISTENER_BASE_URL = "https://www.courtlistener.com"
+COURTLISTENER_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4/"
 COURTLISTENER_API_KEY = ""
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"

--- a/web/main/legal_document_sources.py
+++ b/web/main/legal_document_sources.py
@@ -526,7 +526,7 @@ class CourtListener:
         "name": "CourtListener",
         "short_description": "CourtListener contains millions of legal opinions.",
         "long_description": "CourtListener searches millions of opinions across hundreds of jurisdictions.",
-        "link": settings.COURTLISTENER_BASE_URL,
+        "link": settings.COURTLISTENER_API_BASE_URL,
         "search_regexes": [],
         "footnote_regexes": [],
     }
@@ -539,7 +539,7 @@ class CourtListener:
         try:
             params = CourtListener.get_search_params(search_params)
             resp = requests.get(
-                f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/search",
+                f"{settings.COURTLISTENER_API_BASE_URL}search",
                 params,
                 headers={"Authorization": f"Token {settings.COURTLISTENER_API_KEY}"},
             )
@@ -575,7 +575,7 @@ class CourtListener:
             raise APICommunicationError("A CourtListener API key is required")
         try:
             resp = requests.get(
-                f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/clusters/{id}/",
+                f"{settings.COURTLISTENER_API_BASE_URL}clusters/{id}/",
                 headers={"Authorization": f"Token {settings.COURTLISTENER_API_KEY}"},
             )
             resp.raise_for_status()
@@ -653,7 +653,7 @@ class CourtListener:
     def get_opinion_body(sub_opinion_url):
         opinion_num = int(sub_opinion_url.split("/")[-2])
         resp = requests.get(
-            f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/opinions/{opinion_num}/",
+            f"{settings.COURTLISTENER_API_BASE_URL}opinions/{opinion_num}/",
             headers={"Authorization": f"Token {settings.COURTLISTENER_API_KEY}"},
         )
 
@@ -701,7 +701,7 @@ class CourtListener:
         params = {"q": f"cluster_id:{cluster_id}"}
 
         resp = requests.get(
-            f"{settings.COURTLISTENER_BASE_URL}/api/rest/v3/search",
+            f"{settings.COURTLISTENER_API_BASE_URL}search",
             params,
             headers={"Authorization": f"Token {settings.COURTLISTENER_API_KEY}"},
         )


### PR DESCRIPTION
For more details, [visit](https://linear.app/harvard-lil/issue/LIL-2656/switch-h2o-to-use-courtlistener-api-v4). 