### PR TITLE
Stop a failed deploy from leaving the site behind the maintenance page

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -218,6 +218,7 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
 
       - name: Run Django migrations
+        id: migrate
         uses: harvard-lil/lil-actions/ecs-django-migrations@main
         with:
           cluster: ${{ env.ECS_CLUSTER }}
@@ -247,13 +248,40 @@ jobs:
           event-rules: ${{ env.EVENT_RULES }}
           task-definition-arn: ${{ steps.task-def.outputs.task-definition-arn }}
 
+      # Maintenance goes on before the rollout is confirmed, and until now no
+      # step in this job had an `if:`. So any failure in between -- a bad image,
+      # a slow rollout, a broken index rebuild -- aborted the workflow with the
+      # maintenance page still up, and it stayed up until someone flipped the
+      # load balancer by hand. ECS runs at minimumHealthyPercent 100, so the old
+      # tasks are still serving throughout: the site was only ever down because
+      # the maintenance page was covering a working site.
+      #
+      # Migrations are the one exception. A migration that fails partway can
+      # leave the schema in a state neither the old nor the new code is safe
+      # against, so that case deliberately stays dark for a human. `cancelled`
+      # is treated the same way, since interrupting a migration is no safer than
+      # having one fail.
       - name: Turn off Maintenance mode
+        if: always() && (steps.migrate.outcome == 'success' || steps.migrate.outcome == 'skipped')
         uses: harvard-lil/lil-actions/ecs-maintenance@main
         with:
           mode: 'off'
           load-balancer: ${{ env.LOAD_BALANCER }}
           target-group: ${{ env.TARGET_GROUP }}
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
+
+      # The condition here is the exact complement of the step above, so the
+      # site is never left behind the maintenance page without this firing.
+      - name: Report that the site was left in maintenance
+        if: always() && steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped'
+        run: |
+          echo "::error::Django migrations did not complete (outcome: ${{ steps.migrate.outcome }})."
+          echo "::error::MAINTENANCE MODE IS STILL ON and was left on deliberately --"
+          echo "::error::https://opencasebook.org is serving the maintenance page, not the application."
+          echo "::error::The database may be partially migrated. Check its state before"
+          echo "::error::lifting maintenance; re-running this workflow will not lift it"
+          echo "::error::either, because it will fail at the same step."
+          exit 1
 
       - name: Purge Cloudflare cache
         uses: harvard-lil/lil-actions/cloudflare-purge@main
@@ -262,6 +290,35 @@ jobs:
           token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       
