### PR TITLE
Small updates, post new deployment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,14 +79,10 @@ jobs:
           docker buildx build --push --provenance=false --platform linux/amd64 --tag ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} .
           aws lambda update-function-code --function-name ${ARN} --image-uri ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${IMG}:${TAG} --region ${REGION}
 
-      # Commit built assets if necessary, then deploy via Salt reactor
-      - name: Deploy
+      # Commit built assets if necessary
+      - name: Commit Assets
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'  # avoid docker-compose "the input device is not a TTY" -- https://github.com/actions/runner/issues/241#issuecomment-842566950
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
-          DEPLOY_HEADER: ${{ secrets.DEPLOY_HEADER }}
         run: |
           set -x
           git config user.email "lil@law.harvard.edu"
@@ -101,9 +97,6 @@ jobs:
               git commit -m "Add built JS [skip ci]"
               git push origin develop || exit 1
           fi
-          export DEPLOY_CONTENT='{"GITHUB_RUN_NUMBER":"'$GITHUB_RUN_NUMBER'","GITHUB_SHA":"'$GITHUB_SHA'","GITHUB_REF":"'$GITHUB_REF'","GITHUB_REPOSITORY":"'$GITHUB_REPOSITORY'","GITHUB_ACTOR":"'$GITHUB_ACTOR'"}' ;
-          export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;
-          curl -X POST "$DEPLOY_URL" --data "$DEPLOY_CONTENT" -H "Content-Type: application/json" -H "$DEPLOY_HEADER: $DEPLOY_SIG"
 
       ### push docker images to registry, from main branch, once tests pass ###
 

--- a/web/main/templates/base.html
+++ b/web/main/templates/base.html
@@ -28,7 +28,7 @@
       <a href="#main" class="skip-link">Skip to main content</a>
       <a href="#footer" class="skip-link">Skip to footer</a>
       <div class="modal-overlay"></div> <!--bizarrely, something is swapping out the class overlay -> modal-overlay in the Rails app... to be investigated -->
-      {% include 'includes/announcement_banner.html' %}
+      {% comment %}{% include 'includes/announcement_banner.html' %} {% endcomment %}
       {% block banner %}{% endblock banner %}
       <header id="main-header">
         {% include 'includes/header.html' %}

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -1077,6 +1077,7 @@ def dashboard(request, user_id=None, user_slug=None):
         for x in user.casebooks.exclude(state=Casebook.LifeCycle.ARCHIVED.value)
         .exclude(state=Casebook.LifeCycle.DRAFT.value)
         .exclude(state=Casebook.LifeCycle.PREVIOUS_SAVE.value)
+        .order_by("-updated_at")
         .all()
         if x.viewable_by(request.user)
     ]


### PR DESCRIPTION
This PR does three things, following up on yesterday's deployment:

- it removes the banner warning about maintenance
- it arranges for casebooks on users' dashboards to be displayed with most recently updated books first, instead of showing things ordered by primary key (kristi says this is restoring previous behavior)
- it stops Github actions from asking the Salt reactor to deploy, when new commits are merged to `develop`