### PR TITLE
Take each tier's values from its GitHub environment

### DIFF
--- a/.github/workflows/deploy_sequence.yml
+++ b/.github/workflows/deploy_sequence.yml
@@ -24,10 +24,6 @@ on:
         description: 'Name for this tier in notifications, e.g. Staging'
         required: true
         type: string
-      site-url:
-        description: 'Public URL of this tier, used in notifications'
-        required: true
-        type: string
       image-digest:
         description: >
           Digest of the web image to deploy, already present in this tier's ECR
@@ -41,46 +37,13 @@ on:
         description: 'Commit the artifact was built from, naming the matching pandoc-lambda image'
         required: true
         type: string
-      lambda-function-name:
-        description: 'Export Lambda for this tier'
-        required: true
-        type: string
-      maintenance-script:
+      environment:
         description: >
-          Cloudflare Worker serving this tier's maintenance page, e.g.
-          h2o-maintenance-prod. Created by lil-terraform's
-          lil-cloudflare-maintenance module.
+          GitHub environment this tier deploys to. It carries the tier's
+          variables and secrets, and its branch policy is what stops another
+          branch reaching them, so naming it here is what selects the tier.
         required: true
         type: string
-      maintenance-hostnames:
-        description: 'Comma-separated hostnames the page answers on'
-        required: true
-        type: string
-
-    secrets:
-      aws-role-arn:
-        required: true
-      ecr-repository:
-        required: true
-      aws-region:
-        required: true
-      ecs-cluster:
-        required: true
-      ecs-service:
-        required: true
-      container-name:
-        required: true
-      task-definition-family:
-        required: true
-      event-rules:
-        # Empty is tolerated: a tier with no scheduled tasks has nothing to update.
-        required: false
-      cloudflare-zone-id:
-        required: true
-      cloudflare-api-token:
-        required: true
-      slack-webhook-url:
-        required: true
 
 permissions:
   id-token: write     # assume the deploy role via OIDC
@@ -91,20 +54,21 @@ jobs:
   deploy:
     name: Deploy to ${{ inputs.environment-label }}
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
 
     env:
-      TASK_DEFINITION_FAMILY: ${{ secrets.task-definition-family }}
-      CONTAINER_NAME: ${{ secrets.container-name }}
-      ECS_CLUSTER: ${{ secrets.ecs-cluster }}
-      ECS_SERVICE: ${{ secrets.ecs-service }}
-      EVENT_RULES: ${{ secrets.event-rules }}
+      TASK_DEFINITION_FAMILY: ${{ vars.TASK_DEFINITION_FAMILY }}
+      CONTAINER_NAME: ${{ vars.CONTAINER_NAME }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+      EVENT_RULES: ${{ vars.EVENT_RULES }}
 
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ secrets.aws-region }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       # The registry is derived here rather than passed in, for the same reason
       # the inputs above are pieces rather than URIs.
@@ -118,7 +82,7 @@ jobs:
         with:
           task-definition-family: ${{ env.TASK_DEFINITION_FAMILY }}
           container-name: ${{ env.CONTAINER_NAME }}
-          image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ecr-repository }}@${{ inputs.image-digest }}
+          image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}@${{ inputs.image-digest }}
 
       # Whether this deploy needs a maintenance window is a property of the new
       # code, so it cannot be answered by asking the tasks currently running.
@@ -237,10 +201,10 @@ jobs:
         uses: harvard-lil/lil-actions/cloudflare-maintenance@main
         with:
           mode: 'on'
-          zone-id: ${{ secrets.cloudflare-zone-id }}
-          script: ${{ inputs.maintenance-script }}
-          hostnames: ${{ inputs.maintenance-hostnames }}
-          token: ${{ secrets.cloudflare-api-token }}
+          zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          script: ${{ vars.MAINTENANCE_SCRIPT }}
+          hostnames: ${{ vars.MAINTENANCE_HOSTNAMES }}
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Wait for the new deployment to become stable
         uses: harvard-lil/lil-actions/ecs-wait-for-deployment@main
