### PR TITLE
Github Actions cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  # Third-party action versions were drifting here because nothing watched them:
+  # this repository sat on actions/checkout v4 while lil-actions had moved to v7,
+  # and two different majors of checkout were in use here at the same time.
+  #
+  # Pinning to commit SHAs is what stops a compromised tag from arriving
+  # silently, and it is also what makes a pin invisible once set -- a SHA does
+  # not look stale. Something has to raise them, hence this.
+  #
+  # Only `.github/workflows/` is scanned; the github-actions ecosystem does not
+  # recurse into composite `action.yml` files. That is why lil-actions lists each
+  # composite directory explicitly. This repository defines no composite actions.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -69,6 +69,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # `type=gha` talks to the Actions cache service, which needs a runtime
+      # token and endpoint that the runner injects into JavaScript actions only
+      # -- never into `run:` steps. `docker/build-push-action` gets them for
+      # free by being a JS action; the plain `docker buildx build` calls below
+      # do not, and buildx responds by skipping the cache silently rather than
+      # failing. That is why setting up this builder alone still produced no
+      # cache at all.
+      #
+      # crazy-max/ghaction-github-runtime is the usual way to do this. Using
+      # actions/github-script instead keeps a job-scoped credential out of a
+      # third party's hands, and that action is already used elsewhere here.
+      - name: Expose the Actions cache credentials to buildx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            for (const name of ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL', 'ACTIONS_CACHE_URL']) {
+              const value = process.env[name]
+              if (value) {
+                core.exportVariable(name, value)
+              } else {
+                core.warning(`${name} is not set; the build cache will be skipped.`)
+              }
+            }
+
       # Cached with type=gha, which inherits GitHub's cache scoping: a pull
       # request can read main's cache but writes only to its own, so a fork
       # cannot feed layers into a published image. This matters more now that

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -23,10 +23,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       
@@ -60,14 +60,14 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository == 'harvard-lil/h2o'
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Required for the cache flags below to do anything at all. buildx's
       # default `docker` driver silently supports neither --cache-from nor
       # --cache-to, so before this step every run rebuilt the image from
       # scratch and the repository's Actions cache sat at zero bytes.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # `type=gha` talks to the Actions cache service, which needs a runtime
       # token and endpoint that the runner injects into JavaScript actions only
@@ -87,7 +87,7 @@ jobs:
       # Exporting the URLs without it produces a confusing
       # "failed to parse error response 400" rather than anything cache-shaped.
       - name: Expose the Actions cache credentials to buildx
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const required = ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL']
@@ -179,7 +179,7 @@ jobs:
       ### codecov ###
       # https://github.com/codecov/codecov-action
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -188,7 +188,7 @@ jobs:
       # to carry for the pandoc-lambda publish.
       - name: Configure AWS credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@v6.1.1
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.STAGING_AWS_REGION }}
@@ -196,7 +196,7 @@ jobs:
       - name: Login to AWS ECR
         id: publish-ecr-login
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: aws-actions/amazon-ecr-login@v2.1.4
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       # Push the image built at the top of this job -- not a rebuild. Tagged with
       # the commit main actually points at, so staging can find it.

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -80,11 +80,18 @@ jobs:
       # crazy-max/ghaction-github-runtime is the usual way to do this. Using
       # actions/github-script instead keeps a job-scoped credential out of a
       # third party's hands, and that action is already used elsewhere here.
+      #
+      # ACTIONS_CACHE_SERVICE_V2 is not decoration. buildx picks the cache API
+      # version from that flag alone -- not from which URL happens to be set --
+      # and defaults to v1, whose endpoint now answers with an HTML error page.
+      # Exporting the URLs without it produces a confusing
+      # "failed to parse error response 400" rather than anything cache-shaped.
       - name: Expose the Actions cache credentials to buildx
         uses: actions/github-script@v7
         with:
           script: |
-            for (const name of ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL', 'ACTIONS_CACHE_URL']) {
+            const required = ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_RESULTS_URL']
+            for (const name of required) {
               const value = process.env[name]
               if (value) {
                 core.exportVariable(name, value)
@@ -92,6 +99,12 @@ jobs:
                 core.warning(`${name} is not set; the build cache will be skipped.`)
               }
             }
+            // Follow the runner's own view when it offers one, but never fall
+            // back to v1: ACTIONS_CACHE_URL is deliberately not exported.
+            core.exportVariable(
+              'ACTIONS_CACHE_SERVICE_V2',
+              process.env.ACTIONS_CACHE_SERVICE_V2 ?? 'true'
+            )
 
       # Cached with type=gha, which inherits GitHub's cache scoping: a pull
       # request can read main's cache but writes only to its own, so a fork

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -53,11 +53,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.1
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.PROD_AWS_REGION }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.4
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       # Production never builds. It ships the exact image staging is running.
       #
@@ -256,14 +256,14 @@ jobs:
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
 
       - name: Purge Cloudflare cache
-        uses: jakejarvis/cloudflare-purge-action@master
-        env:
-          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        uses: harvard-lil/lil-actions/cloudflare-purge@main
+        with:
+          zone: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
             webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
             webhook-type: incoming-webhook

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -53,13 +53,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0   # need merge parents to resolve the main commit we promote
 
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.1
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.STAGING_AWS_REGION }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.4
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       # Promote, do not rebuild. lint_test.yml built this image on main, ran the
       # suite against it, and pushed it tagged with the main commit SHA.
@@ -230,14 +230,14 @@ jobs:
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
 
       - name: Purge Cloudflare cache
-        uses: jakejarvis/cloudflare-purge-action@master
-        env:
-          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        uses: harvard-lil/lil-actions/cloudflare-purge@main
+        with:
+          zone: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           
           
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
             webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
             webhook-type: incoming-webhook


### PR DESCRIPTION
- Pass through ACTIONS_RUNTIME_TOKEN and ACTIONS_RESULTS_URL to the builder so we can use the cache.
- Add dependabot config for github actions.
- Update our third-party actions to supported versions.
- Pin actions to hashes. 
- Use our own `harvard-lil/lil-actions/cloudflare-purge` instead of an unmaintained one.