### PR TITLE
Make the build cache real, and deploy the export Lambda from the deploy workflows

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -15,8 +15,6 @@ on:
         required: false
       STAGING_ECR_REPOSITORY:
         required: false
-      AWS_ACCOUNT_ID:
-        required: false
 
 jobs:
   lint:
@@ -63,6 +61,14 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+
+      # Required for the cache flags below to do anything at all. buildx's
+      # default `docker` driver silently supports neither --cache-from nor
+      # --cache-to, so before this step every run rebuilt the image from
+      # scratch and the repository's Actions cache sat at zero bytes.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Cached with type=gha, which inherits GitHub's cache scoping: a pull
       # request can read main's cache but writes only to its own, so a fork
       # cannot feed layers into a published image. This matters more now that
@@ -81,6 +87,7 @@ jobs:
           docker buildx build \
             --target prod \
             --load \
+            --provenance=false \
             --cache-from type=gha,scope=h2o \
             --cache-to type=gha,mode=max,scope=h2o \
             -t h2o-prod:${{ github.sha }} \
@@ -90,6 +97,7 @@ jobs:
           docker buildx build \
             --target test \
             --load \
+            --provenance=false \
             --cache-from type=gha,scope=h2o \
             -t h2o-test:ci \
             -f ./Dockerfile .
@@ -168,7 +176,11 @@ jobs:
           docker tag "h2o-prod:${{ github.sha }}" "${REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
           docker push "${REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
 
-      # build, push, and deploy pandoc-lambda image to stage if necessary
+      # Build and publish only -- pointing a Lambda at this image is a deploy,
+      # and happens in staging.yml / prod.yml alongside every other deploy.
+      # Doing it here meant staging's export Lambda tracked main's tip while
+      # staging's web app ran the last promoted commit, and production's was
+      # never updated by anything at all.
       # Authenticated by the OIDC session configured above.
       # provenance: false because buildx's container driver otherwise attaches a
       # provenance attestation, making the push an image index -- which Lambda
@@ -188,17 +200,3 @@ jobs:
           # -- the Lambda is deployed from the SHA tag below. Pushing a moving
           # tag would fail the second time it ran.
           image-tag: ""
-
-      - name: Point the staging Lambda at the new image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          IMAGE_URI: ${{ steps.pandoc-lambda.outputs.sha-image-uri }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.STAGING_AWS_REGION }}
-        run: |
-          set -euxo pipefail
-          aws lambda update-function-code \
-            --function-name "arn:aws:lambda:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:function:h2o-export-stage" \
-            --image-uri "$IMAGE_URI" \
-            --region "$AWS_DEFAULT_REGION"
-

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -83,6 +83,7 @@ jobs:
           STAGING_ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
           STAGING_ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
           STAGING_CONTAINER_NAME: ${{ secrets.STAGING_CONTAINER_NAME }}
+          STAGING_ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
         run: |
           set -euo pipefail
 
@@ -128,8 +129,28 @@ jobs:
           esac
 
           DIGEST="${STAGING_IMAGE#*@}"
-          echo "Promoting $STAGING_IMAGE"
+
+          # Recover which commit built this artifact, by reading the other tags
+          # on the same digest. The web image and its matching pandoc-lambda
+          # image are both tagged with the commit SHA, so this is what lets the
+          # export Lambda be promoted from the same commit as the web service
+          # rather than from whatever main happens to point at now.
+          SOURCE_SHA=$(aws ecr describe-images \
+            --repository-name "$STAGING_ECR_REPOSITORY" \
+            --image-ids "imageDigest=$DIGEST" \
+            --query 'imageDetails[0].imageTags' --output text \
+            | tr '\t' '\n' | { grep -E '^[0-9a-f]{40}$' || true; } | head -n1)
+
+          if [ -z "$SOURCE_SHA" ]; then
+            echo "::error::No commit-SHA tag on $DIGEST in $STAGING_ECR_REPOSITORY,"
+            echo "::error::so the matching pandoc-lambda image cannot be identified."
+            exit 1
+          fi
+
+          echo "Promoting $STAGING_IMAGE, built from $SOURCE_SHA"
           echo "staging-image=$STAGING_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "source-sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "image-digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "image-uri=${REGISTRY}/${ECR_REPOSITORY}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Copy that image into the production repository
@@ -145,6 +166,16 @@ jobs:
             --tag "${REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" \
             "$STAGING_IMAGE"
 
