### PR TITLE
Minimal upgrade to Postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,6 @@ services:
     # command: bash
 
 volumes:
-  db_data_12:
   db_data_16:
   minio_data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   db:
-    image: registry.lil.tools/library/postgres:12.11
+    image: registry.lil.tools/library/postgres:16.6
     volumes:
-      - db_data_12:/var/lib/postgresql/data:delegated
+      - db_data_16:/var/lib/postgresql/data:delegated
     ports:
       - "127.0.0.1:54320:5432"
     environment:
@@ -75,6 +75,7 @@ services:
 
 volumes:
   db_data_12:
+  db_data_16:
   minio_data:
 
 networks:


### PR DESCRIPTION
Tests pass locally.

See the PG release notes for versions [13](https://www.postgresql.org/docs/13/release-13.html), [14](https://www.postgresql.org/docs/14/release.html), [15](https://www.postgresql.org/docs/15/release.html), and [16](https://www.postgresql.org/docs/16/release.html).

The RDS upgrade path from 12.19, which is what we are running now, does not extend directly to 16.6, so I took the liberty of upgrading our stage instance from 12.19 to 12.22, and then to 16.6; we can kick the tires on stage. The upgrades took some minutes; we'll go into maintenance mode when it's time to upgrade the production instances.