### PR TITLE
Serve compiled assets from the CDN rather than from each container

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -197,7 +197,10 @@ jobs:
             --exclude 'dist/*' \
             --cache-control 'public, max-age=3600' --no-progress
         env:
-          STATIC_BUCKET: h2o-static
+          # h2o-static was already taken in S3's global namespace by another
+          # account, so the bucket is org-scoped. h2o/static in lil-terraform
+          # outputs this name.
+          STATIC_BUCKET: lil-h2o-static
 
       # Build and publish only -- pointing a Lambda at this image is a deploy,
       # and happens in staging.yml / prod.yml alongside every other deploy.

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -174,6 +174,31 @@ jobs:
           docker tag "h2o-prod:${{ github.sha }}" "${REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
           docker push "${REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
 
+      # Every version's assets live together in one bucket, so a browser holding
+      # a page from an earlier deploy can still fetch its bundles. Objects are
+      # only ever added: there is no --delete here and there should not be, since
+      # removing an old hash is what this exists to prevent.
+      #
+      # Two passes, because the cache headers differ by whether the filename
+      # carries a content hash. Everything under dist/ does, so it can be
+      # immutable for a year; Django admin's files and anything else collected
+      # alongside them do not, and would go stale for a year if treated the same.
+      - name: Publish compiled assets
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euxo pipefail
+          rm -rf collected-static
+          docker compose cp web:/app/web/static ./collected-static
+
+          aws s3 sync ./collected-static/dist "s3://${STATIC_BUCKET}/dist" \
+            --cache-control 'public, max-age=31536000, immutable' --no-progress
+
+          aws s3 sync ./collected-static "s3://${STATIC_BUCKET}" \
+            --exclude 'dist/*' \
+            --cache-control 'public, max-age=3600' --no-progress
+        env:
+          STATIC_BUCKET: h2o-static
+
       # Build and publish only -- pointing a Lambda at this image is a deploy,
       # and happens in staging.yml / prod.yml alongside every other deploy.
       # Doing it here meant staging's export Lambda tracked main's tip while

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"

--- a/web/config/settings/settings_aws_ecs.py
+++ b/web/config/settings/settings_aws_ecs.py
@@ -67,3 +67,13 @@ USE_SENTRY = config["TIER"] == "prod"
 SENTRY_DSN = config["SENTRY_DSN"]
 SENTRY_ENVIRONMENT = config["TIER"]
 SENTRY_TRACES_SAMPLE_RATE = 0.001
+
+# Compiled assets are served from S3 through Cloudflare rather than from this
+# container. Without that, a rolling deploy briefly has old and new tasks behind
+# the same load balancer, and a page rendered by one can request a
+# content-hashed bundle that only exists in the other.
+#
+# WhiteNoise deliberately stays in MIDDLEWARE. The files are still in the image,
+# so anything that reaches /static/ here is still answered while we confirm from
+# the access logs that nothing does. Removing it is a separate change.
+STATIC_URL = "https://static.opencasebook.org/"


### PR DESCRIPTION
harvard-lil/lil-terraform#149 added a module for serving static assets at static.opencasebook.org (or a potential future static.perma.cc etc.). This uses that to in fact push and serve assets there.

This is a useful Django pattern to avoid the need for a maintenance window during deploys. The reason you need a maintenance window is for a period in the middle you have old ECS containers and new ones running side by side. So there's the possibility of someone loading a page from an old one, which references old content hashes, and then trying to fetch those and hitting a new one, which doesn't know about them (or vice versa), potentially caching 404 results.

This fixes it by having all the content-addressed static assets live indefinitely on static.opencasebook.org. Since they're hashed, we can push them during the push to main or to stage, and they're already there when we push to prod. They could eventually be aged out, but there's no real need.

Limitation: this does the simple thing of pushing the assets every time they change on main, which pushes some unnecessary files. The fancier way is to put them in a tagged layer in the container image and pull out that layer on push to stage, but it didn't seem worth the moving parts here.

AI comment:

The files are still in the image and the middleware stays, so anything reaching `/static/` is still answered. Once access logs show nothing does, removing it is a small separate change. Doing both at once would mean a stray hardcoded path becomes a 404 with nothing to fall back on.