### PR TITLE
Update DMCA policy text on terms of service page

### DIFF
--- a/web/main/templates/pages/terms-of-service.html
+++ b/web/main/templates/pages/terms-of-service.html
@@ -47,17 +47,7 @@
     <p>Except for any User Content, H2O owns and retains all right, title, and interest in and to the H2O Services, including, but not limited to, the design and architecture of the H2O Services, as well as any software, logos, or content provided through H2O, including any intellectual property or other proprietary rights contained therein (collectively, "H2O IP"). You must seek permission from H2O if you desire to use the H2O Services in a way that is not outlined in these Terms of Service. Except for any rights explicitly granted in writing by H2O under these Terms of Service or otherwise, you are not granted any rights in and to any H2O IP.</p>
 
     <h3>b. Digital Millennium Copyright Act Policy</h3>
-    <p>H2O respects the intellectual property rights of others and asks that Users do the same. If you are a rights-holder and believe that your rights have been violated in connection with User Content that is made available through the H2O Services, in accordance with the Digital Millennium Copyright Act ("DMCA", see 17 U.S.C. § 512(c)(3) for more information) please send an email or written notice to H2O’s designated agent for infringement claims with the following information:</p>
-    <ul>
-        <li>1. An electronic or physical signature of a person authorized to act on behalf of the rights-holder.</li>
-        <li>2. A description of the work that you claim has been infringed.</li>
-        <li>3. A URL indicating where the claimed infringing material is located on the H2O Services.</li>
-        <li>4. Your address, telephone number, and email address.</li>
-        <li>5. A statement by you declaring a good-faith belief that the content use is not authorized by the rights-holder or its agent and is prohibited by law.</li>
-        <li>6. A statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or an agent authorized to act on the copyright owner's behalf.</li>
-    </ul>
-
-    <p>H2O’s designated agent for notice for claims of infringement can be reached as follows: Tracy Walden, Harvard University Information Technology, IT Security | Policy, Risk and Compliance, +1.617.496.8515, 1414 Massachusetts Avenue, Room 346, Cambridge, MA 02138, Email: dmca@harvard.edu</p>
+  <p>H2O respects the intellectual property rights of others and asks that Users do the same. If you are a rights-holder and believe that your rights have been violated in connection with User Content that is made available through the H2O Services, in accordance with the Digital Millennium Copyright Act, you can <a href="https://www.harvard.edu/copyright-issue/">report copyright infringement to our designated DMCA agent</a>.</p>
 
     <h3>c. Counter-Notice</h3>
     <p>If you receive notification that your User Content has been removed from the H2O Services, you have an opportunity to appeal this removal if you believe that your User Content was removed in error. If you believe that the removed User Content does not violate any third-party rights, or you have authorization from the rights-holder or the rights-holder’s authorized agent to use the material in question, you may appeal the removal by sending an email or written notice to H2O’s designated agent with the following information:</p>


### PR DESCRIPTION
In response to [LIL-4407](https://linear.app/harvard-lil/issue/LIL-4407/update-h2o-terms-of-service-page-new-copyright-info), this pull request updates the H2O Terms of Service page with new copyright info.
