### PR TITLE
Fix reading mode line length for better readability on large screens

### DIFF
--- a/web/frontend/styles/cases.scss
+++ b/web/frontend/styles/cases.scss
@@ -61,3 +61,25 @@
         height: auto;
     }
 }
+
+// Improve readability on large screens by limiting line length
+// Targets reading mode content specifically
+main {
+    max-width: 90rem; // ~1440px at default font size
+    margin: 0 auto;
+}
+
+// Constrain reading content width for better readability
+section.resource,
+.case-text,
+.headnote {
+    max-width: 60rem; // ~960px at default font size, optimal for reading
+    margin-left: auto;
+    margin-right: auto;
+    
+    // Add some padding for breathing room
+    @media (min-width: $screen-md) {
+        padding-left: 2rem;
+        padding-right: 2rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Implements maximum width constraints for reading mode content to improve readability on large displays
- Uses rem units for better responsiveness as suggested in the issue discussion
- Centers content and adds appropriate padding

## Description
This PR addresses issue #2026 by constraining the line length of text in reading mode. On large displays (like 27" 4K monitors), the text currently spans the entire screen width, making it difficult to read.

### Changes made:
1. Constrained main content to max-width of `90rem` (~1440px at default font size)
2. Limited reading content (case-text, resources, headnotes) to `60rem` (~960px) for optimal reading experience
3. Used rem units instead of pixels for better responsiveness across different screen densities
4. Centered content with auto margins
5. Added responsive padding on larger screens

### Implementation notes:
- The changes are made in `web/frontend/styles/cases.scss` where the reading content styles are defined
- The constraints only apply on larger screens, maintaining the existing responsive behavior on smaller devices
- Used rem units as suggested by @matteocargnelutti in the issue discussion

## Test plan
- [ ] Tested on large display (>1440px width) to verify text is properly constrained
- [ ] Tested on medium screens to ensure no regression
- [ ] Tested on mobile devices to ensure responsive behavior is maintained
- [ ] Verified that the reading experience is improved with the new line length constraints

Fixes #2026