### PR TITLE
Serialise the uwsgi build in the lint job too

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Run mypy
         run: |
           cd web
-          pip install -r requirements.txt
+          # CPUCOUNT=1 for the same reason the Dockerfile sets it: uwsgi's build
+          # spawns one compiler thread per CPU, and on a multi-core runner they
+          # intermittently collide with `OSError: [Errno 14] Bad address:
+          # '/bin/sh'`. Nothing here needs uwsgi -- it arrives through
+          # requirements.txt -- so the cost of serialising its build is a few
+          # seconds against an occasional red build on an unrelated commit.
+          CPUCOUNT=1 pip install -r requirements.txt
           PYTHONPATH=. mypy
 
   test:


### PR DESCRIPTION
`main` is red on a commit that only changed workflow YAML. The failure is in mypy's `pip install`:

```
Building wheel for uwsgi (pyproject.toml): finished with status 'error'
  OSError: [Errno 14] Bad address: '/bin/sh'
```

uwsgi spawns one compiler thread per CPU and they intermittently collide. The Dockerfile has set `CPUCOUNT=1` for exactly this since the image work; the lint job installs the same `requirements.txt` on the runner without it, so the flake has been reachable there all along and simply hadn't landed yet.

Nothing in the lint job uses uwsgi — it comes in transitively — so serialising its build costs a few seconds and removes a source of red builds on unrelated commits.