### PR TITLE
Publish artifacts before deploying anything

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -119,46 +119,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # One OIDC session for everything below that touches AWS. Replaces the
-      # long-lived AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY this workflow used
-      # to carry for the pandoc-lambda publish.
-      - name: Configure AWS credentials
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@v6.1.1
-        with:
-          role-to-assume: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.STAGING_AWS_REGION }}
-
-      # build, push, and deploy pandoc-lambda image to stage if necessary
-      # Authenticated by the OIDC session configured above.
-      # provenance: false because buildx's container driver otherwise attaches a
-      # provenance attestation, making the push an image index -- which Lambda
-      # rejects. ecs-build also tags the full commit SHA, where this previously
-      # used a short SHA.
-      # TODO: this could potentially use existing built image
-      - name: Build and publish pandoc-lambda image
-        id: pandoc-lambda
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
-        uses: harvard-lil/lil-actions/ecs-build@main
-        with:
-          ecr-repository: pandoc-lambda
-          context: docker/pandoc-lambda
-          dockerfile: docker/pandoc-lambda/Dockerfile
-          provenance: "false"
-
-      - name: Point the staging Lambda at the new image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
-        env:
-          IMAGE_URI: ${{ steps.pandoc-lambda.outputs.sha-image-uri }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.STAGING_AWS_REGION }}
-        run: |
-          set -euxo pipefail
-          aws lambda update-function-code \
-            --function-name "arn:aws:lambda:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:function:h2o-export-stage" \
-            --image-uri "$IMAGE_URI" \
-            --region "$AWS_DEFAULT_REGION"
-
       # Commit built assets if necessary
       - name: Commit Assets
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -189,6 +149,23 @@ jobs:
           registry-pass: ${{ secrets.GITHUB_TOKEN }}
           bake-action: "push"
 
+      # Ordering: everything that publishes an artifact runs before anything
+      # that deploys one. Publishing is gated on the suite passing and nothing
+      # else, so a failed deployment must not also prevent a tested image from
+      # being published. The reverse order meant a single AccessDenied on Lambda
+      # skipped the GHCR push and the prod image as well.
+
+      # One OIDC session for everything below that touches AWS. Replaces the
+      # long-lived AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY this workflow used
+      # to carry for the pandoc-lambda publish.
+      - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@v6.1.1
+        with:
+          role-to-assume: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.STAGING_AWS_REGION }}
+
+      # build, push, and deploy pandoc-lambda image to stage if necessary
       ### build and publish the deployable prod artifact ###
       # ecs-build tags both :latest and :<commit sha>. Staging later resolves that
       # SHA tag to a digest and deploys it, so the artifact tested here is the one
@@ -199,4 +176,32 @@ jobs:
         uses: harvard-lil/lil-actions/ecs-build@main
         with:
           ecr-repository: ${{ secrets.STAGING_ECR_REPOSITORY }}
-          target: prod
+          target: prod      # Authenticated by the OIDC session configured above.
+      # provenance: false because buildx's container driver otherwise attaches a
+      # provenance attestation, making the push an image index -- which Lambda
+      # rejects. ecs-build also tags the full commit SHA, where this previously
+      # used a short SHA.
+      # TODO: this could potentially use existing built image
+      - name: Build and publish pandoc-lambda image
+        id: pandoc-lambda
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
+        uses: harvard-lil/lil-actions/ecs-build@main
+        with:
+          ecr-repository: pandoc-lambda
+          context: docker/pandoc-lambda
+          dockerfile: docker/pandoc-lambda/Dockerfile
+          provenance: "false"
+
+      - name: Point the staging Lambda at the new image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(steps.rebuild.outputs.services-rebuilt, 'pandoc-lambda')
+        env:
+          IMAGE_URI: ${{ steps.pandoc-lambda.outputs.sha-image-uri }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.STAGING_AWS_REGION }}
+        run: |
+          set -euxo pipefail
+          aws lambda update-function-code \
+            --function-name "arn:aws:lambda:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:function:h2o-export-stage" \
+            --image-uri "$IMAGE_URI" \
+            --region "$AWS_DEFAULT_REGION"
+


### PR DESCRIPTION
Follow-up to #2120, prompted by its first run on `main` failing.

## What happened

The suite passed — 608 tests, JS build, artifact extraction, all green. Then:

```
Build and publish pandoc-lambda image    success
Point the staging Lambda at the new image  FAILURE
Commit Assets                            skipped
Push docker images                       skipped
Build and publish prod-target image      skipped
```

An `AccessDeniedException` on `lambda:UpdateFunctionCode` (fixed separately in [lil-terraform#145](https://github.com/harvard-lil/lil-terraform/pull/145)) meant **nothing was published at all** — not the GHCR images, not the prod image, not the built assets. A tested, good artifact was withheld because an unrelated deployment could not authenticate.

## The change

Publishing and deploying are different kinds of work:

- **Publishing** is gated on the suite passing and nothing else.
- **Deploying** can fail for reasons that say nothing about whether the artifact is good — an IAM gap, a throttle, a service being mid-update.

So publishing now runs first:

```
Commit Assets
Push docker images              -> GHCR
Configure AWS credentials
Build and publish prod-target   -> ECR
Build and publish pandoc-lambda -> ECR
Point the staging Lambda at it  <- the only deploy, now last
```

A deployment failure leaves the published artifacts intact, so re-running deploys rather than rebuilding.

This is a pure reorder — no step's content changes. The added lines in the diff are the moved blocks plus one comment explaining the ordering, so the next person does not "tidy" it back.

## Not the unblock

To be clear about sequencing: this does not fix the failing run. [lil-terraform#145](https://github.com/harvard-lil/lil-terraform/pull/145) does, by granting the OIDC role the Lambda permission its predecessor IAM user had. This just limits the blast radius when a deploy step fails in future.

actionlint clean.