### PR TITLE
Update allowed iframe attributes

### DIFF
--- a/web/frontend/libs/tinymce_extensions.js
+++ b/web/frontend/libs/tinymce_extensions.js
@@ -406,8 +406,12 @@ export function getInitConfig(selector, enhanced, code) {
   }
 
   let extend_valid_elements = [['div', ['class', 'title', 'style', 'tabindex', 'id', 'class', 'data-custom-style']],
-                               ['span', ['class', 'title', 'style', 'tabindex', 'id', 'class', 'data-custom-style'],
-                                ['img', ['class', 'alt', 'title', 'id', 'data-custom-style']]]]
+                               ['span', ['class', 'title', 'style', 'tabindex', 'id', 'class', 'data-custom-style']],
+                               ['img', ['class', 'alt', 'title', 'id', 'data-custom-style']],
+                               // Needed for YouTube embeds; in particular, `referrerpolicy="strict-origin-when-cross-origin"`
+                               // prevents YouTube "Error 153: Video player configuration error" in some environments.
+                               // Allow lots here: the server-side cleanup code will validate more closely.
+                               ['iframe', ['width', 'height', 'src', 'title', 'frameborder', 'allow', 'referrerpolicy', 'allowfullscreen', 'loading', 'class', 'id', 'style']]]
       .map(x => `${x[0]}[${x[1].join('|')}]`)
       .join(',');
 

--- a/web/main/sanitize.py
+++ b/web/main/sanitize.py
@@ -171,6 +171,8 @@ def iframe_attributes(tag, name, value):
         return True
     if name == "src":
         return youtube_src.match(value) or vimeo_src.match(value)
+    if name == "referrerpolicy":
+        return value.lower() == "strict-origin-when-cross-origin"
     return False
 
 


### PR DESCRIPTION
See LIL-4742.

A casebook author noticed that YouTube embeds were no longer working:

<img width="1094" height="504" alt="image" src="https://github.com/user-attachments/assets/936c91ba-9503-4c41-9091-9bc4e18f5a17" />

They correctly identified that our code was stripping a now-necessary attribute from the embed code. This PR adds that attribute to the allow list, both on the front end (the WYSIWYG editor authors use to add embeds) and the back end (which cleans the submitted HTML before saving it to the database).