### PR TITLE
Pass digests between deploy jobs, not image URIs

### DIFF
--- a/.github/workflows/deploy_sequence.yml
+++ b/.github/workflows/deploy_sequence.yml
@@ -28,12 +28,17 @@ on:
         description: 'Public URL of this tier, used in notifications'
         required: true
         type: string
-      image-uri:
-        description: 'Digest-pinned web image, already present in this tier ECR repository'
+      image-digest:
+        description: >
+          Digest of the web image to deploy, already present in this tier's ECR
+          repository. A digest and not a full URI: a URI contains the registry,
+          the registry contains the account ID, the account ID is masked, and
+          GitHub silently drops a job output it believes holds a secret rather
+          than passing it on.
         required: true
         type: string
-      lambda-image-uri:
-        description: 'pandoc-lambda image built from the same commit as image-uri'
+      source-sha:
+        description: 'Commit the artifact was built from, naming the matching pandoc-lambda image'
         required: true
         type: string
       lambda-function-name:
@@ -54,6 +59,8 @@ on:
 
     secrets:
       aws-role-arn:
+        required: true
+      ecr-repository:
         required: true
       aws-region:
         required: true
@@ -98,13 +105,19 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ secrets.aws-region }}
 
+      # The registry is derived here rather than passed in, for the same reason
+      # the inputs above are pieces rather than URIs.
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
+
       - name: Pin the web container to the promoted digest
         id: task-def
         uses: harvard-lil/lil-actions/ecs-register-task-def@main
         with:
           task-definition-family: ${{ env.TASK_DEFINITION_FAMILY }}
           container-name: ${{ env.CONTAINER_NAME }}
-          image-uri: ${{ inputs.image-uri }}
+          image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ecr-repository }}@${{ inputs.image-digest }}
 
       # Whether this deploy needs a maintenance window is a property of the new
       # code, so it cannot be answered by asking the tasks currently running.
@@ -178,7 +191,7 @@ jobs:
       - name: Point the export Lambda at the promoted image
         env:
           FUNCTION_NAME: ${{ inputs.lambda-function-name }}
-          LAMBDA_IMAGE_URI: ${{ inputs.lambda-image-uri }}
+          LAMBDA_IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/pandoc-lambda:${{ inputs.source-sha }}
         run: |
           set -euxo pipefail
           aws lambda update-function-code \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -40,8 +40,8 @@ jobs:
     if: always() && github.event_name == 'push' && needs.lint-and-test.result == 'success'
     
     outputs:
-      image-uri: ${{ steps.resolve.outputs.image-uri }}
-      lambda-image-uri: ${{ steps.resolve.outputs.lambda-image-uri }}
+      image-digest: ${{ steps.resolve.outputs.image-digest }}
+      source-sha: ${{ steps.resolve.outputs.source-sha }}
 
     env:
       ECR_REPOSITORY: ${{ secrets.PROD_ECR_REPOSITORY }}
@@ -182,13 +182,14 @@ jobs:
     with:
       environment-label: Prod
       site-url: https://opencasebook.org
-      image-uri: ${{ needs.prepare.outputs.image-uri }}
-      lambda-image-uri: ${{ needs.prepare.outputs.lambda-image-uri }}
+      image-digest: ${{ needs.prepare.outputs.image-digest }}
+      source-sha: ${{ needs.prepare.outputs.source-sha }}
       lambda-function-name: h2o-export
       maintenance-script: h2o-maintenance-prod
       maintenance-hostnames: opencasebook.org,www.opencasebook.org
     secrets:
       aws-role-arn: ${{ secrets.PROD_AWS_ROLE_TO_ASSUME }}
+      ecr-repository: ${{ secrets.PROD_ECR_REPOSITORY }}
       aws-region: ${{ secrets.PROD_AWS_REGION }}
       ecs-cluster: ${{ secrets.PROD_ECS_CLUSTER }}
       ecs-service: ${{ secrets.PROD_ECS_SERVICE }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,8 +40,8 @@ jobs:
     if: always() && github.event_name == 'push' && needs.lint-and-test.result == 'success'
     
     outputs:
-      image-uri: ${{ steps.resolve.outputs.image-uri }}
-      lambda-image-uri: ${{ steps.resolve.outputs.lambda-image-uri }}
+      image-digest: ${{ steps.resolve.outputs.image-digest }}
+      source-sha: ${{ steps.resolve.outputs.source-sha }}
 
     env:
       ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
@@ -155,13 +155,14 @@ jobs:
     with:
       environment-label: Staging
       site-url: https://staging.opencasebook.org
-      image-uri: ${{ needs.prepare.outputs.image-uri }}
-      lambda-image-uri: ${{ needs.prepare.outputs.lambda-image-uri }}
+      image-digest: ${{ needs.prepare.outputs.image-digest }}
+      source-sha: ${{ needs.prepare.outputs.source-sha }}
       lambda-function-name: h2o-export-stage
       maintenance-script: h2o-maintenance-staging
       maintenance-hostnames: staging.opencasebook.org
     secrets:
       aws-role-arn: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
+      ecr-repository: ${{ secrets.STAGING_ECR_REPOSITORY }}
       aws-region: ${{ secrets.STAGING_AWS_REGION }}
       ecs-cluster: ${{ secrets.STAGING_ECS_CLUSTER }}
       ecs-service: ${{ secrets.STAGING_ECS_SERVICE }}


### PR DESCRIPTION
The most recent staging deploy job was skipped because github masked secret outputs needed for the next step:

```
Skip output 'image-uri' since it may contain secret.
Skip output 'lambda-image-uri' since it may contain secret.
```

Explicitly pass these actually-non-secret values so they're not masked.

Later on we should consider moving these to vars instead of secrets, probably in an env group.