### PR TITLE
Pin production to the digest the copy produced

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -40,7 +40,7 @@ jobs:
     if: always() && github.event_name == 'push' && needs.lint-and-test.result == 'success'
     
     outputs:
-      image-digest: ${{ steps.resolve.outputs.image-digest }}
+      image-digest: ${{ steps.copy.outputs.image-digest }}
       source-sha: ${{ steps.resolve.outputs.source-sha }}
 
     env:
@@ -146,22 +146,58 @@ jobs:
           echo "Promoting $STAGING_IMAGE, built from $SOURCE_SHA"
           echo "staging-image=$STAGING_IMAGE" >> "$GITHUB_OUTPUT"
           echo "source-sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
-          echo "image-digest=$DIGEST" >> "$GITHUB_OUTPUT"
-          echo "image-uri=${REGISTRY}/${ECR_REPOSITORY}@${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "lambda-image-uri=${REGISTRY}/pandoc-lambda:${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "staging-digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      # `imagetools create` builds a new index around whatever it is given, so
+      # copying a single-platform manifest produces a different digest in the
+      # destination than the one it was read from. The copy's own digest is
+      # therefore the one production can be pinned to, and the check below is
+      # what establishes that it still resolves to the manifest staging ran.
       - name: Copy that image into the production repository
+        id: copy
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           STAGING_IMAGE: ${{ steps.resolve.outputs.staging-image }}
+          STAGING_DIGEST: ${{ steps.resolve.outputs.staging-digest }}
         run: |
-          set -euxo pipefail
-          # Manifest-only copy between repositories in the same registry: no
-          # layers move and the digest is preserved, so production runs the same
-          # bytes staging did.
+          set -euo pipefail
+          # Between repositories in the same registry, no layers move.
           docker buildx imagetools create \
             --tag "${REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" \
             "$STAGING_IMAGE"
+
+          PROD_DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=${IMAGE_TAG}" \
+            --query 'imageDetails[0].imageDigest' --output text)
+
+          if [ -z "$PROD_DIGEST" ] || [ "$PROD_DIGEST" = "None" ]; then
+            echo "::error::The copy left no ${IMAGE_TAG} tag in ${ECR_REPOSITORY}."
+            exit 1
+          fi
+
+          if [ "$PROD_DIGEST" != "$STAGING_DIGEST" ]; then
+            # Not the same digest, so it has to be an index that names the
+            # staging manifest as one of its children. Anything else means we
+            # are about to deploy something other than what staging validated.
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name "$ECR_REPOSITORY" \
+              --image-ids "imageDigest=${PROD_DIGEST}" \
+              --query 'images[0].imageManifest' --output text)
+
+            if ! jq -e --arg d "$STAGING_DIGEST" \
+              'select(.manifests) | .manifests | map(.digest) | index($d)' \
+              <<<"$MANIFEST" >/dev/null; then
+              echo "::error::${ECR_REPOSITORY}@${PROD_DIGEST} does not resolve to"
+              echo "::error::${STAGING_DIGEST}, the manifest staging is running."
+              exit 1
+            fi
+            echo "Copied as ${PROD_DIGEST}, an index over ${STAGING_DIGEST}."
+          else
+            echo "Copied as ${PROD_DIGEST}, digest unchanged."
+          fi
+
+          echo "image-digest=$PROD_DIGEST" >> "$GITHUB_OUTPUT"
 
       # Retention keeps `deployed-` images long past the build candidates that
       # churn by every merge to main. The production task definition is pinned to
@@ -170,7 +206,7 @@ jobs:
         uses: harvard-lil/lil-actions/ecr-tag-image@main
         with:
           repository: ${{ env.ECR_REPOSITORY }}
-          source: ${{ steps.resolve.outputs.image-digest }}
+          source: ${{ steps.copy.outputs.image-digest }}
           tag: deployed-${{ steps.resolve.outputs.source-sha }}
 
   # The shared sequence. Everything above identifies which artifact to deploy and


### PR DESCRIPTION
Make sure prod uses the digest of its copy instead of the one in staging ECR.

`docker buildx imagetools create` builds a new index around its source, so copying a single-platform manifest between repositories yields a different digest in the destination than the one it was read from.