### PR TITLE
Put webpack bundles under STATIC_URL, and keep WhiteNoise's prefix

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -190,10 +190,10 @@ jobs:
           rm -rf collected-static
           docker compose cp web:/app/web/static ./collected-static
 
-          aws s3 sync ./collected-static/dist "s3://${STATIC_BUCKET}/dist" \
+          aws s3 sync ./collected-static/dist "s3://${STATIC_BUCKET}/static/dist" \
             --cache-control 'public, max-age=31536000, immutable' --no-progress
 
-          aws s3 sync ./collected-static "s3://${STATIC_BUCKET}" \
+          aws s3 sync ./collected-static "s3://${STATIC_BUCKET}/static" \
             --exclude 'dist/*' \
             --cache-control 'public, max-age=3600' --no-progress
         env:

--- a/web/config/settings/settings_aws_ecs.py
+++ b/web/config/settings/settings_aws_ecs.py
@@ -73,7 +73,9 @@ SENTRY_TRACES_SAMPLE_RATE = 0.001
 # the same load balancer, and a page rendered by one can request a
 # content-hashed bundle that only exists in the other.
 #
-# WhiteNoise deliberately stays in MIDDLEWARE. The files are still in the image,
-# so anything that reaches /static/ here is still answered while we confirm from
-# the access logs that nothing does. Removing it is a separate change.
-STATIC_URL = "https://static.opencasebook.org/"
+# The /static/ path carries weight beyond tidiness. WhiteNoise takes its URL
+# prefix from urlparse(STATIC_URL).path, so pointing this at the bucket root
+# would move the copies still in the image from /static/... to /..., and they
+# would stop answering the URLs that anything already rendered asks for.
+# WhiteNoise stays in MIDDLEWARE as the fallback that arrangement gives us.
+STATIC_URL = "https://static.opencasebook.org/static/"

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -21,6 +21,15 @@ RelativeBundleTracker.prototype.writeOutput = function (compiler, contents) {
         if (chunk.path.startsWith(relativePathRoot)) {
           chunk.path = chunk.path.substr(relativePathRoot.length);
         }
+        // django-webpack-loader returns publicPath verbatim when it is present,
+        // and otherwise builds the URL through staticfiles_storage. Dropping it
+        // from the compiled build is what puts bundles under STATIC_URL like
+        // every other static file, instead of at a location baked in here at
+        // build time. The dev server's stats keep theirs; they point at
+        // localhost:8080, which no Django setting knows about.
+        if (!devMode) {
+          delete chunk.publicPath;
+        }
       }
     }
   }


### PR DESCRIPTION
Fix static asset serving for the new static.opencasebook.org cdn approach:

- `vue.config.js` writes a `publicPath` onto every chunk in `webpack-stats.json`, and django-webpack-loader 0.7 returns it verbatim when set. Stripping `publicPath` makes it use `STATIC_URL` as intended.
- Add a `/static/` base to the cdn bucket, so whitenoise continues to work and serve assets from the container as a fallback.