+      # Retention keeps `deployed-` images long past the build candidates that
+      # churn by every merge to main. The production task definition is pinned to
+      # this digest, so it has to outlive them.
+      - name: Mark the promoted web image as deployed
+        uses: harvard-lil/lil-actions/ecr-tag-image@main
+        with:
+          repository: ${{ env.ECR_REPOSITORY }}
+          source: ${{ steps.resolve.outputs.image-digest }}
+          tag: deployed-${{ steps.resolve.outputs.source-sha }}
+
       - name: Pin the web container to the promoted digest
         id: task-def
         uses: harvard-lil/lil-actions/ecs-register-task-def@main
@@ -159,6 +190,18 @@ jobs:
           cluster: ${{ env.ECS_CLUSTER }}
           service: ${{ env.ECS_SERVICE }}
           task-definition: ${{ steps.task-def.outputs.task-definition-arn }}
+
+      # Production's export Lambda had no deploy path at all before this, which
+      # is how it came to sit on an image built in August 2024.
+      - name: Point the production export Lambda at the promoted image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SOURCE_SHA: ${{ steps.resolve.outputs.source-sha }}
+        run: |
+          set -euxo pipefail
+          aws lambda update-function-code \
+            --function-name h2o-export \
+            --image-uri "${REGISTRY}/pandoc-lambda:${SOURCE_SHA}" >/dev/null
 
       - name: Put site into maintenance mode
         uses: harvard-lil/lil-actions/ecs-maintenance@main

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -115,7 +115,26 @@ jobs:
           fi
 
           echo "source-sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "image-digest=$digest" >> "$GITHUB_OUTPUT"
           echo "image-uri=${REGISTRY}/${ECR_REPOSITORY}@${digest}" >> "$GITHUB_OUTPUT"
+
+      # Mark both promoted artifacts before deploying them. ECR retention keeps
+      # `deployed-` images far longer than the build candidates that churn past
+      # them every merge to main -- without this tag, the image the service is
+      # running is just another candidate and ages out on the same schedule.
+      - name: Mark the promoted web image as deployed
+        uses: harvard-lil/lil-actions/ecr-tag-image@main
+        with:
+          repository: ${{ env.ECR_REPOSITORY }}
+          source: ${{ steps.resolve.outputs.image-digest }}
+          tag: deployed-${{ steps.resolve.outputs.source-sha }}
+
+      - name: Mark the promoted pandoc-lambda image as deployed
+        uses: harvard-lil/lil-actions/ecr-tag-image@main
+        with:
+          repository: pandoc-lambda
+          source: ${{ steps.resolve.outputs.source-sha }}
+          tag: deployed-${{ steps.resolve.outputs.source-sha }}
 
       # Keep the moving :latest tag pointing at what we deploy, so a Terraform
       # apply (whose task definition references :latest) cannot quietly revert
@@ -144,6 +163,19 @@ jobs:
           cluster: ${{ env.ECS_CLUSTER }}
           service: ${{ env.ECS_SERVICE }}
           task-definition: ${{ steps.task-def.outputs.task-definition-arn }}
+
+      # The export Lambda is part of this application and ships with it. It used
+      # to be updated by lint_test.yml on every merge to main, which left it
+      # running main's tip while the web service ran the last promoted commit.
+      - name: Point the staging export Lambda at the promoted image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SOURCE_SHA: ${{ steps.resolve.outputs.source-sha }}
+        run: |
+          set -euxo pipefail
+          aws lambda update-function-code \
+            --function-name h2o-export-stage \
+            --image-uri "${REGISTRY}/pandoc-lambda:${SOURCE_SHA}" >/dev/null
 
       - name: Put site into maintenance mode
         uses: harvard-lil/lil-actions/ecs-maintenance@main


### PR DESCRIPTION
Fixes from the last deploy to staging of the new docker pipeline:

- Fully enable the build cache. Use `docker/setup-buildx-action` to create the container-driver builder. We need to use `--provenance=false` to not attach attestations because Lambda will reject containers with indexes -- if we want to add that back in later we can use `actions/attest-build-provenance`.
- As a pre-existing issue, the timing of the pandoc-lambda update was wrong. `lint_test.yml` pointed `h2o-export-stage` at a new image on every merge to main, which shouldn't happen until staging deploy. Prod's lambda had no deploy path at all, and is running `pandoc-lambda:c9b9678`, built 2024-08-01 and last touched 2024-08-02. Both now deploy alongside everything else, from the same commit the web service is promoted from.
- `deployed-` tagging -- deploys now tag what they promoted. This will let us (over in lil-terraform) configure retention of images actually deployed to staging or prod separate from retention of images built for main and unused. (Underlying issue: in order to meet our goal of using the same image everywhere, rather than rebuilding a possibly-different image at each stage, we have to save every image built on push to `main` in case it's promoted to `stage`. That churns pretty fast, and we don't want it to push the recently-deployed staging or prod images out of the top-n last used.)

Deployment note: this means when we deploy to prod, we'll be bumping a pandoc lambda for the first time in two years.