### PR TITLE
Hold traffic at Cloudflare during a maintenance window, not at the load balancer

### DIFF
--- a/.github/workflows/deploy_sequence.yml
+++ b/.github/workflows/deploy_sequence.yml
@@ -40,6 +40,17 @@ on:
         description: 'Export Lambda for this tier'
         required: true
         type: string
+      maintenance-script:
+        description: >
+          Cloudflare Worker serving this tier's maintenance page, e.g.
+          h2o-maintenance-prod. Created by lil-terraform's
+          lil-cloudflare-maintenance module.
+        required: true
+        type: string
+      maintenance-hostnames:
+        description: 'Comma-separated hostnames the page answers on'
+        required: true
+        type: string
 
     secrets:
       aws-role-arn:
@@ -53,12 +64,6 @@ on:
       container-name:
         required: true
       task-definition-family:
-        required: true
-      load-balancer:
-        required: true
-      target-group:
-        required: true
-      maintenance-target-group:
         required: true
       event-rules:
         # Empty is tolerated: a tier with no scheduled tasks has nothing to update.
@@ -80,9 +85,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      LOAD_BALANCER: ${{ secrets.load-balancer }}
-      TARGET_GROUP: ${{ secrets.target-group }}
-      MAINTENANCE_TARGET_GROUP: ${{ secrets.maintenance-target-group }}
       TASK_DEFINITION_FAMILY: ${{ secrets.task-definition-family }}
       CONTAINER_NAME: ${{ secrets.container-name }}
       ECS_CLUSTER: ${{ secrets.ecs-cluster }}
@@ -183,14 +185,20 @@ jobs:
             --function-name "$FUNCTION_NAME" \
             --image-uri "$LAMBDA_IMAGE_URI" >/dev/null
 
-      - name: Put site into maintenance mode
+      # Held at Cloudflare rather than by shifting load-balancer weight, so the
+      # page still answers if the origin is unreachable, and the load balancer
+      # is left out of it entirely. The action confirms the change by requesting
+      # the site and fails if it never sees it, so the migration below does not
+      # start against traffic that is still flowing.
+      - name: Hold traffic at the edge
         if: steps.window.outputs.needed == 'true'
-        uses: harvard-lil/lil-actions/ecs-maintenance@main
+        uses: harvard-lil/lil-actions/cloudflare-maintenance@main
         with:
           mode: 'on'
-          load-balancer: ${{ env.LOAD_BALANCER }}
-          target-group: ${{ env.TARGET_GROUP }}
-          maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
+          zone-id: ${{ secrets.cloudflare-zone-id }}
+          script: ${{ inputs.maintenance-script }}
+          hostnames: ${{ inputs.maintenance-hostnames }}
+          token: ${{ secrets.cloudflare-api-token }}
 
       - name: Wait for the new deployment to become stable
         uses: harvard-lil/lil-actions/ecs-wait-for-deployment@main
@@ -239,14 +247,14 @@ jobs:
       # schema in a state neither the old nor the new code is safe against. That
       # case stays behind the maintenance page for a human. `cancelled` counts
       # the same: interrupting a migration is no safer than one failing.
-      - name: Turn off Maintenance mode
+      - name: Release traffic at the edge
         if: always() && steps.window.outputs.needed == 'true' && (steps.migrate.outcome == 'success' || steps.migrate.outcome == 'skipped')
-        uses: harvard-lil/lil-actions/ecs-maintenance@main
+        uses: harvard-lil/lil-actions/cloudflare-maintenance@main
         with:
           mode: 'off'
-          load-balancer: ${{ env.LOAD_BALANCER }}
-          target-group: ${{ env.TARGET_GROUP }}
-          maintenance-target-group: ${{ env.MAINTENANCE_TARGET_GROUP }}
+          zone-id: ${{ secrets.cloudflare-zone-id }}
+          hostnames: ${{ inputs.maintenance-hostnames }}
+          token: ${{ secrets.cloudflare-api-token }}
 
       # Complement of the condition above, so the site is never left behind the
       # maintenance page without this saying so.

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -185,6 +185,8 @@ jobs:
       image-uri: ${{ needs.prepare.outputs.image-uri }}
       lambda-image-uri: ${{ needs.prepare.outputs.lambda-image-uri }}
       lambda-function-name: h2o-export
+      maintenance-script: h2o-maintenance-prod
+      maintenance-hostnames: opencasebook.org,www.opencasebook.org
     secrets:
       aws-role-arn: ${{ secrets.PROD_AWS_ROLE_TO_ASSUME }}
       aws-region: ${{ secrets.PROD_AWS_REGION }}
@@ -192,9 +194,6 @@ jobs:
       ecs-service: ${{ secrets.PROD_ECS_SERVICE }}
       container-name: ${{ secrets.PROD_CONTAINER_NAME }}
       task-definition-family: ${{ secrets.PROD_TASK_DEFINITION_FAMILY }}
-      load-balancer: ${{ secrets.PROD_LOAD_BALANCER }}
-      target-group: ${{ secrets.PROD_TARGET_GROUP }}
-      maintenance-target-group: ${{ secrets.PROD_MAINTENANCE_TARGET_GROUP }}
       event-rules: ${{ secrets.PROD_EVENT_RULES }}
       cloudflare-zone-id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -158,6 +158,8 @@ jobs:
       image-uri: ${{ needs.prepare.outputs.image-uri }}
       lambda-image-uri: ${{ needs.prepare.outputs.lambda-image-uri }}
       lambda-function-name: h2o-export-stage
+      maintenance-script: h2o-maintenance-staging
+      maintenance-hostnames: staging.opencasebook.org
     secrets:
       aws-role-arn: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
       aws-region: ${{ secrets.STAGING_AWS_REGION }}
@@ -165,9 +167,6 @@ jobs:
       ecs-service: ${{ secrets.STAGING_ECS_SERVICE }}
       container-name: ${{ secrets.STAGING_CONTAINER_NAME }}
       task-definition-family: ${{ secrets.STAGING_TASK_DEFINITION_FAMILY }}
-      load-balancer: ${{ secrets.STAGING_LOAD_BALANCER }}
-      target-group: ${{ secrets.STAGING_TARGET_GROUP }}
-      maintenance-target-group: ${{ secrets.STAGING_MAINTENANCE_TARGET_GROUP }}
       event-rules: ${{ secrets.STAGING_EVENT_RULES }}
       cloudflare-zone-id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Use the new `cloudflare-maintenance` action in harvard-lil/lil-actions#42 to handle maintenance mode at Cloudflare level.