### PR TITLE
Refuse to publish a commit that is already published

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -159,6 +159,44 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
+      # A commit is published once. This build is not reproducible -- no cache, a
+      # floating base image, unpinned apt, pip and npm -- so re-running main
+      # produces different bytes for the same source, and pushing them would move
+      # the SHA tag off the image the earlier run tested and staging may already
+      # be running.
+      #
+      # Refusing is the whole of it: there is no safe partial republish. The
+      # compiled assets are collected from a running container rather than baked
+      # into the image, so assets belonging to the image below cannot be
+      # recovered from it without running it, and syncing this build's assets
+      # beside the earlier build's image would leave the two disagreeing about
+      # which content hashes exist.
+      - name: Refuse to republish a commit
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          ECR_REPOSITORY: ${{ secrets.STAGING_ECR_REPOSITORY }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          published=""
+          for repo in "$ECR_REPOSITORY" pandoc-lambda; do
+            digest="$(aws ecr describe-images --repository-name "$repo" \
+              --image-ids "imageTag=${SHA}" \
+              --query 'imageDetails[0].imageDigest' --output text 2>/dev/null)"
+            if [ -n "$digest" ] && [ "$digest" != "None" ]; then
+              echo "::error::${repo}:${SHA} already exists, at ${digest}."
+              published="yes"
+            fi
+          done
+          if [ -n "$published" ]; then
+            echo "::error::An earlier run published this commit. Re-running would replace"
+            echo "::error::what it published with bytes nothing has tested."
+            echo "::error::To ship a change, push a new commit. To genuinely replace what"
+            echo "::error::was published, delete the tags named above and run this again."
+            exit 1
+          fi
+          echo "Nothing published for ${SHA} yet."
+
       # Push the image built at the top of this job -- not a rebuild. Tagged with
       # the commit main actually points at, so staging can find it.
       - name: Publish the prod image to ECR


### PR DESCRIPTION
If a push to main manages to build and push the container, and then fail and get re-run, it can create two containers attached to one commit hash, which causes a mess. Detect and just refuse to run if there's already a container -- it shouldn't be common.

The problem is subtle -- AI explanation:

Prerequisite for lil

> -terraform#146, which makes the SHA tags immutable.
> 
> The build is not reproducible — no cache, a floating `python:3.11-bookworm`, unpinned apt, pip and npm — so re-running main produces different bytes for the same source. Today that silently moves the SHA tag onto the new image, and it happened on 3 September:
> 
> ```
> 03:39:10Z  staging-h2o  tag=e5365608aa52…  digest=sha256:83575927eb42
> 12:31:04Z  staging-h2o  tag=e5365608aa52…  digest=sha256:9e34e7f4c936
> ```
> 
> The first run failed on the static-assets IAM permission and was re-run. `sha256:83575927eb42` is now an untagged orphan, and the tag that identifies that commit points at bytes the first run never tested. Since staging resolves a deploy by that tag, this is the artifact chain.