@@ -272,9 +236,9 @@ jobs:
         uses: harvard-lil/lil-actions/cloudflare-maintenance@main
         with:
           mode: 'off'
-          zone-id: ${{ secrets.cloudflare-zone-id }}
-          hostnames: ${{ inputs.maintenance-hostnames }}
-          token: ${{ secrets.cloudflare-api-token }}
+          zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          hostnames: ${{ vars.MAINTENANCE_HOSTNAMES }}
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       # Complement of the condition above, so the site is never left behind the
       # maintenance page without this saying so.
@@ -283,7 +247,7 @@ jobs:
         run: |
           echo "::error::Django migrations did not complete (outcome: ${{ steps.migrate.outcome }})."
           echo "::error::MAINTENANCE MODE IS STILL ON and was left on deliberately --"
-          echo "::error::${{ inputs.site-url }} is serving the maintenance page, not the application."
+          echo "::error::${{ vars.SITE_URL }} is serving the maintenance page, not the application."
           echo "::error::The database may be partially migrated. Check its state before"
           echo "::error::lifting maintenance; re-running this workflow will not lift it"
           echo "::error::either, because it will fail at the same step."
@@ -292,8 +256,8 @@ jobs:
       - name: Purge Cloudflare cache
         uses: harvard-lil/lil-actions/cloudflare-purge@main
         with:
-          zone: ${{ secrets.cloudflare-zone-id }}
-          token: ${{ secrets.cloudflare-api-token }}
+          zone: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       # Everything from here down runs with the site already serving. None of it
       # is needed for a page to render: the new tasks are healthy and the schema
@@ -331,7 +295,7 @@ jobs:
       # everything else already done, rather than stopping the rollout partway.
       - name: Point the export Lambda at the promoted image
         env:
-          FUNCTION_NAME: ${{ inputs.lambda-function-name }}
+          FUNCTION_NAME: ${{ vars.LAMBDA_FUNCTION_NAME }}
           LAMBDA_IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/pandoc-lambda:${{ inputs.source-sha }}
         run: |
           set -euxo pipefail
@@ -347,7 +311,7 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
-            webhook: ${{ secrets.slack-webhook-url }}
+            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
             webhook-type: incoming-webhook
             payload: |
               {
@@ -372,7 +336,7 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
-            webhook: ${{ secrets.slack-webhook-url }}
+            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
             webhook-type: incoming-webhook
             payload: |
               {
@@ -395,7 +359,7 @@ jobs:
                     "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*View the site:* <${{ inputs.site-url }}|${{ inputs.site-url }}>"
+                          "text": "*View the site:* <${{ vars.SITE_URL }}|${{ vars.SITE_URL }}>"
                       }
                     }
                 ]

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -34,6 +34,7 @@ jobs:
   prepare:
     name: Prepare the production artifact
     runs-on: ubuntu-latest
+    environment: prod
     if: github.event_name == 'push'
     
     outputs:
@@ -41,7 +42,7 @@ jobs:
       source-sha: ${{ steps.resolve.outputs.source-sha }}
 
     env:
