### PR TITLE
Load the TinyMCE skin from STATIC_URL

### DIFF
--- a/web/frontend/libs/tinymce_extensions.js
+++ b/web/frontend/libs/tinymce_extensions.js
@@ -423,7 +423,7 @@ export function getInitConfig(selector, enhanced, code) {
   let config = {
     height:'25vh',
     plugins: plugins,
-    skin_url: '/static/tinymce_skin',
+    skin_url: window.TINYMCE_SKIN_URL,
     content_style: semanticStyles,
     menubar: false,
     branding: false,

--- a/web/main/templates/admin/change_form_with_richeditor.html
+++ b/web/main/templates/admin/change_form_with_richeditor.html
@@ -3,6 +3,7 @@
 
 {% block footer %}
   {{ block.super }}
+  {% include 'includes/tinymce_skin_url.html' %}
   {% render_bundle 'chunk-common' %}
   {% render_bundle 'rich_text_editor' %}
 {% endblock %}

--- a/web/main/templates/casebook_outline_edit.html
+++ b/web/main/templates/casebook_outline_edit.html
@@ -8,7 +8,7 @@
 {% block page_title %} {% if mode %}{{mode}} | {% endif %} {{casebook.title}} {% if section %}: {{ section.title }} {% endif %} {% endblock %}
 
 {% if editing %}
-{% block extra_foot %}{% render_bundle 'rich_text_editor' %}{% endblock %}
+{% block extra_foot %}{% include 'includes/tinymce_skin_url.html' %}{% render_bundle 'rich_text_editor' %}{% endblock %}
 {% endif %}
 
 {% block banner %}

--- a/web/main/templates/casebook_page.html
+++ b/web/main/templates/casebook_page.html
@@ -9,7 +9,7 @@
 {% block page_title %} {% if mode %}{{mode}} | {% endif %} {{casebook.title}} {% if section %}: {{ section.title }} {% endif %} {% endblock %}
 
 {% if editing %}
-{% block extra_foot %}{% render_bundle 'rich_text_editor' %}{% endblock %}
+{% block extra_foot %}{% include 'includes/tinymce_skin_url.html' %}{% render_bundle 'rich_text_editor' %}{% endblock %}
 {% endif %}
 
 {% block banner %}

--- a/web/main/templates/includes/tinymce_skin_url.html
+++ b/web/main/templates/includes/tinymce_skin_url.html
@@ -1,0 +1,12 @@
+{% load static %}
+{% comment %}
+The skin is a collected static directory, so its URL follows STATIC_URL, which
+points at the asset host rather than this one. A hardcoded /static/ path asks
+the application's own domain instead, where during a maintenance window the
+edge returns the maintenance page's HTML for every request -- which is how a
+stylesheet once got cached as HTML.
+
+Set beside every rich_text_editor bundle, because the admin form that loads it
+extends admin/change_form.html rather than base.html.
+{% endcomment %}
+<script>window.TINYMCE_SKIN_URL = "{% static 'tinymce_skin' %}";</script>


### PR DESCRIPTION
Bug fix to remove one last asset path that loaded directly instead of through static bundle resolution, which could affect caching.