### PR TITLE
Read the deploy role from the environment, not a secret

### DIFF
--- a/.github/workflows/deploy_sequence.yml
+++ b/.github/workflows/deploy_sequence.yml
@@ -45,6 +45,16 @@ on:
         required: true
         type: string
 
+    secrets:
+      # A called workflow's secrets context is only what the caller passes it.
+      # Naming an environment here supplies that environment's variables, and
+      # everything the tier differs by is one, so what is left to pass is the
+      # two values that are secret and the same for every tier.
+      cloudflare-api-token:
+        required: true
+      slack-webhook-url:
+        required: true
+
 permissions:
   id-token: write     # assume the deploy role via OIDC
   contents: read
@@ -67,7 +77,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION }}
 
       # The registry is derived here rather than passed in, for the same reason
@@ -204,7 +214,7 @@ jobs:
           zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           script: ${{ vars.MAINTENANCE_SCRIPT }}
           hostnames: ${{ vars.MAINTENANCE_HOSTNAMES }}
-          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          token: ${{ secrets.cloudflare-api-token }}
 
       - name: Wait for the new deployment to become stable
         uses: harvard-lil/lil-actions/ecs-wait-for-deployment@main
@@ -238,7 +248,7 @@ jobs:
           mode: 'off'
           zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           hostnames: ${{ vars.MAINTENANCE_HOSTNAMES }}
-          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          token: ${{ secrets.cloudflare-api-token }}
 
       # Complement of the condition above, so the site is never left behind the
       # maintenance page without this saying so.
@@ -257,7 +267,7 @@ jobs:
         uses: harvard-lil/lil-actions/cloudflare-purge@main
         with:
           zone: ${{ vars.CLOUDFLARE_ZONE_ID }}
-          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          token: ${{ secrets.cloudflare-api-token }}
 
       # Everything from here down runs with the site already serving. None of it
       # is needed for a page to render: the new tasks are healthy and the schema
@@ -311,7 +321,7 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
-            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+            webhook: ${{ secrets.slack-webhook-url }}
             webhook-type: incoming-webhook
             payload: |
               {
@@ -336,7 +346,7 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
-            webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+            webhook: ${{ secrets.slack-webhook-url }}
             webhook-type: incoming-webhook
             payload: |
               {

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION }}
 
 
@@ -222,6 +222,9 @@ jobs:
       environment-label: Prod
       image-digest: ${{ needs.prepare.outputs.image-digest }}
       source-sha: ${{ needs.prepare.outputs.source-sha }}
+    secrets:
+      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # A job whose condition does not hold is skipped, and a skipped job leaves the
   # run green. This job is what makes a deploy that did not happen show up as a

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION }}
 
 
@@ -160,6 +160,9 @@ jobs:
       environment-label: Staging
       image-digest: ${{ needs.prepare.outputs.image-digest }}
       source-sha: ${{ needs.prepare.outputs.source-sha }}
+    secrets:
+      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # A job whose condition does not hold is skipped, and a skipped job leaves the
   # run green. This job is what makes a deploy that did not happen show up as a


### PR DESCRIPTION
Github doesn't really want to do what we want here -- have secrets per-environment, and have those be used in a reusable workflow. You can't load them directly in the workflow, *and* you can't access them in a caller that accesses a reusable workflow. That's annoying, but fortunately the only secrets we really need are shared between the two environments, so we can just keep them as base level secrets and pass them in manually. So, switch back to using base CLOUDFLARE_API_TOKEN and SLACK_WEBHOOK_URL instead of putting those in the envs.