-      ECR_REPOSITORY: ${{ secrets.PROD_ECR_REPOSITORY }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
       IMAGE_TAG: latest
 
     steps:
@@ -52,8 +53,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.PROD_AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.PROD_AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
 
 
       - name: Login to AWS ECR
@@ -73,10 +74,10 @@ jobs:
         id: resolve
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          STAGING_ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
-          STAGING_ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
-          STAGING_CONTAINER_NAME: ${{ secrets.STAGING_CONTAINER_NAME }}
-          STAGING_ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
+          STAGING_ECS_CLUSTER: ${{ vars.SOURCE_ECS_CLUSTER }}
+          STAGING_ECS_SERVICE: ${{ vars.SOURCE_ECS_SERVICE }}
+          STAGING_CONTAINER_NAME: ${{ vars.SOURCE_CONTAINER_NAME }}
+          STAGING_ECR_REPOSITORY: ${{ vars.SOURCE_ECR_REPOSITORY }}
         run: |
           set -euo pipefail
 
@@ -217,25 +218,10 @@ jobs:
     if: always() && needs.prepare.result == 'success'
     uses: ./.github/workflows/deploy_sequence.yml
     with:
+      environment: prod
       environment-label: Prod
-      site-url: https://opencasebook.org
       image-digest: ${{ needs.prepare.outputs.image-digest }}
       source-sha: ${{ needs.prepare.outputs.source-sha }}
-      lambda-function-name: h2o-export
-      maintenance-script: h2o-maintenance-prod
-      maintenance-hostnames: opencasebook.org,www.opencasebook.org
-    secrets:
-      aws-role-arn: ${{ secrets.PROD_AWS_ROLE_TO_ASSUME }}
-      ecr-repository: ${{ secrets.PROD_ECR_REPOSITORY }}
-      aws-region: ${{ secrets.PROD_AWS_REGION }}
-      ecs-cluster: ${{ secrets.PROD_ECS_CLUSTER }}
-      ecs-service: ${{ secrets.PROD_ECS_SERVICE }}
-      container-name: ${{ secrets.PROD_CONTAINER_NAME }}
-      task-definition-family: ${{ secrets.PROD_TASK_DEFINITION_FAMILY }}
-      event-rules: ${{ secrets.PROD_EVENT_RULES }}
-      cloudflare-zone-id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # A job whose condition does not hold is skipped, and a skipped job leaves the
   # run green. This job is what makes a deploy that did not happen show up as a

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,6 +35,7 @@ jobs:
   prepare:
     name: Prepare the staging artifact
     runs-on: ubuntu-latest
+    environment: staging
     if: github.event_name == 'push'
     
     outputs:
@@ -42,7 +43,7 @@ jobs:
       source-sha: ${{ steps.resolve.outputs.source-sha }}
 
     env:
-      ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
       IMAGE_TAG: latest
 
     steps:
@@ -55,8 +56,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.STAGING_AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
 
 
       - name: Login to AWS ECR
@@ -155,25 +156,10 @@ jobs:
     if: always() && needs.prepare.result == 'success'
     uses: ./.github/workflows/deploy_sequence.yml
     with:
+      environment: staging
       environment-label: Staging
-      site-url: https://staging.opencasebook.org
       image-digest: ${{ needs.prepare.outputs.image-digest }}
       source-sha: ${{ needs.prepare.outputs.source-sha }}
-      lambda-function-name: h2o-export-stage
-      maintenance-script: h2o-maintenance-staging
-      maintenance-hostnames: staging.opencasebook.org
-    secrets:
-      aws-role-arn: ${{ secrets.STAGING_AWS_ROLE_TO_ASSUME }}
-      ecr-repository: ${{ secrets.STAGING_ECR_REPOSITORY }}
-      aws-region: ${{ secrets.STAGING_AWS_REGION }}
-      ecs-cluster: ${{ secrets.STAGING_ECS_CLUSTER }}
-      ecs-service: ${{ secrets.STAGING_ECS_SERVICE }}
-      container-name: ${{ secrets.STAGING_CONTAINER_NAME }}
-      task-definition-family: ${{ secrets.STAGING_TASK_DEFINITION_FAMILY }}
-      event-rules: ${{ secrets.STAGING_EVENT_RULES }}
-      cloudflare-zone-id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # A job whose condition does not hold is skipped, and a skipped job leaves the
   # run green. This job is what makes a deploy that did not happen show up as a


### PR DESCRIPTION
Use github environments (prod, staging) for secrets and vars instead of PROD_ and STAGING_ prefixes.

- Better security -- workflows can't see values they don't need.
- Simpler config -- declaring the environment makes it easier to share code between the deploy scripts.

AI note:

> `lint_test.yml` is untouched and keeps its prefixed secrets. Its publish steps live in a job shared with the pull-request path, so naming an environment there would hand environment secrets to every pull-request build — which is exactly what main.yml's named-secrets split prevents today.