### PR TITLE
Give buildx the credentials the Actions cache needs

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -69,6 +69,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # `type=gha` talks to the Actions cache service, which needs a runtime
+      # token and endpoint that the runner injects into JavaScript actions only
+      # -- never into `run:` steps. `docker/build-push-action` gets them for
+      # free by being a JS action; the plain `docker buildx build` calls below
+      # do not, and buildx responds by skipping the cache silently rather than
+      # failing. That is why setting up this builder alone still produced no
+      # cache at all.
+      #
+      # crazy-max/ghaction-github-runtime is the usual way to do this. Using
+      # actions/github-script instead keeps a job-scoped credential out of a
+      # third party's hands, and that action is already used elsewhere here.
+      - name: Expose the Actions cache credentials to buildx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            for (const name of ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL', 'ACTIONS_CACHE_URL']) {
+              const value = process.env[name]
+              if (value) {
+                core.exportVariable(name, value)
+              } else {
+                core.warning(`${name} is not set; the build cache will be skipped.`)
+              }
+            }
+
       # Cached with type=gha, which inherits GitHub's cache scoping: a pull
       # request can read main's cache but writes only to its own, so a fork
       # cannot feed layers into a published image. This matters more now that

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -80,11 +80,18 @@ jobs:
       # crazy-max/ghaction-github-runtime is the usual way to do this. Using
       # actions/github-script instead keeps a job-scoped credential out of a
       # third party's hands, and that action is already used elsewhere here.
+      #
+      # ACTIONS_CACHE_SERVICE_V2 is not decoration. buildx picks the cache API
+      # version from that flag alone -- not from which URL happens to be set --
+      # and defaults to v1, whose endpoint now answers with an HTML error page.
+      # Exporting the URLs without it produces a confusing
+      # "failed to parse error response 400" rather than anything cache-shaped.
       - name: Expose the Actions cache credentials to buildx
         uses: actions/github-script@v7
         with:
           script: |
-            for (const name of ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL', 'ACTIONS_CACHE_URL']) {
+            const required = ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL']
+            for (const name of required) {
               const value = process.env[name]
               if (value) {
                 core.exportVariable(name, value)
@@ -92,6 +99,12 @@ jobs:
                 core.warning(`${name} is not set; the build cache will be skipped.`)
               }
             }
+            // Follow the runner's own view when it offers one, but never fall
+            // back to v1: ACTIONS_CACHE_URL is deliberately not exported.
+            core.exportVariable(
+              'ACTIONS_CACHE_SERVICE_V2',
+              process.env.ACTIONS_CACHE_SERVICE_V2 ?? 'true'
+            )
 
       # Cached with type=gha, which inherits GitHub's cache scoping: a pull
       # request can read main's cache but writes only to its own, so a fork


### PR DESCRIPTION
(superseded by #2130) Pass ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN through to build so it can write to the cache.