+      # Without this a failed deploy sends nothing at all, since the success
+      # notification below does not run. The case that matters is the one where
+      # the site is deliberately dark and nobody has been told.
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+            webhook-type: incoming-webhook
+            payload: |
+              {
+                "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "*Prod H2O deploy FAILED*"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "*Maintenance mode:*\n${{ (steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped') && 'STILL ON - the site is serving the maintenance page' || 'lifted - the site is serving the previous version' }}\n*Run:*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                      }
+                    }
+                ]
+              }
+
       - name: Notify Slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -191,8 +191,9 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
           task-definition: ${{ steps.task-def.outputs.task-definition-arn }}
 
-      # Production's export Lambda had no deploy path at all before this, which
-      # is how it came to sit on an image built in August 2024.
+      # The export Lambda ships with the web service, from the same commit. It is
+      # deployed independently of the ECS service, so a rollback of one does not
+      # roll back the other.
       - name: Point the production export Lambda at the promoted image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -248,19 +249,16 @@ jobs:
           event-rules: ${{ env.EVENT_RULES }}
           task-definition-arn: ${{ steps.task-def.outputs.task-definition-arn }}
 
-      # Maintenance goes on before the rollout is confirmed, and until now no
-      # step in this job had an `if:`. So any failure in between -- a bad image,
-      # a slow rollout, a broken index rebuild -- aborted the workflow with the
-      # maintenance page still up, and it stayed up until someone flipped the
-      # load balancer by hand. ECS runs at minimumHealthyPercent 100, so the old
-      # tasks are still serving throughout: the site was only ever down because
-      # the maintenance page was covering a working site.
+      # Lifted whenever migrations either succeeded or never ran, which covers
+      # every failure above this point. Those all leave a working site
+      # underneath: the service runs at minimumHealthyPercent 100, so ECS keeps
+      # the previous tasks serving until replacements pass health checks, and
+      # the only thing making the site unreachable is this page.
       #
-      # Migrations are the one exception. A migration that fails partway can
-      # leave the schema in a state neither the old nor the new code is safe
-      # against, so that case deliberately stays dark for a human. `cancelled`
-      # is treated the same way, since interrupting a migration is no safer than
-      # having one fail.
+      # A migration that failed partway is the exception, since it can leave the
+      # schema in a state neither the old nor the new code is safe against. That
+      # case stays behind the maintenance page for a human. `cancelled` counts
+      # the same: interrupting a migration is no safer than one failing.
       - name: Turn off Maintenance mode
         if: always() && (steps.migrate.outcome == 'success' || steps.migrate.outcome == 'skipped')
         uses: harvard-lil/lil-actions/ecs-maintenance@main
@@ -270,8 +268,8 @@ jobs:
           target-group: ${{ env.TARGET_GROUP }}
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
 
-      # The condition here is the exact complement of the step above, so the
-      # site is never left behind the maintenance page without this firing.
+      # Complement of the condition above, so the site is never left behind the
+      # maintenance page without this saying so.
       - name: Report that the site was left in maintenance
         if: always() && steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped'
         run: |
@@ -290,9 +288,9 @@ jobs:
           token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       
-      # Without this a failed deploy sends nothing at all, since the success
-      # notification below does not run. The case that matters is the one where
-      # the site is deliberately dark and nobody has been told.
+      # The success notification below does not run on failure, so this is the
+      # only thing that reports a failed deploy -- including the one case where
+      # the site is deliberately left serving the maintenance page.
       - name: Notify Slack on failure
         if: failure()
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -192,6 +192,7 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
 
       - name: Run Django migrations
+        id: migrate
         uses: harvard-lil/lil-actions/ecs-django-migrations@main
         with:
           cluster: ${{ env.ECS_CLUSTER }}
@@ -221,13 +222,40 @@ jobs:
           event-rules: ${{ env.EVENT_RULES }}
           task-definition-arn: ${{ steps.task-def.outputs.task-definition-arn }}
 
+      # Maintenance goes on before the rollout is confirmed, and until now no
+      # step in this job had an `if:`. So any failure in between -- a bad image,
+      # a slow rollout, a broken index rebuild -- aborted the workflow with the
+      # maintenance page still up, and it stayed up until someone flipped the
+      # load balancer by hand. ECS runs at minimumHealthyPercent 100, so the old
+      # tasks are still serving throughout: the site was only ever down because
+      # the maintenance page was covering a working site.
+      #
+      # Migrations are the one exception. A migration that fails partway can
+      # leave the schema in a state neither the old nor the new code is safe
+      # against, so that case deliberately stays dark for a human. `cancelled`
+      # is treated the same way, since interrupting a migration is no safer than
+      # having one fail.
       - name: Turn off Maintenance mode
+        if: always() && (steps.migrate.outcome == 'success' || steps.migrate.outcome == 'skipped')
         uses: harvard-lil/lil-actions/ecs-maintenance@main
         with:
           mode: 'off'
           load-balancer: ${{ env.LOAD_BALANCER }}
           target-group: ${{ env.TARGET_GROUP }}
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
+
+      # The condition here is the exact complement of the step above, so the
+      # site is never left behind the maintenance page without this firing.
+      - name: Report that the site was left in maintenance
+        if: always() && steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped'
+        run: |
+          echo "::error::Django migrations did not complete (outcome: ${{ steps.migrate.outcome }})."
+          echo "::error::MAINTENANCE MODE IS STILL ON and was left on deliberately --"
+          echo "::error::https://staging.opencasebook.org is serving the maintenance page, not the application."
+          echo "::error::The database may be partially migrated. Check its state before"
+          echo "::error::lifting maintenance; re-running this workflow will not lift it"
+          echo "::error::either, because it will fail at the same step."
+          exit 1
 
       - name: Purge Cloudflare cache
         uses: harvard-lil/lil-actions/cloudflare-purge@main
@@ -236,6 +264,35 @@ jobs:
           token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           
           
+      # Without this a failed deploy sends nothing at all, since the success
+      # notification below does not run. The case that matters is the one where
+      # the site is deliberately dark and nobody has been told.
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+            webhook-type: incoming-webhook
+            payload: |
+              {
+                "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "*Staging H2O deploy FAILED*"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "*Maintenance mode:*\n${{ (steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped') && 'STILL ON - the site is serving the maintenance page' || 'lifted - the site is serving the previous version' }}\n*Run:*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                      }
+                    }
+                ]
+              }
+
       - name: Notify Slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -164,9 +164,9 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
           task-definition: ${{ steps.task-def.outputs.task-definition-arn }}
 
-      # The export Lambda is part of this application and ships with it. It used
-      # to be updated by lint_test.yml on every merge to main, which left it
-      # running main's tip while the web service ran the last promoted commit.
+      # The export Lambda is part of this application and ships with it, from the
+      # same commit as the web service. Deploying it anywhere else lets the two
+      # drift apart.
       - name: Point the staging export Lambda at the promoted image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -222,19 +222,16 @@ jobs:
           event-rules: ${{ env.EVENT_RULES }}
           task-definition-arn: ${{ steps.task-def.outputs.task-definition-arn }}
 
-      # Maintenance goes on before the rollout is confirmed, and until now no
-      # step in this job had an `if:`. So any failure in between -- a bad image,
-      # a slow rollout, a broken index rebuild -- aborted the workflow with the
-      # maintenance page still up, and it stayed up until someone flipped the
-      # load balancer by hand. ECS runs at minimumHealthyPercent 100, so the old
-      # tasks are still serving throughout: the site was only ever down because
-      # the maintenance page was covering a working site.
+      # Lifted whenever migrations either succeeded or never ran, which covers
+      # every failure above this point. Those all leave a working site
+      # underneath: the service runs at minimumHealthyPercent 100, so ECS keeps
+      # the previous tasks serving until replacements pass health checks, and
+      # the only thing making the site unreachable is this page.
       #
-      # Migrations are the one exception. A migration that fails partway can
-      # leave the schema in a state neither the old nor the new code is safe
-      # against, so that case deliberately stays dark for a human. `cancelled`
-      # is treated the same way, since interrupting a migration is no safer than
-      # having one fail.
+      # A migration that failed partway is the exception, since it can leave the
+      # schema in a state neither the old nor the new code is safe against. That
+      # case stays behind the maintenance page for a human. `cancelled` counts
+      # the same: interrupting a migration is no safer than one failing.
       - name: Turn off Maintenance mode
         if: always() && (steps.migrate.outcome == 'success' || steps.migrate.outcome == 'skipped')
         uses: harvard-lil/lil-actions/ecs-maintenance@main
@@ -244,8 +241,8 @@ jobs:
           target-group: ${{ env.TARGET_GROUP }}
           maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
 
-      # The condition here is the exact complement of the step above, so the
-      # site is never left behind the maintenance page without this firing.
+      # Complement of the condition above, so the site is never left behind the
+      # maintenance page without this saying so.
       - name: Report that the site was left in maintenance
         if: always() && steps.migrate.outcome != 'success' && steps.migrate.outcome != 'skipped'
         run: |
@@ -264,9 +261,9 @@ jobs:
           token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           
           
-      # Without this a failed deploy sends nothing at all, since the success
-      # notification below does not run. The case that matters is the one where
-      # the site is deliberately dark and nobody has been told.
+      # The success notification below does not run on failure, so this is the
+      # only thing that reports a failed deploy -- including the one case where
+      # the site is deliberately left serving the maintenance page.
       - name: Notify Slack on failure
         if: failure()
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1


### PR DESCRIPTION
Maintenance mode goes on before the rollout is confirmed, and no step in either deploy job carries an `if:`, so any failure in between aborts the workflow with the maintenance page still up, until someone flips the load balancer by hand.

This narrows it so maintenance mode ends automatically unless django migrations fail to run. AI analysis of the ideal handling:

| failing step | site state underneath | lift? |
|---|---|---|
| Wait for deployment | old tasks still serving | yes |
| **Run Django migrations** | **schema may be half-applied** | **no** |
| Create search index | serving; search degraded | yes |
| Create reporting views | serving; reporting stale | yes |
| Update EventBridge | serving; cron on old task def | yes |

This causes some duplication, will DRY in a followup.